### PR TITLE
Improve the usability in OSGi environment

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,12 @@
     <name>OrientDB Core</name>
 
     <properties>
-        <osgi.import>*</osgi.import>
+        <osgi.import>
+            com.orientechnologies.orient.graph.console;resolution:=optional,
+            com.orientechnologies.orient.graph.gremlin;resolution:=optional,
+            com.orientechnologies.orient.graph.handler;resolution:=optional,
+            *
+        </osgi.import>
         <osgi.export>com.orientechnologies.orient.core.*</osgi.export>
     </properties>
 

--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -18,7 +18,7 @@
 		<javac.src.version>1.6</javac.src.version>
 		<javac.target.version>1.6</javac.target.version>
 		<jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
-		<osgi.import>*</osgi.import>
+		<osgi.import>com.tinkerpop.blueprints;resolution:=optional,*</osgi.import>
 		<osgi.export>com.orientechnologies.orient.graph.*</osgi.export>
 		<blueprints.version>2.3.0-SNAPSHOT</blueprints.version>
 	</properties>

--- a/object/pom.xml
+++ b/object/pom.xml
@@ -24,6 +24,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+            <!-- Use an OSGi ready dependency https://hibernate.onjira.com/browse/JPA-42 -->
 			<groupId>org.hibernate.javax.persistence</groupId>
 			<artifactId>hibernate-jpa-2.0-api</artifactId>
 			<version>1.0.0.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -303,19 +303,16 @@
             <!--
                          | Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd
                         -->
-            <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME
+            <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,
+                Bnd-LastModified,Built-By,Private-Package,Tool,Created-By,Build-Jdk,Include-Resource,
+                Ignore-Package,Private-Package,Bundle-DocURL
             </_removeheaders>
-            <Bundle-Name>${project.name}</Bundle-Name>
-            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Description>${project.description}</Bundle-Description>
-            <Bundle-Version>1.4.0.qualifier</Bundle-Version>
             <Fragment-Host>${osgi.fragment.host}</Fragment-Host>
             <Export-Package>${osgi.export}</Export-Package>
             <Private-Package>${osgi.private}</Private-Package>
-            <Import-Package>${osgi.import}</Import-Package>
+            <Import-Package>${project.groupId}.*;provide:=true,${osgi.import}</Import-Package>
             <DynamicImport-Package>${osgi.dynamicImport}</DynamicImport-Package>
-            <Bundle-DocURL>${project.url}</Bundle-DocURL>
-            <Bundle-RequiredExecutionEnvironment>J2SE-1.6</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
- Align the value of **Bundle-RequiredExecutionEnvironment** with the specification  http://wiki.osgi.org/wiki/Execution_Environment
- Maven bundle plugin has default value of **<_removeheaders>** if it's explicitly defined its value overwritten, I added the default value to make better looking the generated MANIFEST.MF
- Maven bundle plugin has these default values:

``` xml
<Bundle-Name>${project.name}</Bundle-Name>
<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
<Bundle-Description>${project.description}</Bundle-Description>
<Bundle-Version>${project.version}</Bundle-Version>
<Bundle-DocURL>${project.url}</Bundle-DocURL>
```
- Blueprint, Pipes and Gremlin fails in OSGi because OrientDB modules does not import the necessary packages. I tested the http://code.google.com/p/orient/wiki/GraphEdTutorial tutorial in OSGi and it works with this fix.
