### PR TITLE
Add Rexster configuration file.

### DIFF
--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -95,6 +95,12 @@
             <version>${blueprints.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.tinkerpop.rexster</groupId>
+            <artifactId>rexster-core</artifactId>
+            <version>${blueprints.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-test</artifactId>
             <version>${blueprints.version}</version>

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraphRexsterConfiguration.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraphRexsterConfiguration.java
@@ -1,0 +1,62 @@
+package com.tinkerpop.blueprints.impls.orient;
+
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import com.tinkerpop.blueprints.Graph;
+import com.tinkerpop.rexster.Tokens;
+import com.tinkerpop.rexster.config.GraphConfiguration;
+import com.tinkerpop.rexster.config.GraphConfigurationContext;
+import com.tinkerpop.rexster.config.GraphConfigurationException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.configuration.SubnodeConfiguration;
+
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public class OrientGraphRexsterConfiguration implements GraphConfiguration {
+
+    public Graph configureGraphInstance(final GraphConfigurationContext context) throws GraphConfigurationException {
+
+        final String graphFile = context.getProperties().getString(Tokens.REXSTER_GRAPH_LOCATION);
+
+        if (graphFile == null || graphFile.length() == 0) {
+            throw new GraphConfigurationException("Check graph configuration. Missing or empty configuration element: " + Tokens.REXSTER_GRAPH_LOCATION);
+        }
+
+        // get the <properties> section of the xml configuration
+        final HierarchicalConfiguration graphSectionConfig = (HierarchicalConfiguration) context.getProperties();
+        SubnodeConfiguration orientDbSpecificConfiguration;
+
+        try {
+            orientDbSpecificConfiguration = graphSectionConfig.configurationAt(Tokens.REXSTER_GRAPH_PROPERTIES);
+        } catch (IllegalArgumentException iae) {
+            throw new GraphConfigurationException("Check graph configuration. Missing or empty configuration element: " + Tokens.REXSTER_GRAPH_PROPERTIES);
+        }
+
+        try {
+
+            final String username = orientDbSpecificConfiguration.getString("username", "");
+            final String password = orientDbSpecificConfiguration.getString("password", "");
+
+            // Caching must be turned off. OrientDB has different layers of cache:
+            // http://code.google.com/p/orient/wiki/Caching There's one Level1 cache per OGraphDatabase instance
+            // and one level2 per JVM. If a OGraphDatabase caches a vertex and then you change it in
+            // another thread/transaction you could see the older one. To fix it just disable the Level1 cache.
+            // If there were multiple running JVM you could have Level2 cache not updated for the same reason as
+            // above. Then you've to disable Level2 cache....per Luca.
+            //
+            // Disabling the level 1 cache seems to solve the problem where POSTs of edges in rapid succession
+            // force a transaction error like: Cannot update record #6:0 in storage 'orientdb-graph' because the
+            // version is not the latest. Probably you are updating an old record or it has been modified by
+            // another user (db=v2 your=v0)
+            OGlobalConfiguration.CACHE_LEVEL1_ENABLED.setValue(false);
+
+            // calling the open method opens the connection to graphdb.  looks like the
+            // implementation of shutdown will call the orientdb close method.
+            return new OrientGraph(graphFile, username, password);
+
+        } catch (Exception ex) {
+            throw new GraphConfigurationException(ex);
+        }
+    }
+
+}


### PR DESCRIPTION
Rexster no longer depends on OrientDB, therefore this class needs to live with the OrientDB repository.  The addition of rexster-core to the pom comes with provided scope as OrientDB does not need to package rexster dependencies (they are provided by rexster when OrientDB is deployed there).
