### PR TITLE
Do not thrown an exception if the network pool is empty; let the re-fill

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1724,6 +1724,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
   }
 
   protected void checkConnection() {
+      /*
     lock.acquireSharedLock();
 
     try {
@@ -1736,6 +1737,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     } finally {
       lock.releaseSharedLock();
     }
+      */
   }
 
   /**


### PR DESCRIPTION
When remote server goes away and comes back, the networkPool is empty, but the checkConnection() method prevents reattempting a connection to the remote database.  See discussion at https://groups.google.com/forum/#!topic/orient-database/ePkpTaj-gxk.  Similar code exists in develop branch and 1.6.0-SNAPSHOT.  Consider backporting to 1.5.x hotfix.
