### PR TITLE
fix grammar on log lines in OServer. Shutdowning should read Shutting do...

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -229,7 +229,7 @@ public class OServer {
 
       if (plugins.size() > 0) {
         // SHUTDOWN HANDLERS
-        OLogManager.instance().info(this, "Shutdowning plugins:");
+        OLogManager.instance().info(this, "Shutting down plugins:");
         for (OServerHandler h : plugins.values()) {
           OLogManager.instance().info(this, "- %s", h.getName());
           try {
@@ -241,13 +241,13 @@ public class OServer {
 
       if (networkProtocols.size() > 0) {
         // PROTOCOL SHUTDOWN
-        OLogManager.instance().info(this, "Shutdowning protocols");
+        OLogManager.instance().info(this, "Shutting down protocols");
         networkProtocols.clear();
       }
 
       if (networkListeners.size() > 0) {
         // SHUTDOWN LISTENERS
-        OLogManager.instance().info(this, "Shutdowning listeners:");
+        OLogManager.instance().info(this, "Shutting down listeners:");
         // SHUTDOWN LISTENERS
         for (OServerNetworkListener l : networkListeners) {
           OLogManager.instance().info(this, "- %s", l);


### PR DESCRIPTION
very minor one this. Log lines in OServer should not say for example "Shutdowning plugins" but rather "Shutting down plugins". Shutdowning is not a word.
