### PR TITLE
Fix issues with export/import in "merge" mode

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImpExpAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImpExpAbstract.java
@@ -133,9 +133,27 @@ public abstract class ODatabaseImpExpAbstract {
   public String getFileName() {
     return fileName;
   }
+  
+  
 
+  public boolean isIncludeInfo() {
+	return includeInfo;
+  }
+		
+  public boolean isIncludeSecurity() {
+	return includeSecurity;
+  }
+	
+  public void setIncludeInfo(final boolean includeInfo) {
+	  this.includeInfo = includeInfo;
+  }
+	
   public boolean isIncludeSchema() {
     return includeSchema;
+  }
+  
+  public void setIncludeSecurity(final boolean includeSecurity) {
+	  this.includeSecurity = includeSecurity;
   }
 
   public void setIncludeSchema(final boolean includeSchema) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
@@ -495,6 +495,34 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
     database.declareIntent(null);
   }
 
+  public boolean isMigrateLinks() {
+	return migrateLinks;
+  }
+
+  public void setMigrateLinks(boolean migrateLinks) {
+	this.migrateLinks = migrateLinks;
+  }
+
+  public boolean isRebuildIndexes() {
+	return rebuildIndexes;
+  }
+
+  public void setRebuildIndexes(boolean rebuildIndexes) {
+	this.rebuildIndexes = rebuildIndexes;
+  }
+
+  public boolean isPreserveClusterIDs() {
+	return preserveClusterIDs;
+  }
+
+  public boolean isMerge() {
+	return merge;
+  }
+
+  public void setMerge(boolean merge) {
+	this.merge = merge;
+  }
+
   public boolean isDeleteRIDMapping() {
     return deleteRIDMapping;
   }
@@ -1047,7 +1075,7 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
           && !(name.equalsIgnoreCase(OMetadataDefault.CLUSTER_MANUAL_INDEX_NAME)
               || name.equalsIgnoreCase(OMetadataDefault.CLUSTER_INTERNAL_NAME) || name
                 .equalsIgnoreCase(OMetadataDefault.CLUSTER_INDEX_NAME))) {
-        database.command(new OCommandSQL("truncate cluster " + name)).execute();
+        if(!merge) database.command(new OCommandSQL("truncate cluster " + name)).execute();
 
         for (OIndex existingIndex : database.getMetadata().getIndexManager().getIndexes()) {
           if (existingIndex.getClusters().contains(name)) {


### PR DESCRIPTION
- Additional getters and setters for more consistent behaviour

Actually, classes ODatabaseExport and ODatabaseImport have lots of inconsistent thing. I'm working on Export/Import functionality in Orienteer: so more PRs might be good to be accepted. 
