### PR TITLE
added idleTimeout with eviction handling for connection pools

### DIFF
--- a/commons/src/main/java/com/orientechnologies/common/concur/resource/OResourcePool.java
+++ b/commons/src/main/java/com/orientechnologies/common/concur/resource/OResourcePool.java
@@ -89,4 +89,8 @@ public class OResourcePool<K, V> {
   public void close() {
     sem.drainPermits();
   }
+  
+  public void remove(final V res) {
+  	this.resources.remove(res);
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/ODatabasePoolBase.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/ODatabasePoolBase.java
@@ -51,10 +51,15 @@ public abstract class ODatabasePoolBase<DB extends ODatabase> extends Thread {
   protected abstract DB createResource(Object owner, String iDatabaseName, Object... iAdditionalArgs);
 
   public ODatabasePoolBase<DB> setup(final int iMinSize, final int iMaxSize) {
+  	return this.setup(iMinSize, iMaxSize, 0L, 0L);
+  }
+  
+  public ODatabasePoolBase<DB> setup(final int iMinSize, final int iMaxSize, final long idleTimeout,
+			final long timeBetweenEvictionRunsMillis) {
     if (dbPool == null)
       synchronized (this) {
         if (dbPool == null) {
-          dbPool = new ODatabasePoolAbstract<DB>(this, iMinSize, iMaxSize) {
+          dbPool = new ODatabasePoolAbstract<DB>(this, iMinSize, iMaxSize, idleTimeout, timeBetweenEvictionRunsMillis) {
 
             public void onShutdown() {
               if (owner instanceof ODatabasePoolBase<?>)

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/PoolTester2.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/PoolTester2.java
@@ -1,0 +1,86 @@
+package com.orientechnologies.orient.test.database.auto;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.db.graph.OGraphDatabase;
+import com.orientechnologies.orient.core.db.graph.OGraphDatabasePool;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+
+public class PoolTester2 {
+
+	/**
+	 * @param args
+	 * @throws InterruptedException
+	 */
+	public static void main(String[] args) throws InterruptedException {
+
+		ExecutorService executor = Executors.newFixedThreadPool(20);
+
+		OGraphDatabasePool pool = new OGraphDatabasePool("remote:localhost/demo", "admin", "admin");
+		pool.setup(2, 30, 10000, 30000);
+
+		for (int i = 0; i < 200; i++) {
+			MyRunnable runnable = new MyRunnable(i, pool);
+			executor.execute(runnable);
+		}
+		
+		Thread.sleep(40000);
+		
+		for (int i = 0; i < 200; i++) {
+			MyRunnable runnable = new MyRunnable(i, pool);
+			executor.execute(runnable);
+		}
+		
+		// This will make the executor accept no new threads
+		// and finish all existing threads in the queue
+		executor.shutdown();
+		
+		Thread.sleep(60000);
+
+	}
+
+	static class MyRunnable implements Runnable {
+
+		private int									id;
+		private OGraphDatabasePool	pool;
+
+		public MyRunnable(int id, OGraphDatabasePool pool) {
+			this.id = id;
+			this.pool = pool;
+		}
+
+		@Override
+		public void run() {
+			OGraphDatabase conn = null;
+			try {
+				conn = pool.acquire();
+				System.out.println("Opened " + id + " connection " + conn);
+
+				this.doStuff(conn);
+
+				// do stuff
+			} finally {
+				conn.close();
+				System.out.println("Closed " + id + " connection");
+			}
+
+		}
+
+		private void doStuff(OGraphDatabase conn) {
+			try {
+				OSQLSynchQuery<ODocument> query = new OSQLSynchQuery<ODocument>("SELECT FROM V");
+				List<ODocument> result = conn.command(query).execute();
+				if (result.size() > 0) {
+					ODocument doc = result.get(0);
+				}
+			} catch (OException e) {
+				System.err.println("Query failed");
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a really simple implementation of eviction for connections that stay idle in the pool for a minimum time. In this way the pools can be dynamically resized if the connections are not used for a certain amount of time.

Optionally, one may configure the pool to examine and possibly evict connections as they sit idle in the pool. This is performed by an "idle object eviction" task. Caution should be used when configuring this optional feature. Eviction runs contend with client threads for access to connections in the pool, so if they run too frequently performance issues may result.

This can be an important feature for an application with multiple databases / pools (eg: multi tenant application with one database per tenant) that has periodic peak loads. With this implementation the connections are dynamically evicted when are idle for a certain amount of time.

The following code:

```
pool = new ODatabaseDocumentPool();
pool.setup(0, 50, 120000, 600000);
```

runs the Evictor task every 10 minutes closing the connections that are idle for at least 2 minutes.

For a more fine grained handling of pools I would consider the use of Apache Common Pools (http://commons.apache.org/proper/commons-pool/index.html) which gives additional features like LIFO/FIFO pool management or JMX management / monitoring and other useful stuff (see here http://commons.apache.org/proper/commons-pool/api-1.6/index.html).
