### PR TITLE
Removal of lightweight edges

### DIFF
--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
@@ -338,7 +338,8 @@ public class OrientEdge extends OrientElement implements Edge {
    */
   @Override
   public void remove() {
-    checkClass();
+    if (!isLightweight())
+      checkClass();
 
     graph.setCurrentGraphInThreadLocal();
     graph.autoStartTransaction();


### PR DESCRIPTION
Hallo,

I used to get following warning on calling remove() for a lightweight edge:
Committing the active transaction to create the new type 'owner' as subclass of 'E'. The transaction will be reopen right after that. To avoid this behavior create the classes outside the transaction
If my understanding is right, calling checkClass for lightweight edges makes no sense and provokes the warning shown above.
My changes passed both test suites (mvn clean test and ant clean test).

Regards,
Olaf
