### PR TITLE
Create Link Command improvement when the destination field is a @RID

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateLink.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateLink.java
@@ -35,6 +35,7 @@ import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.metadata.security.ODatabaseSecurityResources;
 import com.orientechnologies.orient.core.metadata.security.ORole;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.record.impl.ODocumentHelper;
 import com.orientechnologies.orient.core.serialization.serializer.OStringSerializerHelper;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import com.orientechnologies.orient.core.type.tree.OMVRBTreeRIDSet;
@@ -175,7 +176,12 @@ public class OCommandExecutorSQLCreateLink extends OCommandExecutorSQLAbstract {
       throw new OCommandExecutionException("Destination class '" + destClassName + "' not found");
 
     Object value;
-    String cmd = "select from " + destClassName + " where " + destField + " = ";
+    
+    String cmd = "select from ";
+    if (!ODocumentHelper.ATTRIBUTE_RID.equals(destField)) {
+    	cmd = "select from " + destClassName + " where " + destField + " = ";
+    }
+    
     List<ODocument> result;
     ODocument target;
     Object oldValue;
@@ -215,7 +221,7 @@ public class OCommandExecutorSQLCreateLink extends OCommandExecutorSQLAbstract {
             // SEARCH THE DESTINATION RECORD
             target = null;
 
-            if (value instanceof String)
+            if (!ODocumentHelper.ATTRIBUTE_RID.equals(destField) && value instanceof String)
               if (((String) value).length() == 0)
                 value = null;
               else

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLCreateLinkTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLCreateLinkTest.java
@@ -69,4 +69,45 @@ public class SQLCreateLinkTest {
 
     database.close();
   }
+  
+  @Test
+  public void createRIDLinktest() {
+    database.open("admin", "admin");
+
+    Assert.assertTrue((Integer) database.command(new OCommandSQL("CREATE CLASS POST2")).execute() > 0);
+    Object p1 = database.command(new OCommandSQL("INSERT INTO POST2 (id, title) VALUES ( 10, 'NoSQL movement' )")).execute();
+	Assert
+        .assertTrue(p1 instanceof ODocument);
+    Object p2 = database.command(new OCommandSQL("INSERT INTO POST2 (id, title) VALUES ( 20, 'New OrientDB' )")).execute();
+	Assert
+        .assertTrue(p2 instanceof ODocument);
+
+    Object p3 = database.command(new OCommandSQL("INSERT INTO POST2 (id, title) VALUES ( 30, '(')")).execute();
+	Assert
+        .assertTrue(p3 instanceof ODocument);
+
+    Object p4 = database.command(new OCommandSQL("INSERT INTO POST2 (id, title) VALUES ( 40, ')')")).execute();
+	Assert
+        .assertTrue(p4 instanceof ODocument);
+
+    Assert.assertTrue((Integer) database.command(new OCommandSQL("CREATE CLASS COMMENT2")).execute() > 0);
+    Assert.assertTrue(database.command(new OCommandSQL("INSERT INTO COMMENT (id, postId, text) VALUES ( 0, '" + ((ODocument)p1).getIdentity().toString() + "', 'First' )"))
+        .execute() instanceof ODocument);
+    Assert.assertTrue(database.command(new OCommandSQL("INSERT INTO COMMENT (id, postId, text) VALUES ( 1, '" + ((ODocument)p1).getIdentity().toString() + "', 'Second' )"))
+        .execute() instanceof ODocument);
+    Assert.assertTrue(database.command(new OCommandSQL("INSERT INTO COMMENT (id, postId, text) VALUES ( 21, '" + ((ODocument)p1).getIdentity().toString() + "', 'Another' )"))
+        .execute() instanceof ODocument);
+    Assert.assertTrue(database.command(new OCommandSQL("INSERT INTO COMMENT (id, postId, text) VALUES ( 41, '" + ((ODocument)p2).getIdentity().toString() + "', 'First again' )"))
+        .execute() instanceof ODocument);
+    Assert.assertTrue(database.command(new OCommandSQL("INSERT INTO COMMENT (id, postId, text) VALUES ( 82, '" + ((ODocument)p2).getIdentity().toString() + "', 'Second Again' )"))
+        .execute() instanceof ODocument);
+
+    Assert.assertEquals(
+        ((Number) database.command(new OCommandSQL("CREATE LINK comments TYPE LINKSET FROM comment2.postId TO post2.@rid INVERSE"))
+            .execute()).intValue(), 5);
+
+    Assert.assertEquals(((Number) database.command(new OCommandSQL("UPDATE comment2 REMOVE postId")).execute()).intValue(), 5);
+
+    database.close();
+  }
 }


### PR DESCRIPTION
When the source field is a String that refers to @RID (so the destination field is a @RID) the query to get the destination record can be improved to search by id.

The following command:

CREATE LINK comments TYPE LINKSET FROM comment.postId TO post.@rid INVERSE

has been tested with 3400 posts. Each post has 50 comments for a total of 170K comments.

The previous version takes about 30 minutes to complete. With the new version it executes in less than a minute.
