### PR TITLE
Updated pom.xml to fix groovy dependency

### DIFF
--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -64,11 +64,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.codehaus</groupId>
+			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy</artifactId>
 			<version>1.8.9</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/lib/groovy-1.8.9.jar</systemPath>
 		</dependency>
 
 		<!-- TINKERPOP STACK -->


### PR DESCRIPTION
fixed dependency for groovy (removed system scope and updated groupId), which should allow transitive dependencies for projects that include this pom.
