### PR TITLE
Fix json produced by /profiler/realtime when there is a double quotation mark in a command.

### DIFF
--- a/commons/src/main/java/com/orientechnologies/common/profiler/OProfilerData.java
+++ b/commons/src/main/java/com/orientechnologies/common/profiler/OProfilerData.java
@@ -57,6 +57,7 @@ public class OProfilerData {
     public String description;
 
     public void toJSON(final StringBuilder buffer) {
+      buffer.append(String.format("\"%s\":{", name.replaceAll("\"","\\\\\"")));
       buffer.append(String.format("\"%s\":{", OIOUtils.encode(name)));
       buffer.append(String.format("\"%s\":%d,", "entries", entries));
       buffer.append(String.format("\"%s\":%d,", "last", last));


### PR DESCRIPTION
After a request containing double quotation mark is done, the profiler cannot produce valid json because the quotation mark is not escaped in json keys.

Extract of invalid produced json:
`,"db.project.command.sql.select from User where name = "jeremy"":`

I also suggest to use a library to generate json, to avoid this kind of problem.
