### PR TITLE
Add the ability to supply client SSL (keystore/truststore)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
@@ -481,6 +481,14 @@ public enum OGlobalConfiguration {
       "Delay in ms. after which data modification command will be resent if DB was frozen", Integer.class, 10000),
 
   CLIENT_USE_SSL("client.ssl.enabled", "Use SSL for client connections", Boolean.class, false),
+      
+  CLIENT_SSL_KEYSTORE("client.ssl.keyStore", "Use SSL for client connections", String.class, null),
+  
+  CLIENT_SSL_KEYSTORE_PASSWORD("client.ssl.keyStorePass", "Use SSL for client connections", String.class, null),
+  
+  CLIENT_SSL_TRUSTSTORE("client.ssl.trustStore", "Use SSL for client connections", String.class, null),
+  
+  CLIENT_SSL_TRUSTSTORE_PASSWORD("client.ssl.trustStorePass", "Use SSL for client connections", String.class, null),      
 
   // SERVER
   SERVER_CHANNEL_CLEAN_DELAY("server.channel.cleanDelay", "Time in ms of delay to check pending closed connections", Integer.class,

--- a/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/OSocketFactory.java
+++ b/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/OSocketFactory.java
@@ -15,21 +15,25 @@
  */
 package com.orientechnologies.orient.enterprise.channel;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
-import java.net.ServerSocket;
+import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.URL;
 import java.net.UnknownHostException;
-import java.security.NoSuchAlgorithmException;
-
+import java.security.KeyStore;
 import javax.net.SocketFactory;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.TrustManagerFactory;
 
-import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.config.OContextConfiguration;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import com.orientechnologies.orient.core.exception.OConfigurationException;
 
 public class OSocketFactory {
 
@@ -38,26 +42,34 @@ public class OSocketFactory {
 	SSLContext context = null;
 	OContextConfiguration config;
 
+	private String keyStorePath = null;
+	private String keyStorePassword = null;
+	private String keyStoreType = KeyStore.getDefaultType();
+	private String trustStorePath = null;
+	private String trustStorePassword = null;
+	private String trustStoreType = KeyStore.getDefaultType();
+
 	private OSocketFactory(OContextConfiguration iConfig) {
-		config = iConfig;		
-		setUseSSL(iConfig.getValueAsBoolean(OGlobalConfiguration.CLIENT_USE_SSL));
+		config = iConfig;
+
+		useSSL = iConfig.getValueAsBoolean(OGlobalConfiguration.CLIENT_USE_SSL);
+		keyStorePath = (String) iConfig
+				.getValue(OGlobalConfiguration.CLIENT_SSL_KEYSTORE);
+		keyStorePassword = (String) iConfig
+				.getValue(OGlobalConfiguration.CLIENT_SSL_KEYSTORE_PASSWORD);
+		trustStorePath = (String) iConfig
+				.getValue(OGlobalConfiguration.CLIENT_SSL_TRUSTSTORE);
+		trustStorePassword = (String) iConfig
+				.getValue(OGlobalConfiguration.CLIENT_SSL_TRUSTSTORE_PASSWORD);
 	}
 
 	public static OSocketFactory instance(final OContextConfiguration iConfig) {
 		return new OSocketFactory(iConfig);
 	}
 
-	public static OSocketFactory instance(final OContextConfiguration iConfig,
-			SSLContext context) {
-
-		OSocketFactory sFactory = instance(iConfig);
-		sFactory.setSSLContext(context);
-		return sFactory;
-	}
-
 	private SocketFactory getBackingFactory() {
 		if (socketFactory == null) {
-			if (getUseSSL()) {
+			if (useSSL) {
 				socketFactory = getSSLContext().getSocketFactory();
 			} else {
 				socketFactory = SocketFactory.getDefault();
@@ -66,35 +78,95 @@ public class OSocketFactory {
 		return socketFactory;
 	}
 
-	public void setSSLContext(SSLContext context) {
-		this.context = context;
-		synchronized(socketFactory) {
-			socketFactory = null;
-		}
-	}
-
-	private SSLContext getSSLContext() {
-		if (context == null) {
-			try {
-				context = SSLContext.getDefault();
-			} catch (NoSuchAlgorithmException e) {
-				OLogManager.instance().error(this,
-						"Error creating ssl context", e);
-			}
+	protected SSLContext getSSLContext() {
+		if (context == null) {			
+			context = createSSLContext();
 		}
 		return context;
 	}
 
-	public void setUseSSL(boolean useSSL) {
-		this.useSSL = useSSL;
+	protected SSLContext createSSLContext() {
+		try {
+			if (keyStorePath != null && trustStorePath != null) {
+				if (keyStorePassword == null || keyStorePassword.equals("")) {
+					throw new OConfigurationException("Please provide a keystore password");
+				}
+				if (trustStorePassword == null || trustStorePassword.equals("")) {
+					throw new OConfigurationException("Please provide a truststore password");
+				}
+				
+				SSLContext context = SSLContext.getInstance("TLS");
+
+				KeyManagerFactory kmf = KeyManagerFactory
+						.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+
+				KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+				char[] keyStorePass = keyStorePassword.toCharArray();
+				keyStore.load(getAsStream(keyStorePath), keyStorePass);
+
+				kmf.init(keyStore, keyStorePass);
+
+				TrustManagerFactory tmf = null;
+				if (trustStorePath != null) {
+					tmf = TrustManagerFactory.getInstance(TrustManagerFactory
+							.getDefaultAlgorithm());
+					KeyStore trustStore = KeyStore.getInstance(trustStoreType);
+					char[] trustStorePass = trustStorePassword.toCharArray();
+					trustStore
+							.load(getAsStream(trustStorePath), trustStorePass);
+					tmf.init(trustStore);
+				}
+
+				context.init(kmf.getKeyManagers(),
+						(tmf == null ? null : tmf.getTrustManagers()), null);
+
+				return context;
+			} else {
+				return SSLContext.getDefault();
+			}
+		} catch (Exception e) {
+			throw new OConfigurationException("Failed to create ssl context", e);
+		}
+
 	}
 
-	public boolean getUseSSL() {
-		return useSSL;
+	protected InputStream getAsStream(String path) throws IOException {
+
+		InputStream input = null;
+
+		try {
+			URL url = new URL(path);
+			input = url.openStream();
+		} catch (MalformedURLException ignore) {
+			input = null;
+		}
+
+		if (input == null) {
+			input = getClass().getResourceAsStream(path);
+		}
+
+		if (input == null) {
+			input = getClass().getClassLoader().getResourceAsStream(path);
+		}
+
+		if (input == null) {
+			try {
+				input = new FileInputStream(path);
+			} catch (FileNotFoundException e) {
+				input = null;
+			}
+		}
+
+		if (input == null) {
+			throw new java.io.IOException("Could not load resource from path: "
+					+ path);
+		}
+
+		return input;
 	}
-	
+
 	private Socket configureSocket(Socket socket) throws SocketException {
-				
+
 		// Add possible timeouts?
 		return socket;
 	}
@@ -114,14 +186,14 @@ public class OSocketFactory {
 
 	public Socket createSocket(String host, int port, InetAddress localHost,
 			int localPort) throws IOException, UnknownHostException {
-		return configureSocket(getBackingFactory().createSocket(host, port, localHost,
-				localPort));
+		return configureSocket(getBackingFactory().createSocket(host, port,
+				localHost, localPort));
 	}
 
 	public Socket createSocket(InetAddress address, int port,
 			InetAddress localAddress, int localPort) throws IOException {
-		return configureSocket(getBackingFactory().createSocket(address, port, localAddress,
-				localPort));
+		return configureSocket(getBackingFactory().createSocket(address, port,
+				localAddress, localPort));
 	}
 
 }


### PR DESCRIPTION
Add the ability to supply client SSL (keystore/truststore) paths and password. This allows client implementations to create SSL contexts specific to OrientDB and to avoid conflicts with the default JVM keystore/truststore.

These are an optional. If the config values are not provided then the client will use the default JVM keystore/trustsore.

I will send updates to the security wiki by email. 
