### PR TITLE
Add System V init script data.

### DIFF
--- a/server/script/orientdb.sh
+++ b/server/script/orientdb.sh
@@ -1,5 +1,28 @@
 #!/bin/sh
 
+### BEGIN INIT INFO
+# Provides:          orientdb
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: OrientDB Document Graph NoSQL Database
+### END INIT INFO
+#
+### BEGIN Fedora SysV
+#
+# chkconfig: 2345 90 10
+# description: OrientDB Document Graph NoSQL Database
+#
+### END Fedora SysV
+
+#
+# To install, configure ORIENTDB_DIR and ORIENTDB_USER below and copy or link
+# this file into /etc/rc.d/init.d as orientdb. Then use the following command
+# to automatically set the server to start up:
+# "# /sbin/chkconfig orietdb reset"
+#
+
 # OrientDB init script
 
 # You have to SET the OrientDB installation directory here


### PR DESCRIPTION
N.B. I'm not trying to be elitist or exclusionist. I do not currently use any systems which require use of Upstart or Systemd or the ilk, so I can only contribute the header information for Linux distributions which use the System V chkconfig utility (RHEL [and its clones] at least through 6.x, ALT Linux, and others).

The block added to the orientdb.sh script in this PR allows for easier and faster installation of the database. It also helps remove user error from the equation when it comes to system startup.

As I find that the added block saves me a bit of time during installation, I'm hopeful it will find utility for others. I also hope that it will spur others to update it to make their own lives easier on other distributions and platforms, as well. :+1: 
