### PR TITLE
Fixed clustered node startup problem

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastDistributedDatabase.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastDistributedDatabase.java
@@ -434,7 +434,7 @@ public class OHazelcastDistributedDatabase implements ODistributedDatabase {
               "reached waited request %d on request=%s sourceNode=%s", waitForMessageId.get(), req, req.getSenderNodeName());
 
           waitForMessageId.set(-1);
-          return req;
+          break;
         } else {
           // SKIP IT
           ODistributedServerLog.debug(this, manager.getLocalNodeName(), req.getSenderNodeName(), DIRECTION.IN,


### PR DESCRIPTION
Fixed problem when requests are sent to a node coming up while
synchronizing the DB. The requests didn't go through the logic to wait
until the node is online if the request required it.
