### PR TITLE
Make schema generation aware of registered custom type

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectSerializerContext.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectSerializerContext.java
@@ -60,6 +60,22 @@ public class OObjectSerializerContext implements OObjectSerializer<Object, Objec
 		return customSerializers.get(iClass) != null;
 	}
 
+	public Class<?> getBoundClassTarget(Class<?> iClass) {
+	        if (isClassBinded(iClass)) {
+	            final Type[] actualTypes = OReflectionHelper.getGenericTypes(customSerializers.get(iClass).getClass());
+	            if (actualTypes[1] instanceof Class<?>) {
+			return (Class<?>) actualTypes[1];
+	            } else if (actualTypes[1] instanceof ParameterizedType) {
+		        return (Class<?>) ((ParameterizedType) actualTypes[1]).getRawType();
+	            } else {
+	        	// ?
+	        	throw new IllegalStateException("Class " + iClass.getName() + " reported as binded but is not a class?");
+	            }
+	        } else {
+	            return null;
+	        }
+	}
+
 	public Object serializeFieldValue(final Class<?> iClass, Object iFieldValue) {
 		for (Class<?> type : customSerializers.keySet()) {
 			if (type.isInstance(iFieldValue) || (iFieldValue == null && type == Void.class)) {

--- a/object/src/test/java/com/orientechnologies/orient/object/CustomDatatypeTest.java
+++ b/object/src/test/java/com/orientechnologies/orient/object/CustomDatatypeTest.java
@@ -1,0 +1,95 @@
+package com.orientechnologies.orient.object;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.core.serialization.serializer.object.OObjectSerializer;
+import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+import com.orientechnologies.orient.object.serialization.OObjectSerializerContext;
+import com.orientechnologies.orient.object.serialization.OObjectSerializerHelper;
+
+public class CustomDatatypeTest {
+
+    public static class WrappedString {
+	private String value;
+
+	public String getValue() {
+	    return value;
+	}
+
+	public void setValue(String value) {
+	    this.value = value;
+	}
+
+	@Override
+	public String toString() {
+	    return "Key [value=" + getValue() + "]";
+	}
+    }
+
+    public static class Entity {
+	private String name;
+
+	private WrappedString data;
+
+	public String getName() {
+	    return name;
+	}
+
+	public void setName(String name) {
+	    this.name = name;
+	}
+
+	public WrappedString getData() {
+	    return data;
+	}
+
+	public void setData(WrappedString value) {
+	    this.data = value;
+	}
+
+	@Override
+	public String toString() {
+	    return "Entity [name=" + getName() + ", data=" + getData() + "]";
+	}
+    }
+
+    @Test
+    public void reproduce() throws Exception {
+	final OObjectDatabaseTx db = new OObjectDatabaseTx(
+		"memory:CustomDatatypeTest");
+	db.create();
+
+	// WrappedString custom datatype registration (storing it as
+	// OType.STRING)
+	OObjectSerializerContext serializerContext = new OObjectSerializerContext();
+	serializerContext.bind(new OObjectSerializer<WrappedString, String>() {
+	    @Override
+	    public String serializeFieldValue(Class<?> iClass,
+		    WrappedString iFieldValue) {
+		return iFieldValue.getValue();
+	    }
+
+	    @Override
+	    public WrappedString unserializeFieldValue(Class<?> iClass,
+		    String iFieldValue) {
+		final WrappedString result = new WrappedString();
+		result.setValue(iFieldValue);
+		return result;
+	    }
+	});
+	OObjectSerializerHelper.bindSerializerContext(WrappedString.class,
+		serializerContext);
+
+	// we want schema to be generated
+	db.setAutomaticSchemaGeneration(true);
+
+	// register our entity
+	db.getEntityManager().registerEntityClass(Entity.class);
+
+	// Validate DB did figure out schema properly
+	Assert.assertEquals(db.getMetadata().getSchema().getClass(Entity.class)
+		.getProperty("data").getType(), OType.STRING);
+    }
+}


### PR DESCRIPTION
As in example with doco (SecurityRole>String) it would crack
currently in a moment you try to use autogenerated schema for POJO
for reasons like adding index.
