### PR TITLE
Missing setName method on OClass interface

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClass.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClass.java
@@ -67,6 +67,8 @@ public interface OClass extends Comparable<OClass> {
 
   public String getName();
 
+  public OClass setName(String iName);
+
   public String getStreamableName();
 
   public Collection<OProperty> declaredProperties();

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassAbstractDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassAbstractDelegate.java
@@ -80,6 +80,11 @@ public abstract class OClassAbstractDelegate implements OClass {
   }
 
   @Override
+  public OClass setName(String iName) {
+    return delegate.setName(iName);
+  }
+
+  @Override
   public String getStreamableName() {
     return delegate.getStreamableName();
   }


### PR DESCRIPTION
There is no setName method on OClass interface. That leads to some problems in our code, because we are using "prototyping proxies" objects prior to actual creation of OClass in schema.

Btw, there are several methods in OClassAbstractDelegate which should return OClass. But instead of returning "this" it's returning delegate. That can lead to unpredictable problems. Please let me know - may fix, test and make pull request for this one as well.

P.S. Lots of missing Java Docs on some important conceptually classes...
