### PR TITLE
added new test-class for OObjectEnumLazyList

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
@@ -63,8 +63,14 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
     return new OObjectEnumLazyIterator<TYPE>(enumClass, sourceRecord, serializedList.iterator());
   }
 
-  public boolean contains(final Object o) {
-    return list.contains(o);
+  public boolean contains(final Object o) 
+  {
+	  TYPE enumToCheck = objectToEnum(o);
+	  
+	  if(enumToCheck != null)
+		  return serializedList.contains(enumToCheck.name());
+	  else
+		  return false;
   }
 
   public boolean add(TYPE element) {
@@ -91,12 +97,24 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
     return o;
   }
 
-  public int indexOf(final Object o) {
-    return list.indexOf(o);
+  public int indexOf(final Object o) 
+  {
+	  TYPE enumToCheck = objectToEnum(o);
+	  
+	  if(enumToCheck != null)
+		  return serializedList.indexOf(enumToCheck.name());
+	  else
+		  return -1;
   }
 
-  public int lastIndexOf(final Object o) {
-    return list.lastIndexOf(o);
+  public int lastIndexOf(final Object o) 
+  {
+	  TYPE enumToCheck = objectToEnum(o);
+	  
+	  if(enumToCheck != null)
+		  return serializedList.lastIndexOf(enumToCheck.name());
+	  else
+		  return -1;
   }
 
   public Object[] toArray() {
@@ -273,5 +291,22 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
   @Override
   public String toString() {
     return list.toString();
+  }  
+  
+  private TYPE objectToEnum(Object o)
+  {
+	  if(o != null && (o instanceof Enum))	
+	  {
+		 try
+		 {
+			 return (TYPE) o;
+		 }
+		 catch(ClassCastException e)
+		 {
+			 return null;
+		 }		 
+	  }
+	  else
+		  return null;
   }
 }

--- a/object/src/test/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyListTest.java
+++ b/object/src/test/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyListTest.java
@@ -1,0 +1,112 @@
+package com.orientechnologies.orient.object.enumerations;
+
+import static org.testng.AssertJUnit.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+
+/**
+ * @author JN <a href="mailto:jn@brain-activit.com">Julian Neuhaus</a>
+ * @since 15.08.2014
+ */
+public class OObjectEnumLazyListTest
+{
+	public enum TESTENUM
+	{
+		TEST_VALUE_1,
+		TEST_VALUE_2,
+		TEST_VALUE_3
+	}
+	
+	private OObjectDatabaseTx databaseTx;
+	
+	@BeforeClass
+	protected void setUp() throws Exception {
+		databaseTx = new OObjectDatabaseTx("memory:OObjectEnumLazyListTest");
+		databaseTx.create();
+
+		databaseTx.getEntityManager().registerEntityClass(EntityWithEnumList.class);
+
+	}
+
+	@AfterClass
+	protected void tearDown() {
+				
+		databaseTx.drop();
+	}
+
+	@Test
+	public void containsTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_1));
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_1));
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_1));
+	}	
+	
+	@Test
+	public void indexOfTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_1) == 0);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_2) == 1);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_3) == 2);
+	}	
+	
+	@Test
+	public void lastIndexOfTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_1) == 3);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_2) == 4);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_3) == 5);
+	}	
+	
+	private EntityWithEnumList getTestObject()
+	{
+		EntityWithEnumList toSave = new EntityWithEnumList();
+		
+		List<TESTENUM> enumList = new ArrayList<TESTENUM>();
+		
+		enumList.add(TESTENUM.TEST_VALUE_1);
+		enumList.add(TESTENUM.TEST_VALUE_2);
+		enumList.add(TESTENUM.TEST_VALUE_3);
+		enumList.add(TESTENUM.TEST_VALUE_1);
+		enumList.add(TESTENUM.TEST_VALUE_2);
+		enumList.add(TESTENUM.TEST_VALUE_3);
+		
+		toSave.setEnumList(enumList);
+		
+		EntityWithEnumList proxiedEntitiy = databaseTx.save(toSave);
+		
+		return proxiedEntitiy;
+	}
+	
+	public class EntityWithEnumList
+	{
+		private List<TESTENUM> enumList;
+
+		public EntityWithEnumList()
+		{
+			super();
+		}
+		
+		public List<TESTENUM> getEnumList()
+		{
+			return enumList;
+		}
+
+		public void setEnumList(List<TESTENUM> enumList)
+		{
+			this.enumList = enumList;
+		}		
+	}
+}


### PR DESCRIPTION
included test-cases:
- containsTest()
- indexOfTest()
- lastIndexTest()

refactored methods in OObjectEnumLazyList
- contains(Object o)
- indexOf(Object o)
- lastIndexOf(Object o)

All methods are including the same problem. There are two lists:
List<Object> and ArrayList<Type>. List<Object> contains String values
and is equals to the String values in the database. The Strings
represent the names of the enum-values. The ArrayList<Type> contains the
real enum-values, but these values are only loaded when the method
get(int index) will be used, otherwise the list only contains
null-values. So indexOf and contains doesn't work with this list.
So, if Object is a valid enum for this list, the name of this enum-value
will be used to use contains/indexOf of the List<Object> list.
