### PR TITLE
Avoid using OSGi fragments for -client and -commons as they confuse some

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -35,7 +35,6 @@
     <properties>
         <osgi.import>*</osgi.import>
         <osgi.export>com.orientechnologies.orient.client.*</osgi.export>
-        <osgi.fragment.host>com.orientechnologies.orientdb-core</osgi.fragment.host>
     </properties>
 
     <dependencies>
@@ -45,6 +44,5 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -35,7 +35,6 @@
     <properties>
         <osgi.export>com.orientechnologies.common.*</osgi.export>
         <osgi.import>javax.imageio.spi.*,sun.misc.*;resolution:=optional</osgi.import>
-        <osgi.fragment.host>com.orientechnologies.orientdb-core</osgi.fragment.host>
     </properties>
 
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,7 @@
             org.iq80.snappy;resolution:=optional,
             javax.imageio.spi,sun.misc;resolution:=optional,
             com.orientechnologies.nio;resolution:=optional,
+            com.orientechnologies.orient.client.remote;resolution:=optional,
             *
         </osgi.import>
         <osgi.export>com.orientechnologies.orient.core.*</osgi.export>


### PR DESCRIPTION
Avoid using OSGi fragments for -client and -commons as they confuse some OSGi tools.
