### PR TITLE
fix for max/min functions

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMax.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMax.java
@@ -58,7 +58,7 @@ public class OSQLFunctionMax extends OSQLFunctionMathAbstract {
     
     // what to do with the result, for current record, depends on how this function has been invoked
     // for an unique result aggregated from all output records
-    if (aggregateResults()) {
+    if (aggregateResults() && max != null) {
       if (context == null)
         // FIRST TIME
         context = (Comparable) max;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMin.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionMin.java
@@ -58,7 +58,7 @@ public class OSQLFunctionMin extends OSQLFunctionMathAbstract {
 
     // what to do with the result, for current record, depends on how this function has been invoked
     // for an unique result aggregated from all output records
-    if (aggregateResults()) {
+    if (aggregateResults() && min != null) {
       if (context == null)
         // FIRST TIME
         context = (Comparable) min;


### PR DESCRIPTION
fix bug introduced by
https://github.com/nuvolabase/orientdb/commit/dee9f205dea706ddf009e402632871a780326e61
as code never reaches second if clause. Now is expected to consider both
parameters as collection and collection in each item. 

iParameters has been assumed to be never null as this is expected to be guaranteed by the invoking code. Code is prepared to digest null items of null 'subitems' (items in a collection item).
