### PR TITLE
database should be closed after sending record content

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetGephi.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetGephi.java
@@ -69,12 +69,12 @@ public class OServerCommandGetGephi extends OServerCommandAuthenticatedDbAbstrac
       response = (List<OIdentifiable>) db.command(new OSQLSynchQuery<ORecordSchemaAware<?>>(text, limit).setFetchPlan(fetchPlan))
           .execute();
 
+      sendRecordsContent(iRequest, iResponse, response, fetchPlan);
     } finally {
       if (db != null)
         db.close();
     }
 
-    sendRecordsContent(iRequest, iResponse, response, fetchPlan);
     return false;
   }
 


### PR DESCRIPTION
database is closed before we send the record content to the client,
and we get an exception like this:
2013-06-28 15:21:34:305 SEVE Internal server error:
com.orientechnologies.orient.core.exception.ODatabaseException: Database 'local:/orientdb/databases/tinkerpop' is closed [ONetworkProtocolHttpDb]
