### PR TITLE
Fix 2q cache bug

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
@@ -410,6 +410,11 @@ public enum OGlobalConfiguration {
 
   SERVER_CACHE_FILE_STATIC("server.cache.staticFile", "Cache static resources loading", Boolean.class, false),
 
+  SERVER_CACHE_2Q_INCREASE_ON_DEMAND("server.cache.2q.increaseOnDemand", "Increase 2q cache on demand", Boolean.class, false),
+
+  SERVER_CACHE_2Q_INCREASE_STEP("server.cache.2q.increaseStep",
+      "Increase 2q cache step in percent. Will only work if server.cache.2q.increaseOnDemand is true", Float.class, 0.1f),
+
   SERVER_LOG_DUMP_CLIENT_EXCEPTION_LEVEL(
       "server.log.dumpClientExceptionLevel",
       "Logs client exceptions. Use any level supported by Java java.util.logging.Level class: OFF, FINE, CONFIG, INFO, WARNING, SEVERE",

--- a/core/src/main/java/com/orientechnologies/orient/core/exception/OAllLRUListEntriesAreUsed.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/exception/OAllLRUListEntriesAreUsed.java
@@ -1,0 +1,11 @@
+package com.orientechnologies.orient.core.exception;
+
+public class OAllLRUListEntriesAreUsed extends ODatabaseException {
+  public OAllLRUListEntriesAreUsed(String string) {
+    super(string);
+  }
+
+  public OAllLRUListEntriesAreUsed(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUList.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUList.java
@@ -220,10 +220,14 @@ class LRUList implements Iterable<LRUEntry> {
 
   public LRUEntry removeLRU() {
     LRUEntry entryToRemove = head;
-    while (entryToRemove.usageCounter != 0) {
+    while (entryToRemove != null && entryToRemove.usageCounter != 0) {
       entryToRemove = entryToRemove.after;
     }
-    return remove(entryToRemove.fileId, entryToRemove.pageIndex);
+    if (entryToRemove != null) {
+      return remove(entryToRemove.fileId, entryToRemove.pageIndex);
+    } else {
+      return null;
+    }
   }
 
   public LRUEntry getLRU() {

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUListTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUListTest.java
@@ -132,6 +132,16 @@ public class LRUListTest {
     Assert.assertFalse(entryIterator.hasNext());
   }
 
+  public void testRemoveLRUShouldReturnNullIfAllRecordsAreUsed() {
+    LRUList lruList = new LRUList();
+
+    LRUEntry lruEntry = lruList.putToMRU(1, 10, 100, false, new OLogSequenceNumber(0, 0));
+    lruEntry.usageCounter++;
+    LRUEntry removedLRU = lruList.removeLRU();
+
+    Assert.assertNull(removedLRU);
+  }
+
   public void testAddElevenRemoveLRU() {
     LRUList lruList = new LRUList();
 


### PR DESCRIPTION
When 2q cache became max allowed size and all records are used NullPointer is thrown because LRUList can't find record to remove it.
This patch fix this but in such way.
When all record are used LRUList return null.
When 2q determine that returned record are null it should change max size to allow storing more records.
This behaviour can be managed using new properties in OGlobalConfiguration
