### PR TITLE
Fixed Issue #1592

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1077,6 +1077,9 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           }
           break;
         } finally {
+          if(aquery.getResultListener() != null) {
+          	aquery.getResultListener().end();
+          }
           endResponse(network);
         }
 


### PR DESCRIPTION
end() is now called in OCommandResultListener when using OSQLAsynchQuery towards a remote server
