### PR TITLE
added automatic request parameter binding on OCommandExecutor

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpNetworkCommandManager.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpNetworkCommandManager.java
@@ -3,13 +3,19 @@ package com.orientechnologies.orient.server.network.protocol.http;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.orientechnologies.orient.core.serialization.serializer.OStringSerializerHelper;
 import com.orientechnologies.orient.server.network.protocol.http.command.OServerCommand;
 
 public class OHttpNetworkCommandManager {
-  private final Map<String, OServerCommand> exactCommands    = new HashMap<String, OServerCommand>();
-  private final Map<String, OServerCommand> wildcardCommands = new HashMap<String, OServerCommand>();
+  private static final String                URL_PART_PATTERN    = "([a-zA-Z0-9%\\\\+]*)";
+  private static final String                REST_PARAM_PATTERN  = "\\{[a-zA-Z0-9%]*\\}";
+
+  private final Map<String, OServerCommand>  exactCommands        = new HashMap<String, OServerCommand>();
+  private final Map<String, OServerCommand>  wildcardCommands    = new HashMap<String, OServerCommand>();
+  private final Map<String, OServerCommand>  restCommands        = new HashMap<String, OServerCommand>();
   private OHttpNetworkCommandManager        parent;
 
   public OHttpNetworkCommandManager(final OHttpNetworkCommandManager iParent) {
@@ -19,6 +25,13 @@ public class OHttpNetworkCommandManager {
   public Object getCommand(String iName) {
     OServerCommand cmd = exactCommands.get(iName);
 
+    if (cmd == null) {
+      for (Entry<String, OServerCommand> entry : restCommands.entrySet()) {
+        if (matches(entry.getKey(), iName)) {
+          return entry.getValue();
+        }
+      }
+    }
     if (cmd == null) {
       // TRY WITH WILDCARD COMMANDS
       // TODO: OPTIMIZE SEARCH!
@@ -48,9 +61,64 @@ public class OHttpNetworkCommandManager {
    */
   public void registerCommand(OServerCommand iServerCommandInstance) {
     for (String name : iServerCommandInstance.getNames())
-      if (OStringSerializerHelper.contains(name, '*'))
+      if (OStringSerializerHelper.contains(name, '{')) {
+        restCommands.put(name, iServerCommandInstance);
+      } else if (OStringSerializerHelper.contains(name, '*'))
         wildcardCommands.put(name, iServerCommandInstance);
       else
         exactCommands.put(name, iServerCommandInstance);
+  }
+
+  private boolean matches(String urlPattern, String requestUrl) {
+    String matcherUrl = urlPattern.replaceAll(REST_PARAM_PATTERN, URL_PART_PATTERN);
+
+    if (!matcherUrl.substring(0, matcherUrl.indexOf('|') + 1).equals(requestUrl.substring(0, requestUrl.indexOf('|') + 1))) {
+      return false;
+    }
+    matcherUrl = matcherUrl.substring(matcherUrl.indexOf('|') + 1);
+    requestUrl = requestUrl.substring(requestUrl.indexOf('|') + 1);
+    return requestUrl.matches(matcherUrl);
+  }
+
+  public Map<String, String> extractUrlTokens(String requestUrl) {
+    Map<String, String> result = new HashMap<String, String>();
+    String urlPattern = findUrlPattern(requestUrl);
+    if (urlPattern == null) {
+      return result;
+    }
+    String matcherUrl = urlPattern.replaceAll(REST_PARAM_PATTERN, URL_PART_PATTERN);
+
+    matcherUrl = matcherUrl.substring(matcherUrl.indexOf('|') + 1);
+    requestUrl = requestUrl.substring(requestUrl.indexOf('|') + 1);
+
+    Pattern pattern = Pattern.compile(matcherUrl);
+    Matcher matcher = pattern.matcher(requestUrl);
+    if (matcher.find()) {
+      Pattern templateUrlPattern = Pattern.compile(REST_PARAM_PATTERN);
+      Matcher templateMatcher = templateUrlPattern.matcher(urlPattern);
+      int i = 1;
+      String key;
+      while (templateMatcher.find()) {
+        key = templateMatcher.group();
+        key = key.substring(1);
+        key = key.substring(0, key.length() - 1);
+        String value = matcher.group(i++);
+        result.put(key, value);
+      }
+    }
+    return result;
+  }
+
+  protected String findUrlPattern(String requestUrl) {
+    for (Entry<String, OServerCommand> entry : restCommands.entrySet()) {
+      if (matches(entry.getKey(), requestUrl)) {
+        return entry.getKey();
+      }
+    }
+    if (parent == null) {
+      return null;
+    } else {
+      return parent.findUrlPattern(requestUrl);
+    }
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpAbstract.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpAbstract.java
@@ -23,9 +23,11 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URLDecoder;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.IllegalFormatException;
 import java.util.InputMismatchException;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
 import com.orientechnologies.common.concur.lock.OLockException;
@@ -53,22 +55,22 @@ import com.orientechnologies.orient.server.network.protocol.http.command.OServer
 import com.orientechnologies.orient.server.network.protocol.http.multipart.OHttpMultipartBaseInputStream;
 
 public abstract class ONetworkProtocolHttpAbstract extends ONetworkProtocol {
-  private static final String                 COMMAND_SEPARATOR = "|";
-  private static int                          requestMaxContentLength;                // MAX = 10Kb
+  private static final String                  COMMAND_SEPARATOR  = "|";
+  private static int                          requestMaxContentLength;                  // MAX = 10Kb
   private static int                          socketTimeout;
 
-  protected OClientConnection                 connection;
+  protected OClientConnection                  connection;
   protected OChannelTextServer                channel;
-  protected OUser                             account;
+  protected OUser                              account;
   protected OHttpRequest                      request;
-  protected OHttpResponse                     response;
+  protected OHttpResponse                      response;
 
-  private final StringBuilder                 requestContent    = new StringBuilder();
+  private final StringBuilder                  requestContent    = new StringBuilder();
   private String                              responseCharSet;
   private String[]                            additionalResponseHeaders;
   private String                              listeningAddress  = "?";
 
-  protected static OHttpNetworkCommandManager sharedCmdManager;
+  protected static OHttpNetworkCommandManager  sharedCmdManager;
   protected OHttpNetworkCommandManager        cmdManager;
 
   public ONetworkProtocolHttpAbstract() {
@@ -134,6 +136,16 @@ public abstract class ONetworkProtocolHttpAbstract extends ONetworkProtocol {
       final String commandString = getCommandString(command);
 
       final OServerCommand cmd = (OServerCommand) cmdManager.getCommand(commandString);
+      Map<String, String> requestParams = cmdManager.extractUrlTokens(commandString);
+      if (requestParams != null) {
+        if (request.parameters == null) {
+          request.parameters = new HashMap<String, String>();
+        }
+        for (Map.Entry<String, String> entry : requestParams.entrySet()) {
+          request.parameters.put(entry.getKey(), URLDecoder.decode(entry.getValue(), "UTF-8"));
+        }
+      }
+
       if (cmd != null)
         try {
           if (cmd.beforeExecute(request, response))


### PR DESCRIPTION
when configuring a command you can define a pattern like "GET|commandUrl/{paramOne}/{paramTwo}" and the strings between brackets will be bound to request paramenters.
Ex. orientdb-server-config.xml 

&lt;command implementation="org.test.OServerCommandHelloWorld" pattern="GET|say/hello/to/{name}/{surname}"&gt;
&lt;/command&gt;

you can call it with 

http://&lt;address&gt;/say/hello/to/john/doe

and in your command you will find the request parameters "name" = "john" and "surname" = "doe"
