### PR TITLE
Support GZIP request content

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpRequest.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpRequest.java
@@ -38,6 +38,7 @@ public class OHttpRequest {
   public String                             httpMethod;
   public String                             httpVersion;
   public String                             contentType;
+  public String                             contentEncoding;
   public String                             content;
   public OHttpMultipartBaseInputStream      multipartStream;
   public String                             boundary;

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpUtils.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpUtils.java
@@ -43,6 +43,7 @@ public class OHttpUtils {
 	public static final String	HEADER_IF_MATCH											= "If-Match: ";
 	public static final String	HEADER_X_FORWARDED_FOR							= "X-Forwarded-For: ";
 	public static final String	HEADER_AUTHENTICATION								= "OAuthentication: ";
+	public static final String  HEADER_CONTENT_ENCODING                             = "Accept-Encoding: ";
 
 	public static final String	AUTHORIZATION_BASIC									= "Basic";
 	public static final String	OSESSIONID													= "OSESSIONID";
@@ -62,6 +63,7 @@ public class OHttpUtils {
 	public static final String	CONTENT_JSON												= "application/json";
 	public static final String	CONTENT_JAVASCRIPT									= "text/javascript";
 	public static final String	CONTENT_GZIP												= "application/x-gzip";
+	public static final String  CONTENT_ACCEPT_GZIP_ENCODED                                 = "gzip";
 
 	public static final String	CALLBACK_PARAMETER_NAME							= "callback";
 


### PR DESCRIPTION
If request size is too big, enable gzip could help to make request smaller during transaction and improve the performance, especially string content.

Enable gzip just add header( Header header = new Header("Accept-Encoding", "gzip");), and encode json string content to "UTF-8".
