### PR TITLE
Hazelcast and Blueprints dependency version bump, fixes maven build.

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>3.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -21,7 +21,7 @@
 		<jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
 		<osgi.import>com.tinkerpop.blueprints;resolution:=optional,*</osgi.import>
 		<osgi.export>com.orientechnologies.orient.graph.*</osgi.export>
-		<blueprints.version>2.4.0-SNAPSHOT</blueprints.version>
+		<blueprints.version>2.5.0-SNAPSHOT</blueprints.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Just a very small thing. The maven build has been broken due to referencing outdated dependency versions. This bumps the following dependency versions, thereby fixing the maven build:

hazelcast: 3.0-SNAPSHOT -> 3.0.1-SNAPSHOT
blueprints: 2.4.0-SNAPSHOT -> 2.5.0-SNAPSHOT

It doesn't do anything else. I'm not sure it warrants a pull request, but I didn't find a way to attach a simple patch.

Keep up the great work!
