### PR TITLE
Fix bug reading from socket when dropping a cluster on a remote database...

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1327,24 +1327,26 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           endRequest(network);
         }
 
+        byte result = 0;
         try {
           beginResponse(network);
-
-          if (network.readByte() == 1) {
-            // REMOVE THE CLUSTER LOCALLY
-            final OCluster cluster = clusters[iClusterId];
-            clusters[iClusterId] = null;
-            clusterMap.remove(cluster.getName());
-            if (configuration.clusters.size() > iClusterId)
-              configuration.dropCluster(iClusterId);
-
-            getLevel2Cache().freeCluster(iClusterId);
-            return true;
-          }
-          return false;
+          result = network.readByte();
         } finally {
           endResponse(network);
         }
+
+        if (result == 1) {
+          // REMOVE THE CLUSTER LOCALLY
+          final OCluster cluster = clusters[iClusterId];
+          clusters[iClusterId] = null;
+          clusterMap.remove(cluster.getName());
+          if (configuration.clusters.size() > iClusterId)
+            configuration.dropCluster(iClusterId); //endResponse must be called before this line, which call updateRecord
+
+          getLevel2Cache().freeCluster(iClusterId);
+          return true;
+        }
+        return false;
 
       } catch (OModificationOperationProhibitedException mope) {
         handleDBFreeze();


### PR DESCRIPTION
Fix a bug when dropping a cluster on a remote database. To reproduce the bug, with the console (on a database called mydb) :

```
bin\console.bat "connect remote:localhost/mydb admin admin;create cluster ca PHYSICAL default default append;create cluster cb PHYSICAL default default append;create cluster cc PHYSICAL default default append"
bin\console.bat "connect remote:localhost/mydb admin admin;drop cluster cb"
```

The second command blocks. This also happens when importing an old database.

The bug was caused by the call to updateRecord in dropCluster before closing the response (with endResponse)
