### PR TITLE
Add travis to Develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 # whitelist
 branches:
   only:
-    - developer
+    - develop
 jdk:
   - openjdk7
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# Travis script for (only) develop branch.
+# Compiles OrientDB against openjdk and oraclejdk 7.
+# Installs OrientDB
+# Tests embedded and remote databases
+
 language: java
 
 # whitelist
@@ -8,4 +13,4 @@ jdk:
   - openjdk7
   - oraclejdk7
   
-script: ant clean installg test test-local test-plocal test-remote
+script: ant clean installg test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ jdk:
   - openjdk7
   - oraclejdk7
   
-script: ant clean installg
+script: ant clean installg test test-local test-plocal test-remote

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+
+# whitelist
+branches:
+  only:
+    - developer
+jdk:
+  - openjdk7
+  - oraclejdk7
+  
+script: ant clean installg


### PR DESCRIPTION
I've added travis to the develop branch. On travis the compilations and tests look like:
https://travis-ci.org/GerardSoleCa/orientdb