### PR TITLE
Require root password on server startup and store hash rather than plain text for verification

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/security/OSecurityManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/security/OSecurityManager.java
@@ -145,7 +145,7 @@ public class OSecurityManager {
     return instance;
   }
 
-  private static String byteArrayToHexStr(final byte[] data) {
+  public static String byteArrayToHexStr(final byte[] data) {
     if (data == null)
       return null;
 

--- a/server/config/orientdb-server-config.xml
+++ b/server/config/orientdb-server-config.xml
@@ -80,6 +80,9 @@
 		<storage path="memory:temp" name="temp" userName="admin" userPassword="admin" loaded-at-startup="true" />
 	</storages>
 	<users>
+		<!-- Default root password is "root" -->
+        <user resources="*" password="4813494D137E1631BBA301D5ACAB6E7BB7AA74CE1185D456565EF51D737677B2" name="root"/>
+        <user resources="connect,server.listDatabases" password="guest" name="guest"/>
 	</users>
 	<properties>
 		<!-- Enable/Disable logging. Levels are: finer, fine, finest, info, warning -->

--- a/server/script/server.sh
+++ b/server/script/server.sh
@@ -60,4 +60,4 @@ WWW_PATH=$ORIENTDB_HOME/www
 ORIENTDB_SETTINGS="-Dprofiler.enabled=true -Dcache.level1.enabled=false -Dcache.level2.strategy=1"
 JAVA_OPTS_SCRIPT="-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true"
 
-java -server $JAVA_OPTS $JAVA_OPTS_SCRIPT $ORIENTDB_SETTINGS -Djava.util.logging.config.file="$LOG_FILE" -Dorientdb.config.file="$CONFIG_FILE" -Dorientdb.www.path="$WWW_PATH" -Dorientdb.build.number="@BUILD@" -cp "$ORIENTDB_HOME/lib/orientdb-server-@VERSION@.jar:$ORIENTDB_HOME/lib/*" com.orientechnologies.orient.server.OServerMain
+java -server $JAVA_OPTS $JAVA_OPTS_SCRIPT $ORIENTDB_SETTINGS -Djava.util.logging.config.file="$LOG_FILE" -Dorientdb.config.file="$CONFIG_FILE" -Dorientdb.www.path="$WWW_PATH" -Dorientdb.build.number="@BUILD@" -cp "$ORIENTDB_HOME/lib/orientdb-server-@VERSION@.jar:$ORIENTDB_HOME/lib/*" com.orientechnologies.orient.server.OServerMain "$@"

--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -362,16 +362,20 @@ public class OServer {
   public boolean authenticate(final String iUserName, final String iPassword, final String iResourceToCheck) {
     final OServerUserConfiguration user = getUser(iUserName);
 
-    if (user != null && (iPassword == null || user.password.equals(iPassword))) {
-      if (user.resources.equals("*"))
-        // ACCESS TO ALL
-        return true;
+    try
+    {
+        if (user != null && (iPassword == null || OServerMain.grantAuthority(iUserName, iPassword))) {
+          if (user.resources.equals("*"))
+            // ACCESS TO ALL
+            return true;
 
-      String[] resourceParts = user.resources.split(",");
-      for (String r : resourceParts)
-        if (r.equals(iResourceToCheck))
-          return true;
+          String[] resourceParts = user.resources.split(",");
+          for (String r : resourceParts)
+            if (r.equals(iResourceToCheck))
+              return true;
+        }
     }
+    catch (Exception e) {}
 
     // WRONG PASSWORD OR NO AUTHORIZATION
     return false;

--- a/server/src/main/java/com/orientechnologies/orient/server/OServerMain.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServerMain.java
@@ -33,9 +33,14 @@ public class OServerMain {
 
 	public static void main(final String[] args) throws Exception {
 
+        // It would be cleanest to use args4j for the argument management
+
+        String opt = null;
+        boolean unsecured = false;
+
         if (args.length > 0)
         {
-            String opt = args[0].trim();
+            opt = args[0].trim();
 
             if (opt.startsWith("-p"))
             {
@@ -64,6 +69,7 @@ public class OServerMain {
                     "The hash is       : "
                   + OSecurityManager.instance().digest2String(input1)
                 );
+                System.exit(0);
             }
             else if (opt.startsWith("-s"))
             {
@@ -75,38 +81,53 @@ public class OServerMain {
                     "Random string to paste into salt value of config xml: "
                   + OSecurityManager.instance().byteArrayToHexStr(salt)
                 );
+                System.exit(0);
+            }
+            else if (opt.startsWith("-u"))
+            {
+                unsecured = true;
+                System.out.println("*********************");
+                System.out.println("**  W A R N I N G  **");
+                System.out.println("**                 **");
+                System.out.println("** Running server  **");
+                System.out.println("** unsecured. Omit **");
+                System.out.println("** the -u for      **");
+                System.out.println("** secure version. **");
+                System.out.println("**                 **");
+                System.out.println("*********************");
             }
             else help();
-
-            System.exit(0);
         }
 
 		OServerMain.create().startup();
-
-        String correct = server().getUser("root").password;
-        // Default hash of "root"
-        String defaultPhrase =
-              "4813494D137E1631BBA301D5ACAB6E7B"
-            + "B7AA74CE1185D456565EF51D737677B2";
-
-        if (correct.equals(defaultPhrase))
+        
+        if (!unsecured)
         {
-            String linesep = System.getProperty("line.separator");
-            System.out.println
-            (
-                linesep + linesep
-              + "Passphrase has not been changed from default."
-              + linesep
-              + "Restart server with -p switch to set new passphrase."
-              + linesep
-              + "A longer phrase with alphanumerics enhances security."
-            );
-            System.exit(1);
-        }
+            String correct = server().getUser("root").password;
+            // Default hash of "root"
+            String defaultPhrase =
+                  "4813494D137E1631BBA301D5ACAB6E7B"
+                + "B7AA74CE1185D456565EF51D737677B2";
 
-        requestRootPassPhrase();
-        // The string input could now be retained as a
-        // key for data encryption
+            if (correct.equals(defaultPhrase))
+            {
+                String sep = System.getProperty("line.separator");
+                System.out.println
+                (
+                    sep + sep
+                  + "Passphrase has not been changed from default."
+                  + sep
+                  + "Restart server with -p switch to set new passphrase."
+                  + sep
+                  + "A longer phrase with alphanumerics enhances security."
+                );
+                System.exit(1);
+            }
+
+            requestRootPassPhrase();
+            // The string input could now be retained as a
+            // key for data encryption
+        }
 
 		server().activate();
 	}
@@ -163,10 +184,12 @@ public class OServerMain {
     private static void help()
     {
         System.out.println("OrientDB usage");
-        System.out.println(" orientdb.sh [opt]");
-        System.out.println("-h  Usage guide");
-        System.out.println("-p  Generate passphrase hash");
-        System.out.println("-s  Generate a random crytographic salt");
+        System.out.println(" server.sh [opt]");
+        System.out.println("  -h  Usage guide");
+        System.out.println("  -p  Generate passphrase hash");
+        System.out.println("  -s  Generate a random crytographic salt");
+        System.out.println("  -u  Invoke unsecured server instance");
         System.out.println();
+        System.exit(0);
     }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/OServerMain.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServerMain.java
@@ -15,6 +15,10 @@
  */
 package com.orientechnologies.orient.server;
 
+import com.orientechnologies.orient.core.security.OSecurityManager;
+import java.util.Random;
+import java.security.SecureRandom;
+
 public class OServerMain {
 	protected static OServer	server;
 
@@ -28,7 +32,141 @@ public class OServerMain {
 	}
 
 	public static void main(final String[] args) throws Exception {
+
+        if (args.length > 0)
+        {
+            String opt = args[0].trim();
+
+            if (opt.startsWith("-p"))
+            {
+                System.out.println("OrientDB server passphrase generator");
+                System.out.print("Enter passphrase  : ");
+                char[] chars1 = System.console().readPassword();
+                String input1 = new String(chars1);
+                System.out.print("Repeat passphrase : ");
+                                 
+                char[] chars2 = System.console().readPassword();
+                String input2 = new String(chars2);
+
+                if (input1 == null || input2 == null)
+                {
+                    System.out.println("No input received.");
+                    System.exit(1);
+                }
+                else if (!input1.equals(input2))
+                {
+                    System.out.println("Phrases do not match, try again.");
+                    System.exit(1);
+                }
+
+                System.out.println
+                (
+                    "The hash is       : "
+                  + OSecurityManager.instance().digest2String(input1)
+                );
+            }
+            else if (opt.startsWith("-s"))
+            {
+                Random r = new SecureRandom();
+                byte[] salt = new byte[20];
+                r.nextBytes(salt);
+                System.out.println
+                (
+                    "Random string to paste into salt value of config xml: "
+                  + OSecurityManager.instance().byteArrayToHexStr(salt)
+                );
+            }
+            else help();
+
+            System.exit(0);
+        }
+
 		OServerMain.create().startup();
+
+        String correct = server().getUser("root").password;
+        // Default hash of "root"
+        String defaultPhrase =
+              "4813494D137E1631BBA301D5ACAB6E7B"
+            + "B7AA74CE1185D456565EF51D737677B2";
+
+        if (correct.equals(defaultPhrase))
+        {
+            String linesep = System.getProperty("line.separator");
+            System.out.println
+            (
+                linesep + linesep
+              + "Passphrase has not been changed from default."
+              + linesep
+              + "Restart server with -p switch to set new passphrase."
+              + linesep
+              + "A longer phrase with alphanumerics enhances security."
+            );
+            System.exit(1);
+        }
+
+        requestRootPassPhrase();
+        // The string input could now be retained as a
+        // key for data encryption
+
 		server().activate();
 	}
+
+    public static void requestRootPassPhrase()
+    throws Exception
+    {
+        System.out.println();
+        System.out.print("Enter root passphrase: ");
+        char[] chars = System.console().readPassword();
+        String input = new String(chars);
+
+        if (grantAuthority("root", input))
+        {
+            System.out.println("Passphrase OK.");
+        }
+        else
+        {
+            System.out.println("Passphrase incorrect.");
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Grant authority by comparing the stored hash of the correct password
+     * against the given string.
+     * 
+     * @param iUserName
+     *          Username to authenticate
+     * @param iPassword
+     *          Password in clear
+     * @return true if authentication is ok, otherwise false
+     */
+    public static boolean grantAuthority
+    (
+        String iUserName,
+        String iPassword
+    )
+    throws Exception
+    {
+        if (server() == null) create();
+        String correct = server().getUser(iUserName).password;
+        String hashed =
+            OSecurityManager
+            .instance()
+            .digest2String
+            (
+                iPassword
+            );
+        if (hashed.equals(correct)) return true;
+        return false;
+    }
+
+    private static void help()
+    {
+        System.out.println("OrientDB usage");
+        System.out.println(" orientdb.sh [opt]");
+        System.out.println("-h  Usage guide");
+        System.out.println("-p  Generate passphrase hash");
+        System.out.println("-s  Generate a random crytographic salt");
+        System.out.println();
+    }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/OServerShutdownMain.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServerShutdownMain.java
@@ -128,9 +128,11 @@ public class OServerShutdownMain {
     String serverPorts = iArgs.length > 1 ? iArgs[1] : null;
     String rootPassword = iArgs.length > 2 ? iArgs[2] : null;
 
-    System.out.println("Sending shutdown command to remote OrientDB Server instance...");
-
     try {
+        OServerMain.requestRootPassPhrase();
+
+        System.out.println("Sending shutdown command to remote OrientDB Server instance...");
+
       new OServerShutdownMain(serverHost, serverPorts, rootPassword).connect(5000);
       System.out.println("Shutdown executed correctly");
     } catch (Exception e) {


### PR DESCRIPTION
... root password on startup, store the hash of the root password (not the plain text) in the server config xml file, and require that it be changed from the default value.  A passphrase is permitted and a startup option "-p" is provided which allows the user to run the server for the sole purpose of generating a password hash that can be pasted into the server config xml file for subsequent verification.

Minimal code changes, uses existing encryption calls.  Does create a problem if you want to automatically spawn server instances.