### PR TITLE
fixed basic auth headers on JS api

### DIFF
--- a/server/src/site/js/orientdb-api.js
+++ b/server/src/site/js/orientdb-api.js
@@ -172,6 +172,9 @@ function ODatabase(databasePath) {
 			type = 'GET';
 		}
 		$.ajax({
+			beforeSend: function(xhr){
+      				return xhr.setRequestHeader('Authorization', 'BASIC ' + btoa(userName+':'+userPass));
+    			},
 			type : type,
 			url : this.urlPrefix + 'connect/' + this.encodedDatabaseName
 					+ this.urlSuffix,
@@ -179,8 +182,6 @@ function ODatabase(databasePath) {
 			contentType : "application/json; charset=utf-8",
 			processData : false,
 			async : false,
-			username : userName,
-			password : userPass,
 			success : function(msg) {
 				this.setErrorMessage(null);
 				this.setDatabaseInfo(this.transformResponse(msg));


### PR DESCRIPTION
Explictly set basic Auth headers as these are sometimes not set automatically
