### PR TITLE
Added embedded checks when building the ridMap

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
@@ -268,11 +268,17 @@ public class OFetchHelper {
       fieldDepthLevel = iFetchPlan.get(iFieldPathFromRoot);
     }
     if (fetchedLevel == null) {
-      parsedRecords.put(fieldValue.getIdentity(), iLevelFromRoot);
+	  if (!fieldValue.isEmbedded())
+	  {
+	    parsedRecords.put(fieldValue.getIdentity(), iLevelFromRoot);
+	  }
       processRecordRidMap(fieldValue, iFetchPlan, currentLevel, iLevelFromRoot, fieldDepthLevel, parsedRecords, iFieldPathFromRoot,
           iContext);
     } else if ((!fieldValue.getIdentity().isValid() && fetchedLevel < iLevelFromRoot) || fetchedLevel > iLevelFromRoot) {
-      parsedRecords.put(fieldValue.getIdentity(), iLevelFromRoot);
+	  if (!fieldValue.isEmbedded())
+	  {
+        parsedRecords.put(fieldValue.getIdentity(), iLevelFromRoot);
+	  }
       processRecordRidMap((ODocument) fieldValue, iFetchPlan, currentLevel, iLevelFromRoot, fieldDepthLevel, parsedRecords,
           iFieldPathFromRoot, iContext);
     }


### PR DESCRIPTION
When the OFetchHelper builds the parsedRecords map, while fetching all nodes of a collection, the rid #-1:1 is added to the map as soon as it parses the first embedded object.

The next time it parses an embedded object, the method verifies if the rid (#-1:1 again) is already in the map, if it is, the fetchedLevel is set. Because of the incorrect fetchedLevel, the fetch doesn't return the entire tree.
