### PR TITLE
#1955 SELECT .. FETCHPLAN doesn't work in binary protocol

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
@@ -1303,10 +1303,14 @@ public class ONetworkProtocolBinary extends OBinaryNetworkProtocolAbstract {
       if (!isConnectionAlive())
         return;
 
-      // ASSIGNED THE PARSED FETCHPLAN
+       // ASSIGNED THE PARSED FETCHPLAN
       listener.setFetchPlan(connection.database.command(command).getFetchPlan());
 
       final Object result = connection.database.command(command).execute();
+
+      // FETCHPLAN HAS TO BE ASSIGNED AGAIN, because it can be changed by SQL statement
+      listener.setFetchPlan(command.getFetchPlan());
+
 
       if (asynch) {
         // ASYNCHRONOUS


### PR DESCRIPTION
It fixes #1955. After change, FETCHPLAN works with binary protocol on two levels
- COMMAND level - defined in COMMAND payload
- SQL SELECT with FETCHPLAN clause

If both are defined SQL FETCHPLAN overrides COMMAND fetch plan.

Since now
SELECT FROM V WHERE name="HEY BO DIDDLEY" FETCHPLAN "*:1"
returns via binary protocol expected
#9:1 v25 V@name:"HEY BO DIDDLEY",song_type:"cover",performances:5,type:"song",out_followed_by:%AQAAAAUACwAAAAAAAAAAAAsAAAAAAAAAAQALAAAAAAAAAAIACwAAAAAAAAADAAsAAAAAAAAABA==;,out_written_by:#9:7,out_sung_by:#9:8,in_followed_by:%AQAAAAQACwAAAAAAAAAKAAsAAAAAAAAAlgALAAAAAAAAChIACwAAAAAAABXG;

-------------- PREFETCHED ---------
#9:7 v19 V@in_written_by:%AQAAAAkACQAAAAAAAAABAAkAAAAAAAAABgAJAAAAAAAAAXEACQAAAAAAAAJDAAkAAAAAAAACQwAJAAAAAAAAAosACQAAAAAAAALJAAkAAAAAAAAC7QAJAAAAAAAAAyM=;,in_sung_by:%AQAAAAcACQAAAAAAAAJDAAkAAAAAAAACQwAJAAAAAAAAAosACQAAAAAAAALJAAkAAAAAAAAC7QAJAAAAAAAAAvwACQAAAAAAAAMj;,name:"Bo_Diddley",type:"artist"
#9:8 v153 V@in_sung_by:%AAAAAAAAAAAcAAAAAAAAAAAAAIAAAAAAkgAAAAA=;,in_written_by:%AQAAAAQACQAAAAAAAAD0AAkAAAAAAAABzQAJAAAAAAAAAdEACQAAAAAAAAHu;,name:"Garcia",type:"artist"
#11:0 v2 followed_by@out:#9:1,in:#9:2,weight:1
#11:1 v2 followed_by@out:#9:1,in:#9:3,weight:2
#11:2 v2 followed_by@out:#9:1,in:#9:4,weight:1
#11:3 v2 followed_by@out:#9:1,in:#9:5,weight:1
#11:4 v2 followed_by@out:#9:1,in:#9:6,weight:1
#11:10 v2 followed_by@out:#9:3,in:#9:1,weight:2
#11:150 v2 followed_by@out:#9:5,in:#9:1,weight:2
#11:2578 v2 followed_by@out:#9:49,in:#9:1,weight:1
#11:5574 v2 followed_by@out:#9:25,in:#9:1,weight:1
