### PR TITLE
Fixed Ridbag traversing- AccumulativeListener limit (was always 1) in binary protocol

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/OTreeInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/OTreeInternal.java
@@ -43,7 +43,7 @@ public interface OTreeInternal<K, V> {
     public boolean addResult(Map.Entry<K, V> entry) {
       entries.add(entry);
 
-      return limit < entries.size();
+      return limit > entries.size();
     }
 
     public List<Map.Entry<K, V>> getResult() {


### PR DESCRIPTION
It could lead to performance issues (chatty) during remote Ridbag traversing
