### PR TITLE
Introducing UPDATE UPSERT

### DIFF
--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLUpdateTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLUpdateTest.java
@@ -74,6 +74,7 @@ public class SQLUpdateTest {
 
   }
 
+
   @Test
   public void updateWithWhereRid() {
 
@@ -88,7 +89,21 @@ public class SQLUpdateTest {
 
   }
 
-  @Test(dependsOnMethods = "updateWithWhereOperator")
+    @Test
+    public void updateUpsertOperator() {
+
+        List<ODocument> result = database.command(new OCommandSQL("UPDATE Profile SET surname='Merkel' RETURN AFTER where surname = 'Merkel'")).execute();
+        Assert.assertEquals(result.size(), 0);
+
+        result = database.command(new OCommandSQL("UPDATE Profile SET surname='Merkel' UPSERT RETURN AFTER  where surname = 'Merkel'")).execute();
+        Assert.assertEquals(result.size(), 1);
+
+        result = database.command(new OCommandSQL("SELECT FROM Profile  where surname = 'Merkel'")).execute();
+        Assert.assertEquals(result.size(), 1);
+    }
+
+
+    @Test(dependsOnMethods = "updateWithWhereOperator")
   public void updateCollectionsAddWithWhereOperator() {
 
     updatedRecords = (Integer) database.command(new OCommandSQL("update Account add addresses = #13:0")).execute();


### PR DESCRIPTION
It would be nice to have a functionality similar to PostgreSQL or MongoDB's UPSERT.

UPSERT updates a record if it already exists, or inserts a new record if it does not - all in a single statement.
It should decreases time of data insertion, where the scenario 

if(SELECT record exists) {
  UPDATE record;
} else {
  INSERT record;
}

is common.
UPSERT operator has a sense with class name and WHERE operator. In other cases generates an exception.

Full UPDATE syntax would look following:
"UPDATE <class>|cluster:<cluster>> [SET|ADD|PUT|REMOVE|INCREMENT|CONTENT {<JSON>}|MERGE {<JSON>}] [[,] <field-name> = <expression>|<sub-command>]\*  [LOCK <NONE|RECORD>] [UPSERT] [RETURN <COUNT|BEFORE|AFTER>] [WHERE <conditions>]
