### PR TITLE
fixed regression on ODatabaseThreadLocalFactory usage

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
@@ -285,6 +285,10 @@ public abstract class ORecordAbstract<T> implements ORecord<T>, ORecordInternal<
   }
 
   public ODatabaseRecord getDatabase() {
+    return ODatabaseRecordThreadLocal.INSTANCE.get();
+  }
+
+  public ODatabaseRecord getDatabaseIfDefined() {
     return ODatabaseRecordThreadLocal.INSTANCE.getIfDefined();
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordSchemaAwareAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordSchemaAwareAbstract.java
@@ -78,7 +78,7 @@ public abstract class ORecordSchemaAwareAbstract<T> extends ORecordAbstract<T> i
 
   public OClass getSchemaClass() {
     if (_clazz == null) {
-      final ODatabaseRecord database = getDatabase();
+      final ODatabaseRecord database = getDatabaseIfDefined();
       if (database != null && database.getStorageVersions().classesAreDetectedByClusterId()) {
         if (_recordId.clusterId < 0) {
           checkForLoading();
@@ -102,7 +102,7 @@ public abstract class ORecordSchemaAwareAbstract<T> extends ORecordAbstract<T> i
     if (_clazz != null)
       return _clazz.getName();
 
-    final ODatabaseRecord database = getDatabase();
+    final ODatabaseRecord database = getDatabaseIfDefined();
     if (database != null && database.getStorageVersions().classesAreDetectedByClusterId()) {
       if (_recordId.clusterId < 0) {
         checkForLoading();


### PR DESCRIPTION
fixed regression: ODatabaseThreadLocalFactory was ignored when passing from ORecordAbstract.getDatabase()
