### PR TITLE
concurrency: Remove acquireExclusiveLock

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/security/OSecurityShared.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/security/OSecurityShared.java
@@ -201,21 +201,15 @@ public class OSecurityShared extends OSharedResourceAdaptive implements OSecurit
         return user;
     }
 
-    acquireExclusiveLock();
-    try {
+    final List<ODocument> result = getDatabase().<OCommandRequest> command(
+        new OSQLSynchQuery<ODocument>("select from OUser where name = '" + iUserName + "' limit 1").setFetchPlan("roles:1"))
+        .execute();
 
-      final List<ODocument> result = getDatabase().<OCommandRequest> command(
-          new OSQLSynchQuery<ODocument>("select from OUser where name = '" + iUserName + "' limit 1").setFetchPlan("roles:1"))
-          .execute();
+    if (result != null && !result.isEmpty())
+      return cacheUser(new OUser(result.get(0)));
 
-      if (result != null && !result.isEmpty())
-        return cacheUser(new OUser(result.get(0)));
+    return null;
 
-      return null;
-
-    } finally {
-      releaseExclusiveLock();
-    }
   }
 
   public OUser createUser(final String iUserName, final String iUserPassword, final String... iRoles) {


### PR DESCRIPTION
During getUser, select from OUser reads
It does not need an exclusive lock

This logic is similar to @lvca commit
Minor: removed lock on authentication at
https://github.com/orientechnologies/orientdb/commit/000e40420feb842f4e1182f2c08b6e3010547a22

Reviewed-by: Lloyd Chang lloydchang@gmail.com
Signed-off-by: Lloyd Chang lloydchang@gmail.com
