### PR TITLE
OClass.removeClusterId doesn't remove cluster from polymorphicClusterIds

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -642,6 +642,8 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
         k++;
       }
       clusterIds = newClusterIds;
+
+      removePolymorphicClusterId(iId);
     }
 
     if (defaultClusterId == iId)


### PR DESCRIPTION
When a new cluster is added to a class, the `polymorphicClusterIds` field is updated:

https://github.com/orientechnologies/orientdb/blob/master/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java#L602

But if you remove the cluster later on, the `polymorphicClusterIds` field is not updated:

https://github.com/orientechnologies/orientdb/blob/master/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java#L625

Which leads to an exception if you then try to query records of that class: 

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
    at com.orientechnologies.orient.core.iterator.ORecordIteratorClusters.updateClusterRange(ORecordIteratorClusters.java:350) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.iterator.ORecordIteratorClusters.hasNext(ORecordIteratorClusters.java:152) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.fetchFromTarget(OCommandExecutorSQLSelect.java:913) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.executeSearch(OCommandExecutorSQLSelect.java:397) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.execute(OCommandExecutorSQLSelect.java:358) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.sql.OCommandExecutorSQLDelegate.execute(OCommandExecutorSQLDelegate.java:60) ~[orientdb-core-1.7.4.jar:1.7.4]
    at com.orientechnologies.orient.core.storage.OStorageEmbedded.executeCommand(OStorageEmbedded.java:94) ~[orientdb-core-1.7.4.jar:1.7.4]
    ... 36 common frames omitted
```
