### PR TITLE
#2319 UPDATE RETURN <expression> syntax

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLAbstract.java
@@ -125,17 +125,5 @@ public abstract class OCommandExecutorSQLAbstract extends OCommandExecutorAbstra
     return lockStrategy;
   }
 
-  /**
-   * Parses the returning keyword if found.
-   */
-  protected String parseReturn() throws OCommandSQLParsingException {
-    parserNextWord(true);
-    final String returning = parserGetLastWord();
 
-    if (!returning.equalsIgnoreCase("COUNT") && !returning.equalsIgnoreCase("BEFORE") && !returning.equalsIgnoreCase("AFTER"))
-      throwParsingException("Invalid " + KEYWORD_RETURN + " value set to '" + returning
-          + "' but it should be COUNT (default), BEFORE or AFTER. Example: " + KEYWORD_RETURN + " BEFORE");
-
-    return returning;
-  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLDelete.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLDelete.java
@@ -275,6 +275,22 @@ public class OCommandExecutorSQLDelete extends OCommandExecutorSQLAbstract imple
     }
   }
 
+    /**
+     * Parses the returning keyword if found.
+     */
+    protected String parseReturn() throws OCommandSQLParsingException {
+        parserNextWord(true);
+        final String returning = parserGetLastWord();
+
+        if (!returning.equalsIgnoreCase("COUNT") && !returning.equalsIgnoreCase("BEFORE"))
+            throwParsingException("Invalid " + KEYWORD_RETURN + " value set to '" + returning
+                    + "' but it should be COUNT (default), BEFORE. Example: " + KEYWORD_RETURN + " BEFORE");
+
+        return returning;
+    }
+
+
+
   @Override
   public void end() {
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/SQLUpdateReturnModeEnum.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/SQLUpdateReturnModeEnum.java
@@ -1,0 +1,9 @@
+package com.orientechnologies.orient.core.sql;
+/**
+ * Created by Kowalot on 10.05.14.
+ */
+public enum SQLUpdateReturnModeEnum {
+    COUNT,
+    BEFORE,
+    AFTER
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLUpdateTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLUpdateTest.java
@@ -259,6 +259,44 @@ public class SQLUpdateTest {
 
   }
 
+    public void updateWithReturn() {
+        ODocument doc = new ODocument("Data");
+        doc.field("name", "Pawel");
+        doc.field("city", "Wroclaw");
+        doc.field("really_big_field", "BIIIIIIIIIIIIIIIGGGGGGG!!!");
+        doc.save();
+        // check AFTER
+        String sqlString = "UPDATE "+doc.getIdentity().toString()+" SET gender='male' RETURN AFTER";
+        List<ODocument> result1 = database.command(new OCommandSQL(sqlString)).execute();
+        Assert.assertEquals(result1.size(),1);
+        Assert.assertEquals(result1.get(0).getIdentity(), doc.getIdentity());
+        Assert.assertEquals((String) result1.get(0).field("gender"), "male");
+        final ODocument lastOne = result1.get(0).copy();
+        // check record attributes and BEFORE
+        sqlString = "UPDATE "+doc.getIdentity().toString()+" SET Age=1 RETURN BEFORE @this";
+        result1 = database.command(new OCommandSQL(sqlString)).execute();
+        Assert.assertEquals(result1.size(),1);
+        Assert.assertEquals(lastOne.getVersion(), result1.get(0).getVersion());
+        Assert.assertFalse(result1.get(0).containsField("Age"));
+        // check INCREMENT, AFTER + $current + field
+        sqlString = "UPDATE "+doc.getIdentity().toString()+" INCREMENT Age = 100 RETURN AFTER $current.Age";
+        result1 = database.command(new OCommandSQL(sqlString)).execute();
+        Assert.assertEquals(result1.size(),1);
+        Assert.assertTrue(result1.get(0).containsField("result"));
+        Assert.assertEquals(result1.get(0).field("result"), 101);
+        Assert.assertTrue(result1.get(0).containsField("rid"));
+        Assert.assertTrue(result1.get(0).containsField("version"));
+        // check exclude   + WHERE + LIMIT
+        sqlString = "UPDATE "+doc.getIdentity().toString()+" INCREMENT Age = 100 RETURN AFTER $current.Exclude('really_big_field') WHERE Age=101 LIMIT 1";
+        result1 = database.command(new OCommandSQL(sqlString)).execute();
+        Assert.assertEquals(result1.size(),1);
+        Assert.assertTrue(result1.get(0).containsField("Age"));
+        Assert.assertEquals(result1.get(0).field("Age"), 201);
+        Assert.assertFalse(result1.get(0).containsField("really_big_field"));
+
+    }
+
+
   @Test
   public void updateWithNamedParameters() {
     ODocument doc = new ODocument("Data");


### PR DESCRIPTION
In this pull request you may find implementation of #2319 UPDATE RETURN <expression> syntax.
Now it's possible to define what will be returned using record attributes and $current record potentially enriched by functions.
Please find below possible variants of usage:

Existing syntax

UPDATE ♯7:0 SET gender='male' RETURN AFTER
UPDATE ♯7:0 SET gender='male' RETURN BEFORE
UPDATE ♯7:0 SET gender='male' RETURN COUNT

enhanced by optional expressions

UPDATE ♯7:0 SET gender='male' RETURN AFTER @rid
UPDATE ♯7:0 SET gender='male' RETURN AFTER @version
UPDATE ♯7:0 SET gender='male' RETURN AFTER @this
UPDATE ♯7:0 INCREMENT Counter = 123  RETURN BEFORE $current.Counter
UPDATE ♯7:0 SET gender='male' RETURN AFTER $current.exclude(„really_big_field”)
UPDATE ♯7:0 ADD  out_Edge = ♯12:1 RETURN AFTER $current.outE(„Edge”)

In case when single field is returned, the result is wrapped in a record storing value in „result” field (Just to avoid introducing new serialisation – there is no primitive-values collection serialization in binary protocol).  Additionally to that usefull fields like version and rid of original record is provided in corresponding fields. New syntax will allow to optimise client-server network traffic.
## Additional notes:

Result projections are processed after releasing locks just to avoid potential locks.
The meaning of $current variable is compatible with equivalent traverse's command variable.
New test cases has been added to cover mentioned syntax.
 All tests passed.
