### PR TITLE
RidBag deserialization from JSON when @fieldType is provided

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -827,6 +827,7 @@ public class ODocument extends ORecordSchemaAwareAbstract<Object> implements Ite
 
       if (iPropertyValue instanceof ORidBag) {
         final ORidBag ridBag = (ORidBag) iPropertyValue;
+        ridBag.setOwner(null); // in order to avoid IllegalStateException when ridBag changes the owner (ODocument.merge)
         ridBag.setOwner(this);
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
@@ -457,8 +457,7 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
         Object collectionItem;
         for (String item : items) {
           iFieldValue = item.trim();
-          if (!(iLinkedType == OType.DATE || iLinkedType == OType.BYTE || iLinkedType == OType.INTEGER || iLinkedType == OType.LONG
-              || iLinkedType == OType.DATETIME || iLinkedType == OType.DECIMAL || iLinkedType == OType.DOUBLE || iLinkedType == OType.FLOAT))
+          if (iFieldValue.startsWith("\""))
             iFieldValueAsString = iFieldValue.length() >= 2 ? iFieldValue.substring(1, iFieldValue.length() - 1) : iFieldValue;
           else
             iFieldValueAsString = iFieldValue;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdate.java
@@ -311,21 +311,29 @@ public class OCommandExecutorSQLUpdate extends OCommandExecutorSQLRetryAbstract 
         // GET THE TYPE IF ANY
         if (record.getSchemaClass() != null) {
           OProperty prop = record.getSchemaClass().getProperty(entry.getKey());
-          if (prop != null && prop.getType() == OType.LINKSET)
+            if (prop != null && prop.getType() == OType.LINKSET)
             // SET TYPE
             coll = new HashSet<Object>();
+            if (prop != null && prop.getType() == OType.LINKBAG)
+            {
+                // there is no ridbag value already but property type is defined as LINKBAG
+                bag = new ORidBag();
+                bag.setOwner(record);
+                record.field(entry.getKey(),bag);
+            }
         }
-
-        if (coll == null)
+         if (coll == null && bag==null)
           // IN ALL OTHER CASES USE A LIST
           coll = new ArrayList<Object>();
-
-        // containField's condition above does NOT check subdocument's fields so
-        Collection<Object> currColl = record.field(entry.getKey());
-        if (currColl == null)
-          record.field(entry.getKey(), coll);
-        else
-          coll = currColl;
+         if (coll!=null)
+         {
+            // containField's condition above does NOT check subdocument's fields so
+            Collection<Object> currColl = record.field(entry.getKey());
+            if (currColl == null)
+              record.field(entry.getKey(), coll);
+            else
+              coll = currColl;
+         }
 
       } else {
         fieldValue = record.field(entry.getKey());
@@ -560,7 +568,7 @@ public class OCommandExecutorSQLUpdate extends OCommandExecutorSQLRetryAbstract 
           parserGoBack();
           value = EMPTY_VALUE;
         } else {
-          fieldValue = getBlock(parserRequiredWord(false, "Value expected"));
+          fieldValue = getBlock(parserRequiredWord(false, "Value expected", " =><,\r\n"));
           value = getFieldValueCountingParameters(fieldValue);
         }
       else

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -16,8 +16,11 @@
 package com.orientechnologies.orient.test.database.auto;
 
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.OTrackedList;
+import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.OJSONWriter;
@@ -709,4 +712,18 @@ public class JSONTest {
     Assert.assertEquals(list.get(0), "string");
     Assert.assertEquals(list.get(1), 42);
   }
+
+    @Test
+    public void testEmbeddedRIDBagDeserialisationWhenFieldTypeIsProvided() throws Exception {
+        ODocument documentSource = new ODocument();
+        documentSource.fromJSON("{FirstName:\"Student A 0\",in_EHasGoodStudents:[#57:0],@fieldTypes:\"in_EHasGoodStudents=g\"}");
+
+        ORidBag bag = documentSource.field("in_EHasGoodStudents");
+        Assert.assertEquals(bag.size(),1);
+        OIdentifiable rid = bag.rawIterator().next();
+        Assert.assertTrue(rid.getIdentity().getClusterId()==57);
+        Assert.assertTrue(rid.getIdentity().getClusterPosition().intValue()==0);
+
+    }
+
 }


### PR DESCRIPTION
Useful for INSERT INTO CONTENT when you want to preinitialize ridbags
Combined with single UPDATE ADD in_edgeField can be efficent way to create 1-N edges.

PS. ODocument I couln't find more elegant way to reset RidBag owner (it's needed when two documents are merged INSERT INTO CONTENT--> ODocument.merge()
The other option was to enhance setOwner(owner) to setOwner(owner,forceFlag)

Test case added. Tests passed
