### PR TITLE
INSERT INTO .. RETURN <EXP>

### DIFF
--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLInsertTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLInsertTest.java
@@ -15,10 +15,12 @@
  */
 package com.orientechnologies.orient.test.database.auto;
 
+import com.orientechnologies.orient.core.command.script.OCommandScript;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.id.OClusterPosition;
+import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.iterator.ORecordIteratorCluster;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
@@ -348,5 +350,78 @@ public class SQLInsertTest {
     }
     return positions;
   }
+
+
+    public void insertWithReturn() {
+
+        try{
+        database.open("admin", "admin");
+
+        if (!database.getMetadata().getSchema().existsClass("actor2"))
+        {
+            database.command(new OCommandSQL("CREATE CLASS Actor2")).execute();
+            database.getMetadata().getSchema().reload();
+        }
+
+        // RETURN with $current.
+        ODocument doc = database.command(
+            new OCommandSQL("INSERT INTO Actor2 SET FirstName=\"FFFF\" RETURN $current")).execute();
+        Assert.assertTrue(doc != null);
+        Assert.assertEquals(doc.getClassName(), "Actor2");
+
+       // RETURN with @rid
+       Object res1 = database.command(
+                new OCommandSQL("INSERT INTO Actor2 SET FirstName=\"Butch 1\" RETURN @rid")).execute();
+       Assert.assertTrue(res1 instanceof ORecordId);
+       Assert.assertTrue(((OIdentifiable) res1).getIdentity().isValid());
+
+        // Create many records and return @rid
+        Object res2 = database.command(
+                new OCommandSQL("INSERT INTO Actor2(FirstName,LastName) VALUES ('Jay','Miner'),('Frank','Hermier'),('Emily','Saut')  RETURN @rid")).execute();
+        Assert.assertTrue(res2 instanceof List<?>);
+        Assert.assertTrue(((List) res2).get(0) instanceof ORecordId);
+
+
+        // Create many records by INSERT INTO ...FROM and return wrapped field
+        ORID another = ((OIdentifiable) res1).getIdentity();
+        final String sql = "INSERT INTO Actor2 RETURN $current.FirstName  FROM SELECT * FROM ["+ doc.getIdentity().toString()+","+another.toString() +"]";
+        ArrayList res3 = database.command(
+                new OCommandSQL(sql)).execute();
+        Assert.assertEquals(res3.size(),2);
+        Assert.assertTrue(((List) res3).get(0) instanceof ODocument);
+        final ODocument res3doc = (ODocument)res3.get(0);
+        Assert.assertTrue(res3doc.containsField("result"));
+        Assert.assertTrue("FFFF".equalsIgnoreCase((String) res3doc.field("result")) || "Butch 1".equalsIgnoreCase((String) res3doc.field("result")));
+        Assert.assertTrue(res3doc.containsField("rid"));
+        Assert.assertTrue(res3doc.containsField("version"));
+
+        // create record using content keyword and update it in sql batch passing recordID between commands
+        final String sql2 = "let var1=INSERT INTO Actor2 CONTENT {Name:\"content\"} RETURN $current.@rid\n" +
+                "let var2=UPDATE $var1 SET Bingo=1 RETURN AFTER @rid\n" +
+                "return $var2\n" +
+                "end";
+        List<?> res_sql2 = database.command(
+                new OCommandScript("sql",sql2)).execute();
+        Assert.assertEquals(res_sql2.size(), 1);
+        Assert.assertTrue(((List) res_sql2).get(0) instanceof ORecordId);
+
+        // create record using content keyword and update it in sql batch passing recordID between commands
+        final String sql3 = "let var1=INSERT INTO Actor2 CONTENT {Name:\"Bingo owner\"} RETURN @this\n" +
+                "let var2=UPDATE $var1 SET Bingo=1 RETURN AFTER\n" +
+                "return $var2\n" +
+                "end";
+        List<?> res_sql3 = database.command(
+                new OCommandScript("sql",sql3)).execute();
+        Assert.assertEquals(res_sql3.size(),1);
+        Assert.assertTrue(((List) res_sql3).get(0) instanceof ODocument);
+        final ODocument sql3doc =  (ODocument)(((List) res_sql3).get(0));
+        Assert.assertEquals(sql3doc.field("Bingo"),1);
+        Assert.assertEquals(sql3doc.field("Name"),"Bingo owner");
+
+        }finally{
+            database.close();
+        }
+    }
+
 
 }

--- a/tests/src/test/resources/orientdb-server-config.xml
+++ b/tests/src/test/resources/orientdb-server-config.xml
@@ -19,7 +19,8 @@
         </handler>
         <handler class="com.orientechnologies.orient.server.handler.OServerSideScriptInterpreter">
             <parameters>
-                <parameter value="false" name="enabled"/>
+                <parameter value="true" name="enabled"/>
+                <parameter value="SQL" name="allowedLanguages"/>
             </parameters>
         </handler>
     </handlers>


### PR DESCRIPTION
Since now INSERT command has additional keyword RETURN used with expression (similarly to #2319 )

``` SQL
INSERT INTO [class:]<class>|cluster:<cluster>|index:<index> [(<field>[,]*) VALUES (<expression>[,]*)[,]*]|[SET <field> = <expression>|<sub-command>[,]*]|CONTENT {<JSON>} [RETURN <expression>] [FROM select-query]
```

The command may return created documents, specified field or record attributes. Below you may find couple of examples:

``` SQL
// returns new record
INSERT INTO Actor2 SET FirstName="FFFF" RETURN $current
INSERT INTO Actor2 SET FirstName="FFFF" RETURN @this

// returns only new records rid.
INSERT INTO Actor2 SET FirstName="Butch 1" RETURN @rid

//returns collection of rids
INSERT INTO Actor2(FirstName,LastName) VALUES ('Jay','Miner'),('Frank','Hermier'),('Emily','Saut')  RETURN @rid

//Create records by INSERT INTO ...FROM and return wrapped field „FirstName”
INSERT INTO Actor2 RETURN $current.FirstName  FROM SELECT * FROM [ #12:2,#12:3 ]

// example of usage in sql batch when new Actor2 record is created and @rid is assigned to variable
// This record id is provided then to UPDATE as a target record. 
let var1=INSERT INTO Actor2 CONTENT {Name:"content"} RETURN $current.@rid
let var2=UPDATE $var1 SET Bingo=1 RETURN AFTER @rid
return $var2
```
