### PR TITLE
Flush OIndexManager on load to prevent loss of uncommited changes (e.g. during export)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerAbstract.java
@@ -92,6 +92,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
         create();
 
       // CLEAR PREVIOUS STUFF
+      flush();
       indexes.clear();
       classPropertyIndex.clear();
 

--- a/core/src/test/java/com/orientechnologies/orient/core/db/tool/ODatabaseExportTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/tool/ODatabaseExportTest.java
@@ -1,0 +1,40 @@
+package com.orientechnologies.orient.core.db.tool;
+
+import com.orientechnologies.orient.core.command.OCommandOutputListener;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.testng.Assert.assertEquals;
+
+public class ODatabaseExportTest {
+
+    @Test
+    public void exportShouldNotLoseUncommitedIndexEntries() throws Exception {
+
+
+        ODatabaseDocumentTx tx = new ODatabaseDocumentTx("memory:exportTest").create();
+
+        OClass kl = tx.getMetadata().getSchema().createClass("test");
+        kl.createProperty("id", OType.STRING);
+        kl.createIndex("id", OClass.INDEX_TYPE.NOTUNIQUE,"id");
+
+        tx.newInstance("test").field("id","a").save();
+
+        assertEquals(tx.getMetadata().getIndexManager().getIndex("id").count("a"), 1);
+
+        new ODatabaseExport(tx, new ByteArrayOutputStream(), new OCommandOutputListener() {
+            @Override
+            public void onMessage(String iText) {
+            }
+        }).exportDatabase();
+
+        assertEquals(tx.getMetadata().getIndexManager().getIndex("id").count("a"),1);
+        tx.close();
+
+    }
+
+}


### PR DESCRIPTION
It seems that during export OIndexManager.load is called. This causes loss of uncommited index changes. My idea is to flush OIndexManager before indexes are reloaded. 
Test case attached
