### PR TITLE
Removed Sonatype OSS snapshots repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,21 +139,6 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <!-- required to include Tinkerpop SNAPSHOT dependencies -->
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>


### PR DESCRIPTION
Since there are no more Blueprints snapshot dependencies (see [here](https://github.com/orientechnologies/orientdb/issues/2065)), Sonatype OSS snapshots repository is no longer needed, it just slows down the build.
