### PR TITLE
Add ability to obtain all posible registry keys

### DIFF
--- a/commons/src/main/java/com/orientechnologies/common/factory/OConfigurableStatefulFactory.java
+++ b/commons/src/main/java/com/orientechnologies/common/factory/OConfigurableStatefulFactory.java
@@ -21,6 +21,7 @@ import com.orientechnologies.common.exception.OException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Configurable stateful factory. New instances are created when newInstance() is called, invoking its default empty constructor.
@@ -64,6 +65,11 @@ public class OConfigurableStatefulFactory<K, V> {
       }
     }
     return null;
+  }
+  
+  public Set<K> getKeys()
+  {
+	  return registry.keySet();
   }
 
   public OConfigurableStatefulFactory<K, V> register(final K iKey, final Class<? extends V> iValue) {


### PR DESCRIPTION
For any kind of editors it's convinient to have information about all possible variants (for example of "Cluster Selections" strategies). This pull request gives possibility to obtain whole set of keys.
