### PR TITLE
Update to start/stop script's use of 'su' command.

### DIFF
--- a/server/script/orientdb.sh
+++ b/server/script/orientdb.sh
@@ -20,7 +20,7 @@ start() {
 	fi
 	echo "Starting OrientDB server daemon..."
 	cd "$ORIENTDB_DIR/bin"
-	su -c "cd \"$ORIENTDB_DIR/bin\"; /usr/bin/nohup ./server.sh 1>../log/orientdb.log 2>../log/orientdb.err &" - $ORIENTDB_USER
+	su $ORIENTDB_USER -c "cd \"$ORIENTDB_DIR/bin\"; /usr/bin/nohup ./server.sh 1>../log/orientdb.log 2>../log/orientdb.err &"
 }
 
 stop() {
@@ -32,7 +32,7 @@ stop() {
 	fi
 	echo "Stopping OrientDB server daemon..."
 	cd "$ORIENTDB_DIR/bin"
-	su -c "cd \"$ORIENTDB_DIR/bin\"; /usr/bin/nohup ./shutdown.sh 1>>../log/orientdb.log 2>>../log/orientdb.err &" - $ORIENTDB_USER
+	su $ORIENTDB_USER -c "cd \"$ORIENTDB_DIR/bin\"; /usr/bin/nohup ./shutdown.sh 1>>../log/orientdb.log 2>>../log/orientdb.err &"
 }
 
 status() {
@@ -41,7 +41,7 @@ status() {
 	then
 		PID=0
 	fi
-	
+
 	# if PID is greater than 0 then OrientDB is running, else it is not
 	return $PID
 }


### PR DESCRIPTION
Hi,

After building OrientDB from source on my Mac (Mavericks), I encountered a problem starting it using orientdb.sh.

It boils down to the syntax of the 'su' command used to start and stop the server.

The previous syntax of:
su -c 'COMMAND' - USER

Is not valid on Macs and produces an error:
su: illegal option -- c

The correct syntax for the same command on Macs is:
su USER -c 'COMMAND'

This seems to work on Linux as well, I tested the command syntax on Fedora 20.

I mentioned this on Twitter and Luca requested a pull request so, here it is. :)

Best,

Jeremiah Hall
