### PR TITLE
release db before returning from authenticate

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/OServerCommandAuthenticatedDbAbstract.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/OServerCommandAuthenticatedDbAbstract.java
@@ -143,9 +143,13 @@ public abstract class OServerCommandAuthenticatedDbAbstract extends OServerComma
     } catch (OLockException e) {
       OLogManager.instance().error(this, "Cannot access to the database '" + iDatabaseName + "'", ODatabaseException.class, e);
     } finally {
-      if (db == null)
-        // WRONG USER/PASSWD
-        sendAuthorizationRequest(iRequest, iResponse, iDatabaseName);
+      if (db == null) {
+          // WRONG USER/PASSWD
+          sendAuthorizationRequest(iRequest, iResponse, iDatabaseName);
+      }
+      else {
+          db.close();
+      }
     }
     return false;
   }


### PR DESCRIPTION
This is my first pull request so please forgive any errors but it seems that the db is not being released when performing HTTP authentication.  This means that open references are left to a database on every authenticate() call.
