### PR TITLE
Fixed execution of sql batch script when lines ending with \n 

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorScript.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorScript.java
@@ -170,6 +170,8 @@ public class OCommandExecutorScript extends OCommandExecutorAbstract {
         if (line == txBegunAtLine)
           // SKIP PREVIOUS COMMAND PART AND JUMP TO THE BEGIN IF ANY
           linePart = txBegunAtPart;
+        else
+          linePart = 0;
 
         for (; linePart < lineParts.size(); ++linePart) {
           final String lastCommand = lineParts.get(linePart);


### PR DESCRIPTION
Apart from script sql console command, sql batch with binary protocol does not execute commands.
Script sql uses ; as a delimiter.
Simple script below does nothing, due to not initialized linePart variable.
begin
let var1 = INSERT INTO Address CONTENT {Town:"Wroclaw",Zip:0}
let var2 = INSERT INTO University CONTENT {Name:"Pwr"}
commit
return 1
