### PR TITLE
fixed problem in OObjectEnumLazyList with contains and indexOf

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
@@ -64,7 +64,7 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
   }
 
   public boolean contains(final Object o) {
-    return list.contains(o);
+	  return this.indexOf(o) > -1;
   }
 
   public boolean add(TYPE element) {
@@ -92,11 +92,21 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
   }
 
   public int indexOf(final Object o) {
-    return list.indexOf(o);
+	  TYPE enumToCheck = objectToEnum(o);
+
+	  if(enumToCheck != null)
+		  return serializedList.indexOf(enumToCheck.name());
+	  else
+		  return -1;
   }
 
   public int lastIndexOf(final Object o) {
-    return list.lastIndexOf(o);
+	  TYPE enumToCheck = objectToEnum(o);
+
+	  if(enumToCheck != null)
+		  return serializedList.lastIndexOf(enumToCheck.name());
+	  else
+		  return -1;
   }
 
   public Object[] toArray() {
@@ -273,5 +283,15 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
   @Override
   public String toString() {
     return list.toString();
+  }
+  
+  private TYPE objectToEnum(Object o)
+  {
+	 if(o != null && (o.getClass() == this.enumClass))	
+	 {
+		 return (TYPE) o;
+	 }
+	 else
+		 return null;
   }
 }

--- a/object/src/test/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyListTest.java
+++ b/object/src/test/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyListTest.java
@@ -1,0 +1,141 @@
+package com.orientechnologies.orient.object.enumerations;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+
+/**
+ * @author JN <a href="mailto:jn@brain-activit.com">Julian Neuhaus</a>
+ * @since 15.08.2014
+ */
+public class OObjectEnumLazyListTest
+{
+	public enum TESTENUM
+	{
+		TEST_VALUE_1,
+		TEST_VALUE_2,
+		TEST_VALUE_3
+	}
+	
+	public enum WRONG_TESTENUM
+	{
+		TEST_VALUE_1,
+		TEST_VALUE_2,
+		TEST_VALUE_3
+	}
+	
+	private OObjectDatabaseTx databaseTx;
+	
+	@BeforeClass
+	protected void setUp() throws Exception {
+		databaseTx = new OObjectDatabaseTx("memory:OObjectEnumLazyListTest");
+		databaseTx.create();
+
+		databaseTx.getEntityManager().registerEntityClass(EntityWithEnumList.class);
+
+	}
+
+	@AfterClass
+	protected void tearDown() {
+				
+		databaseTx.drop();
+	}
+
+	@Test
+	public void containsTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_1));
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_2));
+		assertTrue(hasListWithEnums.getEnumList().contains(TESTENUM.TEST_VALUE_3));
+		
+		assertFalse(hasListWithEnums.getEnumList().contains(WRONG_TESTENUM.TEST_VALUE_1));
+		assertFalse(hasListWithEnums.getEnumList().contains(WRONG_TESTENUM.TEST_VALUE_2));
+		assertFalse(hasListWithEnums.getEnumList().contains(WRONG_TESTENUM.TEST_VALUE_3));
+		
+		assertFalse(hasListWithEnums.getEnumList().contains(null));		
+		assertFalse(hasListWithEnums.getEnumList().contains("INVALID TYPE"));
+	}	
+	
+	@Test
+	public void indexOfTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_1) == 0);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_2) == 1);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(TESTENUM.TEST_VALUE_3) == 2);
+		
+		assertTrue(hasListWithEnums.getEnumList().indexOf(WRONG_TESTENUM.TEST_VALUE_1) == -1);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(WRONG_TESTENUM.TEST_VALUE_2) == -1);
+		assertTrue(hasListWithEnums.getEnumList().indexOf(WRONG_TESTENUM.TEST_VALUE_3) == -1);
+		
+		assertTrue(hasListWithEnums.getEnumList().indexOf(null) == -1);
+		assertTrue(hasListWithEnums.getEnumList().indexOf("INVALID TYPE") == -1);
+	}	
+	
+	@Test
+	public void lastIndexOfTest() {
+		
+		EntityWithEnumList hasListWithEnums = getTestObject();	
+		
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_1) == 3);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_2) == 4);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(TESTENUM.TEST_VALUE_3) == 5);
+		
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(WRONG_TESTENUM.TEST_VALUE_1) == -1);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(WRONG_TESTENUM.TEST_VALUE_2) == -1);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(WRONG_TESTENUM.TEST_VALUE_3) == -1);
+		
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf(null) == -1);
+		assertTrue(hasListWithEnums.getEnumList().lastIndexOf("INVALID TYPE") == -1);
+	}	
+	
+	private EntityWithEnumList getTestObject()
+	{
+		EntityWithEnumList toSave = new EntityWithEnumList();
+		
+		List<TESTENUM> enumList = new ArrayList<TESTENUM>();
+		
+		enumList.add(TESTENUM.TEST_VALUE_1);
+		enumList.add(TESTENUM.TEST_VALUE_2);
+		enumList.add(TESTENUM.TEST_VALUE_3);
+		enumList.add(TESTENUM.TEST_VALUE_1);
+		enumList.add(TESTENUM.TEST_VALUE_2);
+		enumList.add(TESTENUM.TEST_VALUE_3);
+		
+		toSave.setEnumList(enumList);
+		
+		EntityWithEnumList proxiedEntitiy = databaseTx.save(toSave);
+		
+		return proxiedEntitiy;
+	}
+	
+	public class EntityWithEnumList
+	{
+		private List<TESTENUM> enumList;
+
+		public EntityWithEnumList()
+		{
+			super();
+		}
+		
+		public List<TESTENUM> getEnumList()
+		{
+			return enumList;
+		}
+
+		public void setEnumList(List<TESTENUM> enumList)
+		{
+			this.enumList = enumList;
+		}		
+	}
+}


### PR DESCRIPTION
OObjectEnumLazyList.class

Fixed problem in contains and indexOf of OObjectEnumLazyList which leads
to incorrect results.

The used list for contains and indexOf can have null-values which leads to incorrect results. Changed to the serializedList which contains the string values from database. 

Issue: https://github.com/orientechnologies/orientdb/issues/2685
