### PR TITLE
Declare jar dependencies as jar type dependencies

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -48,14 +48,12 @@
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-core</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
         </dependency>
 
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orient-commons</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Just like #2070, more dependencies were wrongly labeled as of pom type.
