### PR TITLE
Proposition to make clusters have varying security for a given class

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClass.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClass.java
@@ -15,10 +15,16 @@
  */
 package com.orientechnologies.orient.core.iterator;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.orientechnologies.orient.core.db.record.ODatabaseRecord;
 import com.orientechnologies.orient.core.db.record.ODatabaseRecordAbstract;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.exception.OSecurityAccessException;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.security.ODatabaseSecurityResources;
+import com.orientechnologies.orient.core.metadata.security.ORole;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
@@ -59,11 +65,37 @@ public class ORecordIteratorClass<REC extends ORecordInternal<?>> extends ORecor
 
     polymorphic = iPolymorphic;
     clusterIds = polymorphic ? targetClass.getPolymorphicClusterIds() : targetClass.getClusterIds();
+    clusterIds = readableClusters(iDatabase, clusterIds);
 
     config();
   }
+  
+  
+  private int[] readableClusters(ODatabaseRecord iDatabase,
+		int[] clusterIds) {
+	List<Integer> listOfReadableIds = new ArrayList<Integer>();
+	
+	for (int clusterId : clusterIds) {
+		try {
+			String clusterName = iDatabase.getClusterNameById(clusterId);
+		    iDatabase.checkSecurity(ODatabaseSecurityResources.CLUSTER, ORole.PERMISSION_READ, clusterName);
+		    listOfReadableIds.add(clusterId);
+		}
+		catch(OSecurityAccessException securityException) {
+			// if the cluster is inaccessible it's simply not processed in the list.add
+		}
+	}
+	
+	int[] readableClusterIds = new int[listOfReadableIds.size()];
+	int index = 0;
+	for (int clusterId : listOfReadableIds) {
+		readableClusterIds[index++] = clusterId;
+	}
+	
+	return readableClusterIds;
+}
 
-  @SuppressWarnings("unchecked")
+@SuppressWarnings("unchecked")
   @Override
   public REC next() {
     final OIdentifiable rec = super.next();


### PR DESCRIPTION
OK

Here it is. I have made two changes to handle access to a sub-set of a class' clusters.
This method is a patch, to give an idea of what can be done. I am not sure yet if that is the best solution (trapping the try/catch). There could be a method that does a soft check (ie not throwing exceptions when the rule is not found).

Also, for reviewers. I have done the iterator + count. Are there other places that would require a similar patch? And would it be better to move the fuction (duplicated) in a standard place. 

I wouldn't accept the patch AS-IS if I were you ;) But I think it is a very good basis for improved security. Multi-tenancy is something that I thought many users of orientdb were using already. When we have a final solution, I will write a little wiki page to give indications for future users.

ps. not sure about the iXXX naming convention. Is that for "input" parameters ?
