### PR TITLE
Make OIndexFullText more useful by capturing not only the full words but also their prefixes

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFullText.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFullText.java
@@ -72,7 +72,7 @@ public class OIndexFullText extends OIndexMultiValues {
     modificationLock.requestModificationLock();
 
     try {
-      final List<String> words = splitIntoWords(key.toString());
+      final Set<String> words = splitIntoWords(key.toString());
 
       // FOREACH WORD CREATE THE LINK TO THE CURRENT DOCUMENT
       for (final String word : words) {
@@ -117,7 +117,7 @@ public class OIndexFullText extends OIndexMultiValues {
 
     key = getCollatingValue(key);
 
-    final List<String> words = splitIntoWords(key.toString());
+    final Set<String> words = splitIntoWords(key.toString());
 
     // FOREACH WORD CREATE THE LINK TO THE CURRENT DOCUMENT
     for (final String word : words) {
@@ -166,7 +166,7 @@ public class OIndexFullText extends OIndexMultiValues {
     modificationLock.requestModificationLock();
 
     try {
-      final List<String> words = splitIntoWords(key.toString());
+      final Set<String> words = splitIntoWords(key.toString());
       boolean removed = false;
 
       for (final String word : words) {
@@ -198,7 +198,7 @@ public class OIndexFullText extends OIndexMultiValues {
   protected void removeFromSnapshot(Object key, OIdentifiable value, Map<Object, Object> snapshot) {
     key = getCollatingValue(key);
 
-    final List<String> words = splitIntoWords(key.toString());
+    final Set<String> words = splitIntoWords(key.toString());
     for (final String word : words) {
       final Set<OIdentifiable> recs;
       final Object snapshotValue = snapshot.get(word);
@@ -256,8 +256,8 @@ public class OIndexFullText extends OIndexMultiValues {
     return configuration;
   }
 
-  private List<String> splitIntoWords(final String iKey) {
-    final List<String> result = new ArrayList<String>();
+  private Set<String> splitIntoWords(final String iKey) {
+    final Set<String> result = new HashSet<String>();
 
     final List<String> words = (List<String>) OStringSerializerHelper.split(new ArrayList<String>(), iKey, 0, -1, separatorChars);
 
@@ -282,13 +282,19 @@ public class OIndexFullText extends OIndexMultiValues {
           buffer.append(c);
       }
 
-      word = buffer.toString();
+      int length = buffer.length();
 
-      // CHECK IF IT'S A STOP WORD
-      if (stopWords.contains(word))
-        continue;
+      while (length > 0) {
+        buffer.setLength(length);
+        word = buffer.toString();
 
-      result.add(word);
+        // CHECK IF IT'S A STOP WORD
+        if (!stopWords.contains(word)) {
+          result.add(word);
+        }
+
+        length--;
+      }
     }
 
     return result;


### PR DESCRIPTION
There have been a lot of discussions surrounding full-text search improvements (involving Lucene or ElasticSearch) but I believe this simple approach hasn't been explored yet.

By indexing all word prefixes for a given key (luca garulli => luca, luc, lu, l, garulli, garull, garul, garu, gar, ga, g) one can easily answer queries where the full key isn't provided such as:
SELECT FROM Person WHERE name CONTAINSTEXT 'Garu'

This approach can be further improved by:
1) configuring the minimum word length to index (not much value in indexing single letters);
2) index not only word prefixes but also substrings thus supporting queries like:
    SELECT FROM Person WHERE name CONTAINSTEXT 'rull'

I'd love to have your comments on whether this worth exploring as a solution for [the default] FT search on OrientDB.
