### PR TITLE
Provide error message when storage path is invalid

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -515,7 +515,12 @@ public class OServer {
         if (stg.userPassword == null)
           stg.userPassword = OUser.ADMIN;
 
-        type = stg.path.substring(0, stg.path.indexOf(':'));
+        int idx = stg.path.indexOf(':');
+        if (idx == -1) {
+          OLogManager.instance().error(this, "-> Invalid path '" + stg.path + "' for database '" + stg.name + "'");
+          return;
+        }
+        type = stg.path.substring(0, idx);
 
         ODatabaseDocument db = null;
         try {


### PR DESCRIPTION
I was getting:
[OServer]Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: -1
  at java.lang.String.substring(String.java:1949)
  at com.orientechnologies.orient.server.OServer.loadStorages(OServer.java:518)
  at com.orientechnologies.orient.server.OServer.loadConfiguration(OServer.java:469)
  at com.orientechnologies.orient.server.OServer.startup(OServer.java:166)
  at com.orientechnologies.orient.server.OServer.startup(OServer.java:141)
  at com.orientechnologies.orient.server.OServer.startup(OServer.java:118)
  at com.orientechnologies.orient.server.OServerMain.main(OServerMain.java:31)

This is just a tweak to provide a better error message when someone doesn't fill in the storage path properly.

For example, path="/some/path" instead of path="local:/some/path".

I'm not too sure what the best way of logging the error is, so you might want to check/change that.
