### PR TITLE
replace throw of OIndexException with ORecordDuplicatedException in OIndexUnique

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexUnique.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexUnique.java
@@ -18,6 +18,7 @@ package com.orientechnologies.orient.core.index;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.record.ORecord;
+import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
 
 /**
  * Index implementation that allows only one value for a key.
@@ -46,8 +47,8 @@ public class OIndexUnique extends OIndexOneValue {
         if (value != null) {
           // CHECK IF THE ID IS THE SAME OF CURRENT: THIS IS THE UPDATE CASE
           if (!value.equals(iSingleValue))
-            throw new OIndexException("Found duplicated key '" + iKey + "' on unique index '" + name + "' for record "
-                + iSingleValue.getIdentity() + ". The record already present in the index is " + value.getIdentity());
+            throw new ORecordDuplicatedException("Found duplicated key '" + iKey + "' on unique index '" + name + "' for record "
+                + iSingleValue.getIdentity() + ". The record already present in the index is " + value.getIdentity(), value.getIdentity());
           else
             return this;
         }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ORecordDuplicatedException.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ORecordDuplicatedException.java
@@ -1,12 +1,13 @@
 package com.orientechnologies.orient.core.storage;
 
+import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.orient.core.id.ORID;
 
 /**
  * @author <a href="mailto:enisher@gmail.com">Artem Orobets</a>
  * @since 9/5/12
  */
-public class ORecordDuplicatedException extends RuntimeException {
+public class ORecordDuplicatedException extends OException {
   private final ORID iRid;
 
   public ORecordDuplicatedException(String message, ORID iRid) {


### PR DESCRIPTION
Changed throw in case of duplicate key to simplify merge as explained in thread:

https://groups.google.com/forum/?fromgroups=#!topic/orient-database/to5qFkESChY
