### PR TITLE
#1958 OMemoryWatchDog issue : WeakHashMap used for listeners

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/memory/OMemoryWatchDog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/memory/OMemoryWatchDog.java
@@ -153,7 +153,6 @@ public class OMemoryWatchDog extends Thread {
         if (!isMemoryAvailable())
           // CALL LISTENER TO FREE MEMORY
           synchronized (listeners) {
-            System.out.println("listeners : " + listeners.size());
             for (ListenerWrapper listener : listeners.keySet()) {
               try {
                 listener.listener.lowMemory(maxHeap - usedHeap, 100 - usedMemoryPer);


### PR DESCRIPTION
I found a better solution than revert to IdentityHashMap: the Listener returned by
OMemoryWatchDog.addListener() is the wrapper and not the listener itself. The caller MUST reference
this returned wrapper with a strong ref.

Thus, Weak map is preserved.

My tests are Ok.
