### PR TITLE
WHERE @rid in [...] doesn't work with rids over multiple clusters

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClusters.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClusters.java
@@ -57,7 +57,7 @@ public class ORecordIteratorClusters<REC extends ORecordInternal<?>> extends OId
   public ORecordIteratorClusters<REC> setRange(final ORID iBegin, final ORID iEnd) {
     beginRange = iBegin;
     endRange = iEnd;
-    if (currentRecord != null && outsideOfTheRange(currentRecord.getIdentity().getClusterPosition())) {
+    if (currentRecord != null && outsideOfTheRange(currentRecord.getIdentity())) {
       currentRecord = null;
     }
     return this;
@@ -132,8 +132,7 @@ public class ORecordIteratorClusters<REC extends ORecordInternal<?>> extends OId
     // ITERATE UNTIL THE NEXT GOOD RECORD
     while (currentClusterIdx < clusterIds.length) {
       while (nextPosition()) {
-        final OClusterPosition currentPosition = currentPosition();
-        if (outsideOfTheRange(currentPosition))
+        if (outsideOfTheRange(current))
           continue;
 
         currentRecord = readCurrentRecord(record, 0);
@@ -160,11 +159,11 @@ public class ORecordIteratorClusters<REC extends ORecordInternal<?>> extends OId
     return false;
   }
 
-  private boolean outsideOfTheRange(OClusterPosition currentPosition) {
-    if (beginRange != null && currentPosition.compareTo(beginRange.getClusterPosition()) < 0)
+  private boolean outsideOfTheRange(ORID orid) {
+    if (beginRange != null && orid.compareTo(beginRange) < 0)
       return true;
 
-    if (endRange != null && currentPosition.compareTo(endRange.getClusterPosition()) > 0)
+    if (endRange != null && orid.compareTo(endRange) > 0)
       return true;
 
     return false;

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLSelectTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLSelectTest.java
@@ -1491,6 +1491,33 @@ public class SQLSelectTest {
   }
 
   @Test
+  public void testSelectRidInList() {
+    OClass placeClass = database.getMetadata().getSchema().createClass("Place");
+    database.getMetadata().getSchema().createClass("FamousPlace", placeClass);
+
+    ODocument firstPlace = new ODocument("Place");
+    database.save(firstPlace);
+    ODocument secondPlace = new ODocument("Place");
+    database.save(secondPlace);
+    ODocument famousPlace = new ODocument("FamousPlace");
+    database.save(famousPlace);
+
+    ORID secondPlaceId = secondPlace.getIdentity();
+    ORID famousPlaceId = famousPlace.getIdentity();
+    //if one of these two asserts fails, the test will be meaningless.
+    Assert.assertTrue(secondPlaceId.getClusterId() < famousPlaceId.getClusterId());
+    Assert.assertTrue(secondPlaceId.getClusterPosition().longValue() > famousPlaceId.getClusterPosition().longValue());
+
+    List<ODocument> result = new OSQLSynchQuery<ODocument>("select from Place where @rid in ["
+        + secondPlaceId + "," + famousPlaceId +
+        "]").execute();
+    Assert.assertEquals(2, result.size());
+
+    database.getMetadata().getSchema().dropClass("FamousPlace");
+    database.getMetadata().getSchema().dropClass("Place");
+  }
+
+  @Test
   public void testMapKeys() {
     Map<String, Object> params = new HashMap<String, Object>();
     params.put("id", 4);


### PR DESCRIPTION
Tested with 1.5.1 and develop branch

``` SQL
SELECT FROM Thing WHERE @rid in [#10:20,#11:5]
```

Where the position of the greatest rid (5) is lesser than the position of the smallest rid (20), orientdb can't find any document.

Pull request provides test and fix.
