### PR TITLE
Added missing optional dependencies to be able to load graph DB under OSGi.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,7 @@
             com.orientechnologies.orient.graph.console;resolution:=optional,
             com.orientechnologies.orient.graph.gremlin;resolution:=optional,
             com.orientechnologies.orient.graph.handler;resolution:=optional,
+            com.orientechnologies.orient.graph.sql.functions;resolution:=optional,
             org.iq80.snappy;resolution:=optional,
             javax.imageio.spi,sun.misc;resolution:=optional,
             com.orientechnologies.nio;resolution:=optional,

--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -35,7 +35,7 @@
         <javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
-        <osgi.import>*</osgi.import>
+        <osgi.import>com.hazelcast.*;resolution:=optional,*</osgi.import>
         <osgi.export>com.orientechnologies.orient.server.cluster.hazelcast.*</osgi.export>
     </properties>
 

--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -36,7 +36,12 @@
         <javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
-        <osgi.import>com.tinkerpop.blueprints;resolution:=optional,*</osgi.import>
+        <osgi.import>
+            com.tinkerpop.blueprints;resolution:=optional,
+            com.tinkerpop.gremlin.groovy.jsr223;resolution:=optional,
+            com.tinkerpop.gremlin.java;resolution:=optional,
+            *
+        </osgi.import>
         <osgi.export>com.orientechnologies.orient.graph.*</osgi.export>
         <blueprints.version>2.5.0-SNAPSHOT</blueprints.version>
     </properties>

--- a/nativeos/pom.xml
+++ b/nativeos/pom.xml
@@ -36,6 +36,7 @@
         <javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <jna.version>4.0.0</jna.version>
+        <osgi.import>com.sun.jna;resolution:=optional,*</osgi.import>
         <osgi.export>com.orientechnologies.nio.*</osgi.export>
     </properties>
 


### PR DESCRIPTION
When running under OSGi, the orientdb-graphdb bundle could not start because of missing constraints.  The addition of these optional imported bundles fixes that.
