### PR TITLE
Declare orientdb-core dependency to be of jar type

### DIFF
--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -76,7 +76,6 @@
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-core</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
orientdb-core pom dependency is of no use here, it's not even a BOM pom. It is not only not-useful, but it is casusing issues. E.g. with SBT, even if I explicitly added orientdb-core dependency, the pom type of orientdb-core dependency in orientdb-graph pom was removing orientdb-core from the classpath, so in my code any class referencing a class which makes use of orientdb-core classes would not compile (was getting infamous "class file is broken error").

Thus, instead of pom type, orientdb-core dependency should be declared as dependency of jar type (default).
