### PR TITLE
allows max and min functions to work also in projections

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMax.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMax.java
@@ -15,6 +15,7 @@
  */
 package com.orientechnologies.orient.core.sql.functions.math;
 
+import java.util.Collection;
 import java.util.List;
 
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -38,35 +39,44 @@ public class OSQLFunctionMax extends OSQLFunctionMathAbstract {
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  public Object execute(final OIdentifiable iCurrentRecord, ODocument iCurrentResult, final Object[] iParameters,
-      OCommandContext iContext) {
-    if (iParameters[0] == null || !(iParameters[0] instanceof Comparable<?>))
-      // PRECONDITIONS
+  public Object execute(final OIdentifiable iCurrentRecord, ODocument iCurrentResult, final Object[] iParameters, OCommandContext iContext) {
+    if (iParameters[0] == null)
       return null;
 
-    if (iParameters.length == 1) {
-      final Comparable<Object> value = (Comparable<Object>) iParameters[0];
-
-      if (context == null)
-        // FIRST TIME
-        context = value;
-      else if (context.compareTo(value) < 0)
-        // BIGGER
-        context = value;
-
-      return null;
+    // calculate max value for current record. 
+    Object max = null;
+    if (iParameters[0] instanceof Collection<?>) {
+    	// for a projection with multiple results find out the max value
+    	Object[] array = ((Collection<?>)iParameters[0]).toArray();
+        for (int i = 0; i < array.length; ++i) {
+          if (max == null || array[i] != null && ((Comparable) array[i]).compareTo(max) > 0)
+            max = array[i];
+        }
     } else {
-      Object max = null;
-      for (int i = 0; i < iParameters.length; ++i) {
-        if (max == null || iParameters[i] != null && ((Comparable) iParameters[i]).compareTo(max) > 0)
-          max = iParameters[i];
-      }
-      return max;
+    	// this is the max as is an unique value
+        max = (Comparable<Object>) iParameters[0];
     }
+    
+    // what to do with the result, for current record, depends on how this function has been invoked
+    // for an unique result aggregated from all output records
+    if (aggregateResults()) {
+        if (context == null)
+            // FIRST TIME
+            context = (Comparable)max;
+        else if (context.compareTo((Comparable)max) < 0)
+            // BIGGER
+            context = (Comparable)max;
+        
+        return null;
+    } 
+    
+    // for non aggregated results (a result per output record)
+    return max;
   }
 
   public boolean aggregateResults() {
-    return configuredParameters.length == 1;
+	  // LET definitions (contain $current) does not require results aggregation
+    return ((configuredParameters.length == 1) && !configuredParameters[0].toString().contains("$current"));
   }
 
   public String getSyntax() {

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMin.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMin.java
@@ -15,6 +15,7 @@
  */
 package com.orientechnologies.orient.core.sql.functions.math;
 
+import java.util.Collection;
 import java.util.List;
 
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -38,35 +39,44 @@ public class OSQLFunctionMin extends OSQLFunctionMathAbstract {
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  public Object execute(final OIdentifiable iCurrentRecord, ODocument iCurrentResult, final Object[] iParameters,
-      OCommandContext iContext) {
-    if (iParameters[0] == null || !(iParameters[0] instanceof Comparable<?>))
-      // PRECONDITIONS
-      return null;
+  public Object execute(final OIdentifiable iCurrentRecord, ODocument iCurrentResult, final Object[] iParameters, OCommandContext iContext) {
+	  if (iParameters[0] == null)
+		  return null;
 
-    if (iParameters.length == 1) {
-      final Comparable<Object> value = (Comparable<Object>) iParameters[0];
+	  // calculate max value for current record. 
+	  Object min = null;
+	  if (iParameters[0] instanceof Collection<?>) {
+		  // for a projection with multiple results find out the max value
+		  Object[] array = ((Collection<?>)iParameters[0]).toArray();
+		  for (int i = 0; i < array.length; ++i) {
+			  if (min == null || array[i] != null && ((Comparable) array[i]).compareTo(min) < 0)
+				  min = array[i];
+		  }
+	  } else {
+		  // this is the max as is an unique value
+		  min = (Comparable<Object>) iParameters[0];
+	  }
 
-      if (context == null)
-        // FIRST TIME
-        context = value;
-      else if (context.compareTo(value) > 0)
-        // BIGGER
-        context = value;
+	  // what to do with the result, for current record, depends on how this function has been invoked
+	  // for an unique result aggregated from all output records
+	  if (aggregateResults()) {
+		  if (context == null)
+			  // FIRST TIME
+			  context = (Comparable)min;
+		  else if (context.compareTo((Comparable)min) < 0)
+			  // BIGGER
+			  context = (Comparable)min;
 
-      return null;
-    } else {
-      Object min = null;
-      for (int i = 0; i < iParameters.length; ++i) {
-        if (min == null || iParameters[i] != null && ((Comparable) iParameters[i]).compareTo(min) < 0)
-          min = iParameters[i];
-      }
-      return min;
-    }
+		  return null;
+	  } 
+
+	  // for non aggregated results (a result per output record)
+	  return min;
   }
 
   public boolean aggregateResults() {
-    return configuredParameters.length == 1;
+	  // LET definitions (contain $current) does not require results aggregation
+    return ((configuredParameters.length == 1) && !configuredParameters[0].toString().contains("$current"));
   }
 
   public String getSyntax() {


### PR DESCRIPTION
The issue has been described in this thread https://groups.google.com/forum/?fromgroups=#!topic/orient-database/oi7gn1qRlIs

Functions max() and min() has been extended to support both:
- working on a projection
- working on a global result
