### PR TITLE
Returns the database name if it does not exists

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/schedule/OScheduleHandler.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/schedule/OScheduleHandler.java
@@ -113,7 +113,7 @@ public class OScheduleHandler extends OServerHandlerAbstract {
         db = new ODatabaseDocumentTx("local:" + url).open(this.user, this.pass);
       } else {
         db = null;
-        OLogManager.instance().error(this, "database pharos not exist");
+        OLogManager.instance().error(this, "database " + this.databaseName + " does not exist");
       }
     } catch (Exception ex) {
       ex.printStackTrace();


### PR DESCRIPTION
There was a generic "pharos" database name instead of the real database name
