### PR TITLE
Replication of database failed if no /tmp/orientdb directory exists yet

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -686,6 +686,7 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin implements Memb
                   ODistributedDatabaseChunk chunk = (ODistributedDatabaseChunk) value;
 
                   final String fileName = Orient.getTempPath() + "install_" + databaseName + ".zip";
+                  new File(Orient.getTempPath()).mkdirs();
 
                   ODistributedServerLog.info(this, getLocalNodeName(), r.getKey(), DIRECTION.IN,
                       "copying remote database '%s' to: %s", databaseName, fileName);


### PR DESCRIPTION
I'm testing OrientDB replication. For this I started one server. Then I wanted to see the replication of the sampledatabse that comes with OrientDB - for this I removed the directory "GratefulDeadConcerts" in databases. After that I started the second server. I got the following Exception:

2014-03-10 14:15:06:766 INFO Saving distributed configuration file for database 'GratefulDeadConcerts' to: /home/testuser/orientdb/databases/GratefulDeadConcerts/distributed-config.json [OHazelcastPlugin]
2014-03-10 14:15:07:753 INFO [orient-02]<-[orient-01] copying remote database 'GratefulDeadConcerts' to: /tmp/orientdb/install_GratefulDeadConcerts.zip [OHazelcastPlugin][orient-02] error on transferring database 'GratefulDeadConcerts' to '/tmp/orientdb/install_GratefulDeadConcerts.zip'
/tmp/orientdb/install_GratefulDeadConcerts.zip (No such file or directory)
-> java.io.FileOutputStream.open(Native Method)
-> java.io.FileOutputStream.<init>(FileOutputStream.java:212)
-> java.io.FileOutputStream.<init>(FileOutputStream.java:136)
-> com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin.installNewDatabases(OHazelcastPlugin.java:699)
-> com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin.startup(OHazelcastPlugin.java:191)
-> com.orientechnologies.orient.server.OServer.registerPlugins(OServer.java:669)
-> com.orientechnologies.orient.server.OServer.activate(OServer.java:221)
-> com.orientechnologies.orient.server.OServerMain.main(OServerMain.java:32)
2014-03-10 14:15:07:755 WARN [orient-02]<-[orient-01] installing database 'GratefulDeadConcerts' to: /home/testuser/orientdb/databases/GratefulDeadConcerts... [OHazelcastPlugin][orient-02] error on copying database 'GratefulDeadConcerts' on local server
/tmp/orientdb/install_GratefulDeadConcerts.zip (No such file or directory)
-> java.io.FileInputStream.open(Native Method)
-> java.io.FileInputStream.<init>(FileInputStream.java:138)
-> com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin.installDatabase(OHazelcastPlugin.java:780)
-> com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin.installNewDatabases(OHazelcastPlugin.java:732)
-> com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin.startup(OHazelcastPlugin.java:191)
-> com.orientechnologies.orient.server.OServer.registerPlugins(OServer.java:669)
-> com.orientechnologies.orient.server.OServer.activate(OServer.java:221)
-> com.orientechnologies.orient.server.OServerMain.main(OServerMain.java:32)

After I tested around a bit, it recognized that the replication works well when the "/tmp/orientdb" directory was created manually. Checking the code I saw that the "/tmp/orientdb" directory was created in the method "installDatabase(..)", which is to late, since "installNewDatabases(..)" already tries to write to that file.
