### PR TITLE
fix grammar problems in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,37 +4,37 @@
 
 ## What is Orient?
 
-**OrientDB** is an Open Source [NoSQL](http://en.wikipedia.org/wiki/NoSQL) DBMS with both the features of Document and Graph DBMSs. It's written in Java and it's amazing fast: can store up to 150,000 records per second on common hardware. Even if it's Document based database the relationships are managed as in [Graph Databases](http://en.wikipedia.org/wiki/Graph_database) with direct connections among records. You can traverse entire or part of trees and graphs of records in few milliseconds. Supports schema-less, schema-full and schema-mixed modes. Has a strong security profiling system based on user and roles and support the [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) between the query languages. Thank to the [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) layer it's straightforward to use it for people skilled in Relational world.
+**OrientDB** is an Open Source [NoSQL](http://en.wikipedia.org/wiki/NoSQL) DBMS with the features of both Document and Graph DBMSs. It's written in Java and it's amazingly fast: it can store up to 150,000 records per second on common hardware. Even for a Document based database the relationships are managed as in [Graph Databases](http://en.wikipedia.org/wiki/Graph_database) with direct connections among records. You can traverse parts of or entire trees and graphs of records in a few milliseconds. Supports schema-less, schema-full and schema-mixed modes. Has a strong security profiling system based on user and roles and supports [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) amongst the query languages. Thanks to the [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) layer it's straightforward to use for people skilled in the Relational world.
 
-Look also at the [Presentations](https://github.com/nuvolabase/orientdb/wiki/Presentations) with video and slides introduce OrientDB.
+Look also at [Presentations](https://github.com/nuvolabase/orientdb/wiki/Presentations) with video and slides introducing OrientDB.
 
 ## Is OrientDB a Relational DBMS?
 
-No. OrientDB adheres to the [NoSQL](http://en.wikipedia.org/wiki/NoSQL) movement even if supports a subset of [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) as query language. In this way it's easy to start using it without to learn too much new stuff. OrientDB is a [DocumentDatabase] but has the best features of other DBMSs. For example the relationships are handled as in the [Graph Databases](http://en.wikipedia.org/wiki/Graph_database).
+No. OrientDB adheres to the [NoSQL](http://en.wikipedia.org/wiki/NoSQL) movement even though it supports a subset of [SQL](https://github.com/nuvolabase/orientdb/wiki/SQLQuery) as query language. In this way it's easy to start using it without having to learn too much new stuff. OrientDB is a [DocumentDatabase] but has the best features of other DBMSs. For example relationships are handled as in [Graph Databases](http://en.wikipedia.org/wiki/Graph_database).
 
 # Scalability: the database is the bottleneck of most of applications
 
-The most common problem why applications scale out bad is, very often, the database. Database is the bottleneck of most of applications. OrientDB scales out very well on a single machine. A single server makes the work of about 125 servers running [MySQL](http://en.wikipedia.org/wiki/Mysql). The transactional engine can run in distributed systems supporting up to 302,231,454,903,657 Billions (2^78) of records for the maximum capacity of 19,807,040,628,566,084 Terabytes of data distributed on multiple disks in multiple nodes. Today only OrientDB Key/Value Server can run in a cluster with thousands of instances using a Distributed Hash Table algorithm. We're developing the distributed version of OrientDB as well.
+The most common reason applications scale out badly is, very often, the database. The database is the bottleneck of most applications. OrientDB scales out very well on a single machine. A single server does the work of about 125 servers running [MySQL](http://en.wikipedia.org/wiki/Mysql). The transactional engine can run in distributed systems supporting up to 302,231,454,903,657 billion (2^78) records for the maximum capacity of 19,807,040,628,566,084 Terabytes of data distributed on multiple disks in multiple nodes. Today only OrientDB Key/Value Server can run in a cluster with thousands of instances using a Distributed Hash Table algorithm. We're developing the distributed version of OrientDB as well.
 
-## I can't believe! Why it's so fast?
+## I can't believe it! Why is it so fast?
 
-OrientDB has been designed to be very fast. It inherits the best features and concepts from the Object Databases, Graph DBMS and the modern [NoSQL](http://en.wikipedia.org/wiki/NoSQL) engines. Furthermore it uses the own **RB+Tree** algorithm as mix of [Red-Black Tree](http://en.wikipedia.org/wiki/Red-black_tree) and [B+Tree](http://en.wikipedia.org/wiki/B%2Btree). RB+Tree consumes about half memory of the [Red-Black Tree](http://en.wikipedia.org/wiki/Red-black_tree) implementation mantaining the original speed while it balances the tree on insertion/update. Furthermore the RB+Tree allows fast retrieving and storing of nodes in persistent way.
+OrientDB has been designed to be very fast. It inherits the best features and concepts from Object Databases, Graph DBMS and modern [NoSQL](http://en.wikipedia.org/wiki/NoSQL) engines. Furthermore it uses the own **RB+Tree** algorithm as a mix of [Red-Black Tree](http://en.wikipedia.org/wiki/Red-black_tree) and [B+Tree](http://en.wikipedia.org/wiki/B%2Btree). RB+Tree consumes about half memory of the [Red-Black Tree](http://en.wikipedia.org/wiki/Red-black_tree) implementation mantaining the original speed while it balances the tree on insertion/update. Furthermore the RB+Tree allows fast retrieving and storing of nodes in persistent way.
 
 ## Why yet another NoSQL?
 
-All is begun on 2009 when [Luca Garulli](https://github.com/nuvolabase/orientdb/wiki/Team) was searching a super fast and flexible storage for an ambitious project. After have tried different RDBMSs he worked on the available NoSQL products. No one had all the featured he needed. So in a weekend he got the challenge to try if the "old" low-level storage algorithms of Orient ODBMS, an Object Database Luca created in 1999 written in C++, could be reused in Java to develop a brand new graph-document DBMS. It worked! And this is the reason why today OrientDB is between us.
+It all began on 2009 when [Luca Garulli](https://github.com/nuvolabase/orientdb/wiki/Team) was searching for super fast and flexible storage for an ambitious project. After having tried different RDBMSs he worked on the available NoSQL products. Not one had all the features he needed. So in a weekend he got the challenge to see if the "old" low-level storage algorithms of Orient ODBMS, an Object Database Luca created in 1999 written in C++, could be reused in Java to develop a brand new graph-document DBMS. It worked! And this is the reason OrientDB exists today.
 
-## But wasn't OrientDB a ODBMS?
+## But wasn't OrientDB an ODBMS?
 
-Orient ODBMS was the very first version of the Orient engine developed in C++ in 1998. Today OrientDB has been totally rewritten in Java under the form of a Document database but with the previous main goal: performance. However now you can find the [Object Database], but it's a wrapper built on top of the [Document Database](https://github.com/nuvolabase/orientdb/wiki/Document-Database). It maps transparently OrientDB document records with POJOs.
+Orient ODBMS was the very first version of the Orient engine developed in C++ in 1998. Today OrientDB has been totally rewritten in Java in the form of a Document database but with the previous main goal: performance. However, now you can find the [Object Database], but it's a wrapper built on top of the [Document Database](https://github.com/nuvolabase/orientdb/wiki/Document-Database). It maps transparently OrientDB document records to POJOs.
 
-## How does it compares with other products?
+## How does it compare with other products?
 
-Take a look to [GraphDB comparison](https://github.com/nuvolabase/orientdb/wiki/GraphDB-Comparison) and [DocumentDB comparison](https://github.com/nuvolabase/orientdb/wiki/DocumentDB-Comparison).
+Take a look at [GraphDB comparison](https://github.com/nuvolabase/orientdb/wiki/GraphDB-Comparison) and [DocumentDB comparison](https://github.com/nuvolabase/orientdb/wiki/DocumentDB-Comparison).
 
 ## Easy to install and use
 
-Yes. OrientDB is totally written in [Java](http://en.wikipedia.org/wiki/Java_%28programming_language%29) and can run in any platform without configuration and installation. The full Server distribution is about 1Mb without the demo database. Do you develop with a language different than Java? No problem, look at the [Programming Language Bindings].
+Yes. OrientDB is totally written in [Java](http://en.wikipedia.org/wiki/Java_%28programming_language%29) and can run on any platform without configuration and installation. The full Server distribution is about 1Mb without the demo database. Do you develop with a language different than Java? No problem, look at the [Programming Language Bindings].
 
 ## Professional services
 
@@ -49,6 +49,6 @@ OrientDB is free for any use (Apache 2 license). If you are in production don't 
 
 ## Know more
 
-Start to learn OrientDB from the [WiKi Main page](https://github.com/nuvolabase/orientdb/wiki). For any question visit the [OrientDB Community Group](http://www.orientdb.org/community-group.htm). Need help? Go to the [Online support](http://chat.stackoverflow.com/rooms/6625/orientdb). Do you want to hear about OrientDB in a conference? Take a look at the [Events](https://github.com/nuvolabase/orientdb/wiki/) page.
+Start to learn about OrientDB from the [WiKi Main page](https://github.com/nuvolabase/orientdb/wiki). For any questions visit the [OrientDB Community Group](http://www.orientdb.org/community-group.htm). Need help? Go to the [Online support](http://chat.stackoverflow.com/rooms/6625/orientdb). Do you want to hear about OrientDB in a conference? Take a look at the [Events](https://github.com/nuvolabase/orientdb/wiki/) page.
 
 [![](http://mac.softpedia.com/base_img/softpedia_free_award_f.gif)](http://mac.softpedia.com/get/Developer-Tools/Orient.shtml)


### PR DESCRIPTION
The README.md has numerous English grammar problems. Would be nice if the README.md had correct grammar and usage so that when I refer colleagues to this product the front page of the project looks a bit more professional and is more readable.  A couple of sentences are still a bit strange but I didn't want to change them due to wanting to check their intended meaning first.
