### PR TITLE
Fix issue #1431 (Tx and NoTx used concurrently)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OStorageLocal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OStorageLocal.java
@@ -77,15 +77,21 @@ import com.orientechnologies.orient.core.version.OVersionFactory;
 
 public class OStorageLocal extends OStorageLocalAbstract {
   private final int                     DELETE_MAX_RETRIES;
+
   private final int                     DELETE_WAIT_TIME;
 
   private final Map<String, OCluster>   clusterMap                = new LinkedHashMap<String, OCluster>();
+
   private OCluster[]                    clusters                  = new OCluster[0];
+
   private ODataLocal[]                  dataSegments              = new ODataLocal[0];
 
   private final OStorageLocalTxExecuter txManager;
+
   private String                        storagePath;
+
   private final OStorageVariableParser  variableParser;
+
   private int                           defaultClusterId          = -1;
 
   private static String[]               ALL_FILE_EXTENSIONS       = { "ocf", ".och", ".ocl", ".oda", ".odh", ".otx", ".ocs",
@@ -1247,7 +1253,7 @@ public class OStorageLocal extends OStorageLocalAbstract {
   }
 
   public void commit(final OTransaction iTx) {
-    modificationLock.requestModificationLock();
+    modificationLock.prohibitModifications();
     try {
       lock.acquireExclusiveLock();
       try {
@@ -1279,7 +1285,7 @@ public class OStorageLocal extends OStorageLocalAbstract {
         lock.releaseExclusiveLock();
       }
     } finally {
-      modificationLock.releaseModificationLock();
+      modificationLock.allowModifications();
     }
   }
 


### PR DESCRIPTION
A new try with a OModificationLock new implementation that allow full reentrancy (read-read, read-write, write-write and write-read).
Ant tests pass:
   [testng] ===============================================
   [testng] Test Suite Example
   [testng] Total tests run: 999, Failures: 0, Skips: 0
   [testng] ===============================================

But I can't test maven test (not enough memory on my 32bits laptop).
