### PR TITLE
Fix NullPointerException with setShortName(null)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -254,7 +254,8 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     this.shortName = iShortName;
 
     // REGISTER IT
-    owner.classes.put(iShortName.toLowerCase(), this);
+    if(null != iShortName)
+        owner.classes.put(iShortName.toLowerCase(), this);
   }
 
   public String getStreamableName() {

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/ClassTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/ClassTest.java
@@ -1,0 +1,72 @@
+package com.orientechnologies.orient.core.metadata;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OSchema;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.OCommandSQL;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+@Test
+public class ClassTest {
+    private static ODatabaseDocumentTx db = null;
+    public static final String SHORTNAME_CLASS_NAME = "TestShortName";
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        db = new ODatabaseDocumentTx("memory:metadataclasstest");
+        if (db.exists()) {
+            db.open("admin", "admin");
+            db.drop();
+        }
+        db.create();
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+        if (!db.isClosed())
+            db.close();
+    }
+
+    @Test
+    public void testShortName() {
+        OSchema schema = db.getMetadata().getSchema();
+        OClass oClass = schema.createClass(SHORTNAME_CLASS_NAME);
+        Assert.assertNull(oClass.getShortName());
+        Assert.assertNull(queryShortName());
+
+        String shortName = "shortname";
+        oClass.setShortName(shortName);
+        Assert.assertEquals(shortName, oClass.getShortName());
+        Assert.assertEquals(shortName, queryShortName());
+
+        //FAILS, save null value and store "null" string internally
+//        shortName = "null";
+//        oClass.setShortName(shortName);
+//        Assert.assertEquals(shortName, oClass.getShortName());
+//        Assert.assertEquals(shortName, queryShortName());
+
+        oClass.setShortName(null);
+        Assert.assertNull(oClass.getShortName());
+        Assert.assertNull(queryShortName());
+
+        //FAILS StringIndexOutOfBoundsException
+//        oClass.setShortName("");
+//        Assert.assertNull(oClass.getShortName());
+//        Assert.assertNull(queryShortName());
+    }
+
+    private String queryShortName(){
+        String selectShortNameSQL = "select shortName from ( select flatten(classes) from cluster:internal )"
+                + " where name = \"" + SHORTNAME_CLASS_NAME + "\"";
+        List<ODocument> result = db.command(new OCommandSQL(selectShortNameSQL)).execute();
+        Assert.assertEquals(1, result.size());
+        return result.get(0).field("shortName");
+    }
+}


### PR DESCRIPTION
OrientDB 1.5.1
Removing (setting to null) the shortname of a class throws a NullPointerException.

Here is a test and fix.
I don't know what should happen when setting "null" string or "" empty string as a shortname so I left these cases commented in the test.
