### PR TITLE
Junit initial support

### DIFF
--- a/unit/pom.xml
+++ b/unit/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2010-2012 Luca Garulli (l.garulli(at)orientechnologies.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.orientechnologies</groupId>
+        <artifactId>orientdb-parent</artifactId>
+        <version>1.7.9-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>orientdb-unit</artifactId>
+
+    <name>OrientDB JUnit Support</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.7</slf4j.version>
+        <project.build.directory>${project.basedir}/target</project.build.directory>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.orientechnologies</groupId>
+            <artifactId>orientdb-distributed</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.orientechnologies</groupId>
+            <artifactId>orientdb-graphdb</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.orientechnologies</groupId>
+                    <artifactId>orientdb-object</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.tinkerpop.gremlin</groupId>
+                    <artifactId>gremlin-groovy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.tinkerpop.gremlin</groupId>
+                    <artifactId>gremlin-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.tinkerpop</groupId>
+                    <artifactId>pipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.tinkerpop.blueprints</groupId>
+                    <artifactId>blueprints-test</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>${project.build.directory}</directory>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <inherited>false</inherited>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.13</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <buildDirectory>${project.build.directory}</buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/unit/src/main/java/com/orientechnologies/orient/unit/AbstractOrientDBRule.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/AbstractOrientDBRule.java
@@ -1,0 +1,148 @@
+package com.orientechnologies.orient.unit;
+
+import com.orientechnologies.orient.client.remote.OServerAdmin;
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+abstract class AbstractOrientDBRule<BI extends AbstractOrientDBRule.IDatabaseConnectionInfo> extends ExternalResource {
+
+    public static interface IDatabaseConnectionInfo {
+        static final String DEFAULT_DATABASE = "testdb";
+        static final String DEFAULT_DATABASE_TYPE = "graph";
+        static final String DEFAULT_STORAGE_MODE = "plocal";
+
+        String getDatabase();
+        String getDatabaseType();
+        String getStorageMode();
+        String getLogin();
+        String getPassword();
+        String getAddress();
+        int getBinaryPort();
+    }
+
+    protected Logger logger = LoggerFactory.getLogger(AbstractOrientDBRule.class);
+    protected final BI buildInfo;
+
+    protected AbstractOrientDBRule(BI buildInfo) {
+        this.buildInfo = buildInfo;
+    }
+
+    @Override
+    public void before() throws Throwable {
+        super.before();
+
+        final boolean need2recreateDB = buildInfo.getDatabaseType() != null && !buildInfo.getDatabaseType().isEmpty();
+        if (need2recreateDB) {
+            recreateDB();
+        }
+
+        if(logger.isInfoEnabled()) {
+            final IDatabaseConnectionInfo ci = getConnectionInfo();
+            final String connection = String.format("connect remote:%s:%s/%s %s %s", ci.getAddress(), ci.getBinaryPort(),
+                        ci.getDatabase(), ci.getLogin(), ci.getPassword()
+                    );
+
+            logger.info(need2recreateDB ? "\nThe database '{}' has been created (on behalf of user '{}') and ready to use.\n" +
+                            "The following command might be used to establish connection: {}"
+                            : "\nExisted database '{}' and user '{}'.\n The following command " +
+                            "might be used to establish connection: {}"
+                    ,
+                    buildInfo.getDatabase(),
+                    buildInfo.getLogin(),
+                    connection
+            );
+        }
+        assert checkIfDbExists(buildInfo.getStorageMode());
+    }
+
+    public IDatabaseConnectionInfo getConnectionInfo(){
+        return buildInfo;
+    }
+
+    public abstract IDatabaseConnectionInfo getConnectionInfo(int idx);
+
+
+    protected static final OServerAdmin createAndConnectServerAdmin(IDatabaseConnectionInfo ci) throws IOException {
+        final OServerAdmin serverAdmin = new OServerAdmin( ODBTestSupportRule.connectionString("remote", ci) );
+        try {
+            serverAdmin.connect(ci.getLogin(), ci.getPassword());
+        }catch (IOException e){
+            serverAdmin.close();
+            throw e;
+        }
+        return serverAdmin;
+    }
+
+    public void recreateDB(String dbtype) throws Exception {
+        OGlobalConfiguration.STORAGE_KEEP_OPEN.setValue(false);
+        final IDatabaseConnectionInfo ci = getConnectionInfo();
+
+        logger.debug("User '{}'  will be used for a database creation.", ci.getLogin());
+
+        final OServerAdmin sa = new OServerAdmin( String.format("%s:%s/%s", ci.getAddress(), ci.getBinaryPort(), ci.getDatabase()) );
+        sa.connect(ci.getLogin(), ci.getPassword());
+        try {
+            if (sa.existsDatabase(ci.getStorageMode())) {
+                logger.warn("Database '{}' already exists, so it will be dropped", ci.getDatabase());
+                sa.dropDatabase(ci.getStorageMode());
+            }
+
+//            sa.createDatabase(ci.getDatabaseType(), ci.getStorageMode());
+        } finally {
+            sa.close();
+        }
+
+        final OServerAdmin sa2 = new OServerAdmin( String.format("remote:%s:%s/%s", ci.getAddress(), ci.getBinaryPort(), ci.getDatabase()) );
+        sa.connect(ci.getLogin(), ci.getPassword());
+        try {
+            sa2.createDatabase(ci.getDatabaseType(), ci.getStorageMode());
+        } finally {
+            sa2.close();
+        }
+    }
+
+    public void recreateDB() throws Exception {
+        if (buildInfo.getDatabaseType() == null || buildInfo.getDatabaseType().isEmpty()) {
+            throw new IllegalArgumentException("Need to set database type to the Rule");
+        }
+        recreateDB(buildInfo.getDatabaseType());
+    }
+
+    public boolean checkIfDbExists(String storageType) throws IOException {
+        final OServerAdmin serverAdmin = createAndConnectServerAdmin(getConnectionInfo());
+        try {
+            return serverAdmin.existsDatabase(storageType);
+        } finally {
+            serverAdmin.close();
+        }
+    }
+
+    @Override
+    public void after() {
+        super.after();
+    }
+
+    public String getDatabase(){
+        return buildInfo.getDatabase();
+    }
+
+    public String getDatabaseType(){
+        return buildInfo.getDatabaseType();
+    }
+
+    public String getStorageMode(){
+        return buildInfo.getStorageMode();
+    }
+
+    public String getUser(){
+        return buildInfo.getLogin();
+    }
+
+    public String getPassword(){
+        return buildInfo.getPassword();
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/ConnectionInfo.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/ConnectionInfo.java
@@ -1,0 +1,78 @@
+package com.orientechnologies.orient.unit;
+
+public class ConnectionInfo {
+    private String address = "localhost";
+    private int binaryPorts[] = {2424};
+    private String login = "admin";
+    private String password = "admin";
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int[] getBinaryPorts() {
+        return binaryPorts;
+    }
+
+    public void setBinaryPorts(int[] binaryPorts) {
+        this.binaryPorts = binaryPorts;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    protected static void throwIllegalStateIf(boolean condition, String template, Object...args){
+        if(condition){
+            throw new IllegalStateException(String.format(template, args));
+        }
+    }
+
+    public void verify() throws IllegalStateException{
+        throwIllegalStateIf(address == null || address.isEmpty(), "Address must be specified");
+        throwIllegalStateIf(binaryPorts == null || binaryPorts.length < 1, "At least one binary port must be specified");
+        throwIllegalStateIf(login == null || login.isEmpty(), "User login must be specified");
+        throwIllegalStateIf(password == null || password.isEmpty(), "User's password must be specified");
+    }
+
+    public static class ConnectionInfoBuilder<T extends ConnectionInfoBuilder, I extends ConnectionInfo> {
+        protected final I buildInfo;
+
+        public ConnectionInfoBuilder(ConnectionInfo buildInfo) {
+            this.buildInfo = (I)buildInfo;
+        }
+
+        public T useCredential(String login, String password){
+            buildInfo.setLogin(login);
+            buildInfo.setPassword(password);
+            return (T)this;
+        }
+
+        public T useAddress(String address){
+            buildInfo.setAddress(address);
+            return (T) this;
+        }
+
+        public T useBinaryPort(int port){
+            buildInfo.setBinaryPorts(new int[]{port});
+            return (T)this;
+        }
+    }
+
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/EmbeddedOrientDBRule.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/EmbeddedOrientDBRule.java
@@ -1,0 +1,209 @@
+package com.orientechnologies.orient.unit;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.server.OServer;
+import com.orientechnologies.orient.server.distributed.ODistributedServerManager;
+import com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin;
+import com.orientechnologies.orient.unit.cluster.AbstractOrientDBCluster;
+import com.orientechnologies.orient.unit.cluster.ClusterFactory;
+import org.slf4j.LoggerFactory;
+
+public class EmbeddedOrientDBRule extends AbstractOrientDBRule<EmbeddedOrientDBRule.EmbeddedRuleBuilder.EmbeddedRuleBuildInfo> {
+    private static final String DEFAULT_ORIENTDB_SERVER_CONFIG_RESOURCE_PATH = "default-orientdb-test-server-config.xml";
+
+    private AbstractOrientDBCluster cluster;
+
+    protected EmbeddedOrientDBRule(EmbeddedRuleBuilder.EmbeddedRuleBuildInfo buildInfo)
+    {
+        super(buildInfo);
+        logger = LoggerFactory.getLogger(EmbeddedOrientDBRule.class);
+    }
+
+    @Override
+    public void before() throws Throwable {
+        cluster = ClusterFactory.createCluster(buildInfo);
+
+        if(cluster.getAdminName() == null){
+            throw new IllegalStateException("Database user did not set and hasn't been determined automatically.");
+        }
+
+        super.before();
+    }
+
+    @Override
+    public void recreateDB(final String dbtype) throws Exception {
+        synchronized (cluster) {
+
+            if( !AbstractOrientDBCluster.Status.OFFLINE.equals(cluster.getStatus())){
+                cluster.stop();
+            }
+
+            final boolean isEmbedded = buildInfo.isEmbedded();
+
+            if(!isEmbedded) {
+                cluster = ClusterFactory.rebuildCluster(cluster);
+            }
+            cluster.start();
+            super.recreateDB(dbtype);
+
+            if(!isEmbedded) {
+                // wait while the DB will be available on all nodes;
+                final OServer node = cluster.getNode(0);
+                for (boolean dbAvailable = false; !dbAvailable; ) {
+                    ODistributedServerManager dm = node.getDistributedManager();
+
+                    if (((OHazelcastPlugin) dm).getAvailableNodes(buildInfo.database) >= cluster.size()) {
+                        dbAvailable = true;
+                    } else {
+                        Thread.sleep(500);
+                    }
+                    final ODocument doc = dm.getClusterConfiguration();
+                    assert doc != null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void after() {
+        if(cluster != null){
+            try {
+                cluster.stop();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        super.after();
+    }
+
+    public final AbstractOrientDBCluster getCluster(){
+        return cluster;
+    }
+
+    @Override
+    public IDatabaseConnectionInfo getConnectionInfo(int nodeIndex){
+        final IDatabaseConnectionInfo ci = getConnectionInfo();
+        return new DBConnectionInfo(ci.getDatabase(), ci.getDatabaseType(), ci.getStorageMode(),
+                cluster.getAdminName(nodeIndex), cluster.getAdminPassword(nodeIndex), ci.getAddress(),
+                buildInfo.getBinaryPorts()[nodeIndex]);
+    }
+
+    public static EmbeddedRuleBuilder build(){
+        return new EmbeddedRuleBuilder();
+    }
+
+    public static class EmbeddedRuleBuilder extends ClusterFactory.ClusterBuildInfoBuilder<EmbeddedRuleBuilder, EmbeddedRuleBuilder.EmbeddedRuleBuildInfo> {
+
+        protected static class EmbeddedRuleBuildInfo extends ClusterFactory.ClusterBuildInfo implements AbstractOrientDBRule.IDatabaseConnectionInfo{
+            protected String database = DEFAULT_DATABASE;
+            protected String databaseType = DEFAULT_DATABASE_TYPE;
+            protected String storageMode = DEFAULT_STORAGE_MODE;
+
+            @Override
+            public String getDatabase() {
+                return database;
+            }
+
+            @Override
+            public String getDatabaseType() {
+                return databaseType;
+            }
+
+            @Override
+            public String getStorageMode() {
+                return storageMode;
+            }
+
+            @Override
+            public int getBinaryPort() {
+                return getBinaryPorts()[0];
+            }
+        }
+
+        public EmbeddedRuleBuilder() {
+            super(new EmbeddedRuleBuildInfo());
+        }
+
+        private EmbeddedOrientDBRule createRuleAndApplyConfig(String databaseType){
+            try {
+                buildInfo.databaseType = databaseType;
+
+                if(!buildInfo.isServerConfigProvided()){
+                    LoggerFactory.getLogger(EmbeddedRuleBuilder.class).warn("Server Config has not been specified, therefore Default Server Config will be used.");
+                    useServerConfigResource(DEFAULT_ORIENTDB_SERVER_CONFIG_RESOURCE_PATH);
+                }
+
+                return new EmbeddedOrientDBRule(buildInfo);
+            } catch (Exception e) {
+                throw new RuntimeException("Can't instantiate corresponding rule ('" + EmbeddedOrientDBRule.class.getName() + "')", e );
+            }
+        }
+
+        public EmbeddedOrientDBRule createGraphDB() {
+            return createRuleAndApplyConfig("graph");
+        }
+
+        public EmbeddedOrientDBRule createDocumentDB() {
+            return createRuleAndApplyConfig("document");
+        }
+
+        public EmbeddedOrientDBRule withoutDatabaseCreation() {
+            return createRuleAndApplyConfig(null);
+        }
+    }
+
+    private static class DBConnectionInfo implements IDatabaseConnectionInfo{
+        private final String database;
+        private final String databaseType;
+        private final String storageMode;
+        private final String login;
+        private final String password;
+        private final String address;
+        private final int binaryPort;
+
+        private DBConnectionInfo(String database, String databaseType, String storageMode, String login, String password, String address, int binaryPort) {
+            this.database = database;
+            this.databaseType = databaseType;
+            this.storageMode = storageMode;
+            this.login = login;
+            this.password = password;
+            this.address = address;
+            this.binaryPort = binaryPort;
+        }
+
+        @Override
+        public String getDatabase() {
+            return database;
+        }
+
+        @Override
+        public String getDatabaseType() {
+            return databaseType;
+        }
+
+        @Override
+        public String getStorageMode() {
+            return storageMode;
+        }
+
+        @Override
+        public String getLogin() {
+            return login;
+        }
+
+        @Override
+        public String getPassword() {
+            return password;
+        }
+
+        @Override
+        public String getAddress() {
+            return address;
+        }
+
+        @Override
+        public int getBinaryPort() {
+            return binaryPort;
+        }
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/ODBTestSupportRule.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/ODBTestSupportRule.java
@@ -1,0 +1,98 @@
+package com.orientechnologies.orient.unit;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentPool;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.db.record.ODatabaseFlat;
+import com.orientechnologies.orient.core.sql.OCommandSQL;
+import org.junit.rules.ExternalResource;
+
+public class ODBTestSupportRule extends ExternalResource {
+    private final AbstractOrientDBRule orientDBRule;
+
+    public ODBTestSupportRule(AbstractOrientDBRule orientDBRule) {
+        this.orientDBRule = orientDBRule;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        orientDBRule().before();
+        super.before();
+    }
+
+    @Override
+    protected void after() {
+        super.after();
+        orientDBRule().after();
+    }
+
+    protected final AbstractOrientDBRule orientDBRule(){
+        assert orientDBRule != null;
+        return orientDBRule;
+    }
+
+    // TODO: remove cast
+    public int nodesCount(){
+        return ((EmbeddedOrientDBRule)orientDBRule()).getCluster().size();
+    }
+
+    public AbstractOrientDBRule.IDatabaseConnectionInfo getConnectionInfo(){
+        return orientDBRule().getConnectionInfo();
+    }
+
+    public AbstractOrientDBRule.IDatabaseConnectionInfo getConnectionInfo(int idxNode){
+        return orientDBRule().getConnectionInfo(idxNode);
+    }
+
+    public String remoteConnectionString(){
+        return connectionString("remote", getConnectionInfo());
+    }
+
+    public String localConnectionString(){
+        return connectionString("plocal", getConnectionInfo());
+    }
+
+    static protected final String connectionString(String prefix, AbstractOrientDBRule.IDatabaseConnectionInfo ci){
+        return String.format("%s:%s:%s/%s", prefix, ci.getAddress(), ci.getBinaryPort(), ci.getDatabase());
+    }
+
+    protected ODatabaseDocumentTx remoteDocumentDBFromGPool(AbstractOrientDBRule.IDatabaseConnectionInfo ci){
+        final ODatabaseDocumentPool pool = ODatabaseDocumentPool.global();
+        final ODatabaseDocumentTx retVal = pool.acquire(connectionString("remote", ci), ci.getLogin(), ci.getPassword());
+        return retVal;
+    }
+
+    public ODatabaseDocumentTx remoteDocumentDBFromGPool(){
+        final AbstractOrientDBRule.IDatabaseConnectionInfo ci = getConnectionInfo();
+        return remoteDocumentDBFromGPool(ci);
+    }
+
+    public ODatabaseDocumentTx remoteDocumentDBFromGPool(int idxNode){
+        final AbstractOrientDBRule.IDatabaseConnectionInfo ci = orientDBRule.getConnectionInfo(idxNode);
+        return remoteDocumentDBFromGPool(ci);
+    }
+
+    public ODatabaseFlat localDatabaseFlat(){
+        final AbstractOrientDBRule.IDatabaseConnectionInfo ci = getConnectionInfo();
+        final ODatabaseFlat db = new ODatabaseFlat(localConnectionString()).open(ci.getLogin(), ci.getPassword());
+        return db;
+    }
+
+    public <RET> RET executeSQLCommandWithParams(String query, Object...params) throws Exception{
+        final ODatabaseDocumentTx db = remoteDocumentDBFromGPool();
+        try {
+            final String statement = String.format(query);
+            return db.command(new OCommandSQL(statement)).execute(params);
+        }finally{
+            db.close();
+        }
+    }
+
+    public <RET> RET executeSQLCommandWithParams(ODatabaseDocumentTx db, String query, Object...args) throws Exception{
+        final String statement = String.format(query, args);
+        return db.command(new OCommandSQL(statement)).execute(args);
+    }
+
+    public static ODBTestSupportRule create(AbstractOrientDBRule odbRule) {
+        return new ODBTestSupportRule(odbRule);
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/RemoteOrientDBRule.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/RemoteOrientDBRule.java
@@ -1,0 +1,80 @@
+package com.orientechnologies.orient.unit;
+
+import org.slf4j.LoggerFactory;
+
+
+public class RemoteOrientDBRule extends AbstractOrientDBRule<RemoteOrientDBRule.RemoteRuleBuilder.RemoteRuleBuildInfo> {
+    protected RemoteOrientDBRule(RemoteRuleBuilder.RemoteRuleBuildInfo buildInfo) {
+        super(buildInfo);
+        logger = LoggerFactory.getLogger(RemoteOrientDBRule.class);
+    }
+
+    // TODO: Needs to be implemented
+    @Override
+    public IDatabaseConnectionInfo getConnectionInfo(int idx) {
+        throw new UnsupportedOperationException("Is not implemented yet");
+    }
+
+
+    public static RemoteRuleBuilder build(){
+        return new RemoteRuleBuilder();
+    }
+
+    public static class RemoteRuleBuilder extends ConnectionInfo.ConnectionInfoBuilder<RemoteRuleBuilder, RemoteRuleBuilder.RemoteRuleBuildInfo> {
+
+        public static class RemoteRuleBuildInfo extends ConnectionInfo implements AbstractOrientDBRule.IDatabaseConnectionInfo{
+            private String database = DEFAULT_DATABASE;
+            private String databaseType = DEFAULT_DATABASE_TYPE;
+            private String storageMode = DEFAULT_STORAGE_MODE;
+
+            @Override
+            public String getDatabase() {
+                return database;
+            }
+
+            @Override
+            public String getDatabaseType() {
+                return databaseType;
+            }
+
+            @Override
+            public String getStorageMode() {
+                return storageMode;
+            }
+
+            @Override
+            public int getBinaryPort() {
+                return getBinaryPorts()[0];
+            }
+        }
+
+        public RemoteRuleBuilder() {
+            super(new RemoteRuleBuildInfo());
+        }
+
+        protected RemoteRuleBuilder(RemoteRuleBuildInfo buildInfo) {
+            super(buildInfo);
+        }
+
+        private RemoteOrientDBRule createRuleAndApplyConfig(String databaseType){
+            try {
+                buildInfo.databaseType = databaseType;
+                return new RemoteOrientDBRule(buildInfo);
+            } catch (Exception e) {
+                throw new RuntimeException("Can't instantiate corresponding rule ('" + RemoteOrientDBRule.class.getName() + "')", e );
+            }
+        }
+
+        public RemoteOrientDBRule createGraphDB(){
+            return createRuleAndApplyConfig("graph");
+        }
+
+        public RemoteOrientDBRule createDocumentDB(){
+            return createRuleAndApplyConfig("document");
+        }
+
+        public RemoteOrientDBRule withoutDatabaseCreation(){
+            return createRuleAndApplyConfig(null);
+        }
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/cluster/AbstractOrientDBCluster.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/cluster/AbstractOrientDBCluster.java
@@ -1,0 +1,231 @@
+package com.orientechnologies.orient.unit.cluster;
+
+import com.orientechnologies.common.parser.OSystemVariableResolver;
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import com.orientechnologies.orient.server.OServer;
+import com.orientechnologies.orient.server.config.OServerConfiguration;
+import com.orientechnologies.orient.server.distributed.ODistributedServerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class AbstractOrientDBCluster {
+    public enum Status {
+        OFFLINE, STARTING, ONLINE, SHUTDOWNING
+    }
+
+    public enum NodeParams{
+        NODE_HOME,
+        NODE_NAME,
+        NODE_PORT,
+        NODE_USER,
+        NODE_PWD
+    }
+
+    public interface NodeOperationListener {
+        void onBefore(int nodeNo, OServer node) throws Exception;
+        void onAfter(int nodeNo, OServer node) throws Exception;
+    }
+
+    protected static Logger logger = LoggerFactory.getLogger(AbstractOrientDBCluster.class);
+
+    private String name;
+
+    private final AtomicReference<Status> status = new AtomicReference<Status>(Status.OFFLINE);
+    protected List<OServer> nodes;
+
+    public AbstractOrientDBCluster(String clusterName, List<OServer> nodes) {
+        this.name = clusterName;
+        this.nodes = new ArrayList<OServer>(nodes);
+    }
+
+    protected Status setStatus(Status status) {
+        return this.status.getAndSet(status);
+    }
+
+    public OServer getNode(int idx) {
+        return nodes.get(idx);
+    }
+
+    public final void start() throws Exception {
+        start(null);
+    }
+
+    protected void startNode(int idx) throws Exception {
+        final OServer node = getNode(idx);
+        node.activate();
+        waitForState(node, Status.ONLINE);
+    }
+
+    protected void stopNode(int idx) throws Exception {
+        final OServer node = getNode(idx);
+        final String nodeName = getNodeParam(idx, NodeParams.NODE_NAME);
+        for (Status status = getNodeStatus(node); !Status.OFFLINE.equals(status); status = getNodeStatus(node)) {
+            if (status == null) {
+                break;
+            }
+
+            switch (status) {
+                case STARTING:
+                case SHUTDOWNING:
+                    Thread.sleep(100);
+                    break;
+
+                case ONLINE:
+                    node.shutdown();
+                    logger.trace("Node '{}': Waiting for the node will become OFFLINE", nodeName);
+                    break;
+
+                case OFFLINE:
+                    break;
+
+                default:
+                    throw new IllegalStateException("Unhandled Status value: " + status);
+            }
+        }
+    }
+
+    public synchronized void start(NodeOperationListener listener) throws Exception {
+        OGlobalConfiguration.STORAGE_KEEP_OPEN.setValue(false);
+        logger.debug("Cluster '{}': Starting cluster...", getName());
+        setStatus(Status.STARTING);
+        for (int i = 0; i < this.size(); ++i) {
+            final String nodeName = getNodeParam(i, NodeParams.NODE_NAME);
+            logger.debug("Node '{}': Starting node...", nodeName);
+
+            final OServer node = getNode(i);
+
+            System.setProperty(Orient.ORIENTDB_HOME, OSystemVariableResolver.resolveSystemVariables((String) node.getVariable("ORIENTDB_HOME")));
+            System.setProperty(OServerConfiguration.PROPERTY_CONFIG_FILE, OSystemVariableResolver.resolveSystemVariables("${ORIENTDB_HOME}/config/orientdb-server-config.xml"));
+
+            try {
+                node.startup();
+            } catch (Exception e) {
+                logger.error(String.format("\n\nCan't start node '%s' because of error. Cluster '%s' will be stopped.", nodeName, getName()),
+                       e);
+
+                for (int j = i - 1; j >= 0; --j) {
+                    stop();
+                }
+            }
+
+            if (listener != null) {
+                listener.onBefore(i, node);
+            }
+
+            startNode(i);
+
+            if (listener != null) {
+                listener.onAfter(i, node);
+            }
+            logger.info("Node '{}': Node has been started", nodeName);
+        }
+        setStatus(Status.ONLINE);
+        logger.info("Cluster '{}': Cluster is up and running", getName());
+
+    }
+
+    public final void stop() throws Exception {
+        stop(null);
+    }
+
+    public synchronized void stop(NodeOperationListener listener) throws Exception {
+        logger.debug("Cluster '{}': Stopping cluster...", getName());
+        setStatus(Status.SHUTDOWNING);
+
+        for (int i = size() - 1; i > -1; --i) {
+            final String nodeName = getNodeParam(i,NodeParams.NODE_NAME);
+            logger.debug("Node '{}': Stopping node...", nodeName);
+            if (listener != null) {
+                listener.onBefore(i, getNode(i));
+            }
+
+            stopNode(i);
+
+            if (listener != null) {
+                listener.onAfter(i, getNode(i));
+            }
+            logger.info("Node '{}': Node has been stopped", nodeName);
+        }
+        setStatus(Status.OFFLINE);
+        logger.info("Cluster '{}': Cluster has been stopped", getName());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Status getStatus() {
+        return status.get();
+    }
+
+    public int size() {
+        return nodes.size();
+    }
+
+    public String getAdminName() {
+        return getAdminName(0);
+    }
+
+    public String getAdminName(int idx) {
+        return getNodeParam(idx, NodeParams.NODE_USER);
+    }
+
+    public String getAdminPassword() {
+        return getAdminPassword(0);
+    }
+
+    public String getAdminPassword(int idx) {
+        return getNodeParam(idx, NodeParams.NODE_PWD);
+    }
+
+
+    public String getConnectionString() {
+        return getConnectionString(0);
+    }
+
+    public String getConnectionString(int idx) {
+        return String.format("127.0.0.1:%s", getNodeParam(idx,NodeParams.NODE_PORT));
+    }
+
+    protected static OServer waitForState(OServer node, Status state) throws InterruptedException {
+        logger.trace("Node '{}': Waiting for the node will become {}", getNodeParam(node, NodeParams.NODE_NAME), state.name());
+        for (; ; ) {
+            final Status status = getNodeStatus(node);
+            if (status != null && state.equals(status)) {
+                break;
+            }
+            Thread.sleep(50);
+        }
+        return node;
+    }
+
+    protected static Status getNodeStatus(OServer node) {
+        final ODistributedServerManager dm = node.getDistributedManager();
+        if (dm == null) {
+            return null;
+        }
+
+        final Enum<?> oStatus = dm.getNodeStatus();
+        return Status.valueOf(oStatus.name());
+    }
+
+    public <T> T getNodeParam(int idx, NodeParams param){
+        return (T)getNode(idx).getVariable(param.name());
+    }
+
+    static <T> T getNodeParam(OServer node, NodeParams param){
+        return (T)node.getVariable(param.name());
+    }
+
+    public void setNodeParam(int idx, NodeParams param, Object value){
+        setNodeParam(getNode(idx), param, value);
+    }
+    static void setNodeParam(OServer node, NodeParams param, Object value){
+        node.setVariable(param.name(), value);
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/cluster/ClusterFactory.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/cluster/ClusterFactory.java
@@ -1,0 +1,502 @@
+package com.orientechnologies.orient.unit.cluster;
+
+import com.hazelcast.config.*;
+import com.orientechnologies.common.io.OFileUtils;
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.server.OServer;
+import com.orientechnologies.orient.server.OServerMain;
+import com.orientechnologies.orient.server.config.*;
+import com.orientechnologies.orient.server.network.protocol.binary.ONetworkProtocolBinary;
+import com.orientechnologies.orient.unit.ConnectionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Properties;
+
+public class ClusterFactory {
+    public static class ClusterBuildInfo extends ConnectionInfo {
+        private static final int DEFAULT_NUMBER_OF_NODES = 2;
+
+        protected OServerConfiguration serverConfig;
+        protected int nodesCount = DEFAULT_NUMBER_OF_NODES;
+        protected File clusterBaseDir;
+        protected String name = "orient";
+        protected int hazelcastPorts[] = {3434};
+
+        public boolean isEmbedded(){
+            return nodesCount < 0;
+        }
+
+        public boolean isServerConfigProvided(){
+            return serverConfig != null;
+        }
+
+        private int[] adjustPortsIfNeeded(int ports[]){
+            if(nodesCount > ports.length){
+                final int retVal[] = Arrays.copyOf(ports, nodesCount);
+                int lastPort = ports[ports.length-1];
+                for(int i=ports.length; i< nodesCount; ++i ){
+                    retVal[i] = ++lastPort;
+                }
+
+                return retVal;
+            }
+            return ports;
+        }
+
+        @Override
+        public void verify() throws IllegalStateException{
+            super.verify();
+
+            throwIllegalStateIf(serverConfig == null, "Server configuration can't be null");
+            throwIllegalStateIf(clusterBaseDir == null, "Base cluster directory must be specified");
+            throwIllegalStateIf(!isEmbedded() && (hazelcastPorts == null || hazelcastPorts.length < 1),
+                    "At least one hazelcast port must be specified");
+        }
+    }
+
+    public static class ClusterBuildInfoBuilder< T extends ClusterBuildInfoBuilder, I extends ClusterBuildInfo> {
+        private final static String HAZELCAST_PORTS_PROPERTY_NAME = "test.hazelcast.ports";
+        protected final I buildInfo;
+
+        public ClusterBuildInfoBuilder(I buildInfo){
+            this.buildInfo = buildInfo;
+        }
+
+        public T clusterName(String name){
+            buildInfo.name = name;
+            return (T)this;
+        }
+
+        /**
+         * Setup base cluster dir from the specified property file and key.
+         *
+         * @param resourcePath path to the properties file
+         * @param key key for cluster base dir property
+         */
+        public T clusterBaseDirFromPropertyFile(String resourcePath, String key) {
+            final String rpath = resourcePath.startsWith(  File.separator) ?  resourcePath : File.separator + resourcePath;
+            final InputStream is = ClusterFactory.class.getResourceAsStream(rpath);
+            try {
+                if (is == null) {
+                    throw new IllegalStateException(String.format("Can't load properties file, resource '%s' is not found",
+                            rpath)
+                    );
+                }
+
+                final Properties props = new Properties();
+                props.load(is);
+
+                clusterBaseDir(props.getProperty(key));
+
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                try {
+                    is.close();
+                }catch(IOException e){
+                }
+            }
+            return (T)this;
+        }
+
+
+        /**
+         * Load server config from the specified resource file
+         */
+        public T useServerConfigResource(String serverConfigResource){
+            final String resourcePath = serverConfigResource.startsWith(  File.separator) ?  serverConfigResource : File.separator + serverConfigResource;
+
+            final InputStream is = ClusterFactory.class.getResourceAsStream(resourcePath);
+            try{
+                if(is == null) {
+                    throw new IllegalStateException(String.format("Can't load OrientDB server configuration, resource '%s' is not found",
+                            resourcePath)
+                    );
+                }
+
+                final OServerConfigurationLoaderXml loader = new OServerConfigurationLoaderXml(OServerConfiguration.class, is);
+                buildInfo.serverConfig = loader.load();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally{
+                try {
+                    is.close();
+                }catch(IOException e){
+                }
+            }
+
+            // -- setup base cluster directory, if provided
+            final String clusterBaseDir = buildInfo.serverConfig.getProperty(Orient.ORIENTDB_HOME);
+            if(clusterBaseDir != null && !clusterBaseDir.isEmpty()){
+                buildInfo.clusterBaseDir = new File(clusterBaseDir);
+            }
+
+            // -- setup hazelcast ports, if provided
+            final String rawHazelcastPorts = buildInfo.serverConfig.getProperty(HAZELCAST_PORTS_PROPERTY_NAME);
+            if(rawHazelcastPorts != null && !rawHazelcastPorts.isEmpty()){
+
+            }
+
+            return (T)this;
+        }
+
+        public T numberOfNodes(int count){
+            buildInfo.nodesCount = count;
+            return (T)this;
+        }
+
+        public T clusterBaseDir(String pathToBaseClusterDir){
+            buildInfo.clusterBaseDir = new File(pathToBaseClusterDir);
+            return (T)this;
+        }
+
+        /**
+         * Use specified hazelcast ports, one per node.
+         *
+         * Hazelcast ports also might be provided in server configuration file, as a value of 'test.hazelcast.ports' variable.
+         */
+        public T useHazelcastPorts(int...ports){
+            buildInfo.hazelcastPorts = ports;
+            return (T)this;
+        }
+
+        /**
+         * Use specified ports for binary protocol, one per node.
+         *
+         * This val ports also might be provided in server configuration file, as a value of 'test.hazelcast.ports' variable.
+         */
+        public T useBinaryPorts(int...ports){
+            buildInfo.setBinaryPorts(ports);
+            return (T)this;
+        }
+
+        /**
+         * Run "Embedded" OrientDb instance (Non distributed single node configuration)
+         */
+        public T useEmbeddedServer(){
+            buildInfo.nodesCount = -1;
+            return (T)this;
+        }
+    }
+
+    private final static String ORIENT_DB_PATH_PROPERTY_NAME = "server.database.path";
+    private static Logger logger = LoggerFactory.getLogger(ClusterFactory.class);
+
+    public static AbstractOrientDBCluster createCluster(ClusterBuildInfo buildInfo) throws Exception {
+
+        final boolean buildEmbedded = buildInfo.isEmbedded();
+
+        // -- verify and adjust
+        buildInfo.verify();
+
+        /**
+         * At the moment, due to the OrientDb issues there is no chance to get embedded OrientDb cluster up and running on Windows
+         */
+        if( !buildEmbedded && (buildInfo.nodesCount > 1) ){
+            final String osName = System.getProperty("os.name").toLowerCase();
+            if(osName.startsWith("windows")){
+                logger.warn("\n\n\n\tNumber of nodes in the Embedded OrientDB cluster was forced to use only a Single Node because of problem with running cluster of OrientDB on Windows\n\n\n");
+                buildInfo.nodesCount = 1;
+            }
+        }
+
+        if( !buildEmbedded) {
+            buildInfo.hazelcastPorts = buildInfo.adjustPortsIfNeeded(buildInfo.hazelcastPorts);
+        }
+
+        buildInfo.setBinaryPorts( buildInfo.adjustPortsIfNeeded(buildInfo.getBinaryPorts()));
+
+
+        // --
+        final int nmbOfNode = buildEmbedded ? 1 : buildInfo.nodesCount;
+        final ArrayList<OServer> nodes = new ArrayList<OServer>(nmbOfNode);
+
+        final Config hazelcastConfig = buildEmbedded ? null : buildTCPHazelcastConfig(buildInfo.name, buildInfo.getAddress(), buildInfo.hazelcastPorts);
+        for(int i=0; i<nmbOfNode; ++i){
+            final String nodeName = buildEmbedded ? "embedded" : "node-" + i;
+            final OServer node = createNode(buildInfo.serverConfig, buildInfo.clusterBaseDir, nodeName, buildInfo.getAddress(),
+                    buildInfo.getLogin(), buildInfo.getPassword(), buildInfo.getBinaryPorts()[i],
+                    buildEmbedded ? -1 : buildInfo.hazelcastPorts[i], hazelcastConfig);
+            nodes.add(node);
+        }
+
+        if(buildEmbedded){
+            return new AbstractOrientDBCluster("Embedded", nodes) {
+                @Override
+                protected void startNode(int idx) throws Exception {
+                    final OServer node = getNode(idx);
+                    node.activate();
+                }
+
+                @Override
+                protected void stopNode(int idx) throws Exception {
+                    final OServer node = getNode(idx);
+                    node.shutdown();
+                }
+            };
+        } else {
+            return new AbstractOrientDBCluster(hazelcastConfig.getGroupConfig().getName(), nodes) {
+            };
+        }
+    }
+
+    public static AbstractOrientDBCluster rebuildCluster(AbstractOrientDBCluster cluster) {
+        return new MixedOrientDBCluster(cluster);
+    }
+
+    private static OServer createNode(OServerConfiguration generalConfig, File orientHome, String nodeName,
+                   String address, String userName, String password, int binaryPort, int hazelcastPort, Config hazelcastConfig) throws Exception {
+        final File nodeHome = new File(orientHome, nodeName);
+
+        // -- hazelcast setup, if provided (may be null in case of creating embedded server)
+        if(hazelcastConfig != null) {
+            hazelcastConfig.getNetworkConfig().setPort(hazelcastPort);
+        }
+
+        // -- binary protocol setup
+        final OServerNetworkListenerConfiguration binaryListener = getOrCreateNetListenerByClass(generalConfig, ONetworkProtocolBinary.class);
+        binaryListener.portRange = Integer.toString(binaryPort);
+        if(address.equals("localhost") || address.equals("127.0.0.1")){
+            binaryListener.ipAddress = "0.0.0.0";
+        } else {
+            binaryListener.ipAddress = address;
+        }
+
+        // --  user
+        if(generalConfig.users == null){
+            generalConfig.users = new OServerUserConfiguration[0];
+        }
+
+        boolean userAlreadyConfigured = false;
+        for(int i=0; i< generalConfig.users.length; ++i){
+            final OServerUserConfiguration ucfg = generalConfig.users[i];
+
+            if(!userName.equalsIgnoreCase(ucfg.name)){
+                continue;
+            }
+
+            if(!"*".equals(ucfg.resources)){
+                ucfg.resources = "*";
+            }
+
+            if(!password.equals(ucfg.password)){
+                ucfg.password = password;
+            }
+
+            userAlreadyConfigured = true;
+            break;
+        }
+
+        if(!userAlreadyConfigured){
+            final OServerUserConfiguration ucfg = new OServerUserConfiguration();
+            ucfg.name = userName;
+            ucfg.password = password;
+            ucfg.resources = "*";
+            generalConfig.users = Arrays.copyOf(generalConfig.users, generalConfig.users.length +1);
+            generalConfig.users[generalConfig.users.length -1] = ucfg;
+        }
+
+        // --
+        final OServerConfiguration config =  prepareNodeConfig(generalConfig, nodeHome, hazelcastConfig);
+
+        String adminName = null, adminPassword = null;
+        for(OServerUserConfiguration ucfg: config.users){
+            if("*".equals(ucfg.resources)){
+                adminName = ucfg.name;
+                adminPassword = ucfg.password;
+                break;
+            }
+        }
+
+        final OServer node = OServerMain.create();
+        node.setVariable(Orient.ORIENTDB_HOME, nodeHome.getAbsolutePath());
+        AbstractOrientDBCluster.setNodeParam(node, AbstractOrientDBCluster.NodeParams.NODE_HOME, nodeHome);
+        AbstractOrientDBCluster.setNodeParam(node, AbstractOrientDBCluster.NodeParams.NODE_NAME, nodeName);
+        AbstractOrientDBCluster.setNodeParam(node, AbstractOrientDBCluster.NodeParams.NODE_PORT, binaryPort);
+        AbstractOrientDBCluster.setNodeParam(node, AbstractOrientDBCluster.NodeParams.NODE_USER, adminName);
+        AbstractOrientDBCluster.setNodeParam(node, AbstractOrientDBCluster.NodeParams.NODE_PWD, adminPassword);
+
+        node.setServerRootDirectory( nodeHome.getAbsolutePath());
+        return node;
+    }
+
+    private static OServerConfiguration prepareNodeConfig(OServerConfiguration generalConfiguration, File nodeHome,
+            com.hazelcast.config.Config hazelcastConfig) throws Exception {
+
+        final String nodeName = nodeHome.getName();
+
+        //  ----------  setup node db path
+        for(int i=0; i<generalConfiguration.properties.length; ++i){
+            final OServerEntryConfiguration prop = generalConfiguration.properties[i];
+            if(prop.name.equals(ORIENT_DB_PATH_PROPERTY_NAME)){
+                prop.value = new File(nodeHome, "databases").getAbsolutePath();
+            } else if(prop.name.equals(Orient.ORIENTDB_HOME)){
+                prop.value = nodeHome.getAbsolutePath();
+            }
+        }
+
+        //  ----------  create new instance of Server configuration
+        final StringWriter sw = new StringWriter();
+        Utils.writeToXml(sw, generalConfiguration);
+
+        final OServerConfiguration retVal;
+        final InputStream is = new ByteArrayInputStream(sw.toString().getBytes());
+        try {
+            final OServerConfigurationLoaderXml loader = new OServerConfigurationLoaderXml(OServerConfiguration.class, is);
+            retVal = loader.load();
+        }finally{
+            is.close();
+        }
+
+        // ----------  create or re-create directories for node
+        final File configDir = new File(nodeHome, "config");
+        OFileUtils.deleteRecursively(nodeHome);
+
+        if(!configDir.mkdirs()){
+            throw new IllegalStateException(String.format("Can't create node config directory '%s'",
+                    configDir.getAbsolutePath()
+            ));
+        }
+
+        final boolean isDistributedNode = hazelcastConfig != null;
+        if( isDistributedNode ) {
+            // ---------- create hazelcast handler
+            final String HAZELCAST_PLUGIN_CONFIG = "<handler class=\"com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin\">\n" +
+                    "            <parameters>\n" +
+                    "                <parameter value=\"true\" name=\"enabled\"/>\n" +
+                    "                <parameter value=\"%1$s/config/default-distributed-db-config.json\" name=\"configuration.db.default\"/>\n" +
+                    "                <parameter value=\"%1$s/config/hazelcast.xml\" name=\"configuration.hazelcast\"/>\n" +
+                    "                <parameter value=\"com.orientechnologies.orient.server.distributed.conflict.ODefaultReplicationConflictResolver\" name=\"conflict.resolver.impl\"/>\n" +
+                    "                <parameter value=\"com.orientechnologies.orient.server.hazelcast.sharding.strategy.ORoundRobinPartitioninStrategy\" name=\"sharding.strategy.round-robin\"/>\n" +
+                    "                <parameter value=\"%2$s\" name=\"nodeName\"/>\n" +
+                    "            </parameters>\n" +
+                    "        </handler>";
+
+            final OServerHandlerConfiguration hazelcastHandler = Utils.readFromXML(OServerHandlerConfiguration.class, HAZELCAST_PLUGIN_CONFIG, nodeHome, nodeName);
+
+            if (retVal.handlers == null) {
+                retVal.handlers = new LinkedList();
+            }
+            retVal.handlers.add(hazelcastHandler);
+
+            // -- distributed DB
+            final String DEFAULT_DISTRIBUTED_DB_CONFIG_v17 = "{\n" +
+                    "    \"autoDeploy\": true,\n" +
+                    "    \"hotAlignment\": false,\n" +
+                    "    \"readQuorum\": 1,\n" +
+                    "    \"writeQuorum\": 2,\n" +
+                    "    \"failureAvailableNodesLessQuorum\": false,\n" +
+                    "    \"readYourWrites\": true,\n" +
+                    "    \"clusters\": {\n" +
+                    "        \"internal\": {\n" +
+                    "        },\n" +
+                    "        \"index\": {\n" +
+                    "        },\n" +
+                    "        \"*\": {\n" +
+                    "            \"servers\" : [ \"<NEW_NODE>\" ]\n" +
+                    "        }\n" +
+                    "    }\n" +
+                    "}";
+            Utils.writeAsFile(new File(configDir, "default-distributed-db-config.json"), DEFAULT_DISTRIBUTED_DB_CONFIG_v17);
+
+
+            // -- Hazelcast
+            final ConfigXmlGenerator hazelcastConfigXmlGenerator = new ConfigXmlGenerator(true);
+            final String cfg = hazelcastConfigXmlGenerator.generate(hazelcastConfig);
+
+            Utils.writeAsFile(new File(configDir, "hazelcast.xml"), cfg);
+        }
+
+        // ---------- create graph handler (for gremlin)
+//        String GRAPH_HANDLER_CONFIG = "<handler class=\"com.orientechnologies.orient.graph.handler.OGraphServerHandler\">\n" +
+//                "            <parameters>\n" +
+//                "                <parameter value=\"true\" name=\"enabled\"/>\n" +
+//                "                <parameter value=\"50\" name=\"graph.pool.max\"/>\n" +
+//                "            </parameters>\n" +
+//                "        </handler>\n";
+//        final OServerHandlerConfiguration graphHandler = readFromXML(OServerHandlerConfiguration.class, GRAPH_HANDLER_CONFIG);
+//        retVal.handlers.add(graphHandler);
+
+        Utils.writeAsXmlFile(new File(nodeHome, OServerConfiguration.DEFAULT_CONFIG_FILE), retVal);
+        return retVal;
+    }
+
+    private static OServerNetworkListenerConfiguration getOrCreateNetListenerByClass(OServerConfiguration config, Class clazz){
+        if(config.network == null) {
+            config.network = new OServerNetworkConfiguration();
+            config.network.protocols = new LinkedList<OServerNetworkProtocolConfiguration>();
+        }
+
+        String listenerName = null;
+        for (OServerNetworkProtocolConfiguration proto : config.network.protocols) {
+            if (clazz.getName().equals(proto.implementation)) {
+                listenerName = proto.name;
+                break;
+            }
+        }
+
+        if (listenerName == null) {
+            final OServerNetworkProtocolConfiguration protocolConfiguration = new OServerNetworkProtocolConfiguration();
+            listenerName = clazz.getSimpleName();
+            protocolConfiguration.name = listenerName;
+            protocolConfiguration.implementation = clazz.getName();
+            config.network.protocols.add(config.network.protocols.size(), protocolConfiguration);
+        }
+
+        if(config.network.listeners == null){
+            config.network.listeners = new LinkedList<OServerNetworkListenerConfiguration>();
+        }
+        OServerNetworkListenerConfiguration listener = null;
+        for (OServerNetworkListenerConfiguration l : config.network.listeners) {
+            if (listenerName.equals(l.protocol)) {
+                listener = l;
+                break;
+            }
+        }
+
+        if (listener == null) {
+            listener = new OServerNetworkListenerConfiguration();
+            listener.protocol = listenerName;
+            config.network.listeners.add(config.network.listeners.size(), listener);
+        }
+        return listener;
+    }
+
+    private static com.hazelcast.config.Config buildTCPHazelcastConfig(String clusterName, String address, int hazelcastPorts[]){
+        final com.hazelcast.config.Config cfg = new com.hazelcast.config.Config();
+
+        cfg.setGroupConfig( new GroupConfig(clusterName, clusterName) );
+
+        final NetworkConfig networkConfig = new NetworkConfig();
+        networkConfig.setPort(-1);
+        networkConfig.setPortAutoIncrement(true);
+
+        final JoinConfig joinConfig = new JoinConfig();
+
+        joinConfig.setMulticastConfig(new MulticastConfig());
+        joinConfig.getMulticastConfig().setEnabled(false);
+
+        joinConfig.setTcpIpConfig(new TcpIpConfig());
+        joinConfig.getTcpIpConfig().setEnabled(true);
+
+        for(int port: hazelcastPorts){
+            joinConfig.getTcpIpConfig().addMember(String.format("%s:%s", address, port));
+        }
+
+        networkConfig.setJoin(joinConfig);
+
+        cfg.setNetworkConfig(networkConfig);
+
+        final ExecutorConfig executorConfig = new ExecutorConfig();
+        executorConfig.setPoolSize(16);
+
+        cfg.addExecutorConfig(executorConfig);
+        return cfg;
+    }
+
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/cluster/MixedOrientDBCluster.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/cluster/MixedOrientDBCluster.java
@@ -1,0 +1,145 @@
+package com.orientechnologies.orient.unit.cluster;
+
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.server.OServer;
+import com.orientechnologies.orient.server.OServerMain;
+import com.orientechnologies.orient.server.OServerShutdownMain;
+import com.orientechnologies.orient.server.config.OServerConfiguration;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * All cluster nodes of this cluster runs in their own JVMs. The only first node uses JVM in which this cluster instance was created.
+ *
+ * Cluster takes care about spawning and destroying JVMs.
+ */
+class MixedOrientDBCluster extends AbstractOrientDBCluster {
+    static {
+        logger = LoggerFactory.getLogger(MixedOrientDBCluster.class);
+    }
+
+    private Process spawned[];
+
+    public MixedOrientDBCluster(String clusterName, List<OServer> nodes) {
+        super(clusterName, nodes);
+        spawned = new Process[nodes.size()];
+    }
+
+    MixedOrientDBCluster(AbstractOrientDBCluster cluster){
+        this(cluster.getName(), cluster.nodes);
+    }
+
+    private static int getQntOfClusterMembers(OServer node){
+        final ODocument doc = node.getDistributedManager().getClusterConfiguration();
+        final List<ODocument> members = doc.field("members");
+        return members.size();
+    }
+
+    @Override
+    protected void stopNode(int idx) throws Exception {
+        final OServer node = getNode(idx);
+        final String nodeName = getNodeParam(idx, NodeParams.NODE_NAME);
+
+        if(idx == 0){
+            super.stopNode(0);
+        } else {
+            final Process p = spawned[idx];
+            if(p != null){
+                logger.trace("Node '{}': Spawning shutdown process", nodeName);
+                Process pShutdown = spawnNodeProcess(node, OServerShutdownMain.class, true);
+
+                logger.trace("Node '{}': Waiting shutdown process completion", nodeName);
+                int i = pShutdown.waitFor();
+                pShutdown.destroy();
+
+                logger.trace("Node '{}': Waiting completion of  process", nodeName);
+                try {
+                    p.wait(750);
+                } catch (Exception ex){
+                    logger.trace(String.format("Node '%s': Got an exception while waiting process completion", nodeName), ex);
+                }
+                if(!isProcessFinished(p)){
+                    logger.warn("Node '{}': Process termination timeout reached, process will be terminated forcibly", nodeName);
+                }
+
+                p.destroy();
+                spawned[idx] = null;
+            }
+        }
+    }
+
+    boolean isProcessFinished(Process p){
+        try {
+            p.exitValue();
+            return true;
+        }catch(IllegalThreadStateException e){
+        }
+        return false;
+    }
+
+    @Override
+    protected void startNode(int idx) throws Exception {
+        final OServer node = getNode(idx);
+        final String nodeName = getNodeParam(idx, NodeParams.NODE_NAME);
+
+        if(idx == 0){
+            node.startup();
+            super.startNode(0);
+        } else {
+            final Process p = spawnNodeProcess(node, OServerMain.class, true);
+            spawned[idx] = p;
+            final OServer firstNode = getNode(0);
+
+            logger.trace("Node '{}': Waiting for the node will become ONLINE", nodeName);
+            for(boolean nodeOnline = false; !nodeOnline;) {
+                nodeOnline = getQntOfClusterMembers(firstNode) == idx + 1;
+                if(isProcessFinished(p)) {
+                    throw new RuntimeException(
+                            String.format("Node '%s': node failed to start, spawned process hs been finished unexpectedly",
+                                    nodeName)
+                        );
+                }
+                Thread.sleep(100);
+            }
+        }
+    }
+
+    private static Process spawnNodeProcess(OServer node, Class clazz, boolean redirectStream) throws Exception {
+        final File nodeHome = (File)node.getVariable(NodeParams.NODE_HOME.name());
+
+        String separator = System.getProperty("file.separator");
+        String classpath = System.getProperty("java.class.path");
+
+
+        String path = System.getProperty("java.home")
+                + separator + "bin" + separator + "java";
+
+        final List<String>  args = Arrays.asList(
+                path,
+                "-cp",
+                classpath,
+
+//                "-Xdebug",
+//                "-Xnoagent",
+//                "-Djava.compiler=NONE",
+//                "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5007",
+
+                "-Dorientdb.config.file=${ORIENTDB_HOME}/" + OServerConfiguration.DEFAULT_CONFIG_FILE,
+                "-Djava.util.logging.config.file=${ORIENTDB_HOME}/config/orientdb-server-log.properties",
+                clazz.getCanonicalName()
+        );
+
+        final ProcessBuilder processBuilder = new ProcessBuilder(args);
+        processBuilder.redirectErrorStream(redirectStream);
+        processBuilder.directory(nodeHome);
+
+        processBuilder.environment().put(Orient.ORIENTDB_HOME, nodeHome.getAbsolutePath());
+
+        final Process process = processBuilder.start();
+        return process;
+    }
+}

--- a/unit/src/main/java/com/orientechnologies/orient/unit/cluster/Utils.java
+++ b/unit/src/main/java/com/orientechnologies/orient/unit/cluster/Utils.java
@@ -1,0 +1,48 @@
+package com.orientechnologies.orient.unit.cluster;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import java.io.*;
+
+class Utils {
+    private Utils(){}
+
+    public static <T> T readFromXML(Class<T> clazz, String xmlTemplate, Object... params) throws Exception {
+        final JAXBContext context = JAXBContext.newInstance(clazz);
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        final String xml = String.format(xmlTemplate, params);
+        final InputStream is = new ByteArrayInputStream(xml.getBytes());
+        return (T) unmarshaller.unmarshal(is);
+    }
+
+    public static void writeAsXmlFile(File file, Object data) throws Exception{
+        assert file != null;
+        assert data != null;
+
+        final FileWriter fw = new FileWriter(file);
+        try{
+            Utils.writeToXml(fw, data);
+        }finally{
+            fw.close();
+        }
+
+    }
+
+    public static Writer writeToXml(Writer writer, Object data) throws Exception {
+        final JAXBContext context = JAXBContext.newInstance(data.getClass());
+        final Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        marshaller.marshal(data, writer);
+        return writer;
+    }
+
+    public static void writeAsFile(File file, String template, Object... args) throws IOException{
+        final FileWriter fw = new FileWriter(file);
+        try{
+            fw.write(String.format(template, args));
+        }finally{
+            fw.close();
+        }
+    }
+}

--- a/unit/src/main/resources/default-orientdb-test-server-config.xml
+++ b/unit/src/main/resources/default-orientdb-test-server-config.xml
@@ -1,0 +1,14 @@
+<orient-server>
+    <properties>
+        <entry name="db.pool.min" value="1" />
+        <entry name="db.pool.max" value="20" />
+
+        <entry name="cache.level1.enabled" value="false" />
+        <entry name="cache.level2.enabled" value="false" />
+
+        <entry name="profiler.enabled" value="false" />
+
+        <entry name="log.console.level" value="fine" />
+        <entry name="log.file.level" value="fine" />
+    </properties>
+</orient-server>

--- a/unit/src/test/java/com/orientechnologies/orient/unit/EmbeddedOrientDBRuleTest.java
+++ b/unit/src/test/java/com/orientechnologies/orient/unit/EmbeddedOrientDBRuleTest.java
@@ -1,0 +1,70 @@
+package com.orientechnologies.orient.unit;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.db.record.ODatabaseFlat;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OSchema;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertNotNull;
+
+@FixMethodOrder(MethodSorters.JVM)
+public class EmbeddedOrientDBRuleTest {
+
+    @ClassRule
+    public static ODBTestSupportRule embeddedOrientDB = ODBTestSupportRule.create(
+            EmbeddedOrientDBRule.build()
+                    .clusterBaseDirFromPropertyFile("test-orientdb.properties", "cluster-base-dir")
+                    .createGraphDB()
+    );
+
+    private final static Logger logger = LoggerFactory.getLogger(EmbeddedOrientDBRuleTest.class);
+
+    @Test
+    public void simpleConnectionCheck(){
+        final ODatabaseFlat db = embeddedOrientDB.localDatabaseFlat();
+        try {
+            final StringBuilder builder = new StringBuilder(
+                    String.format("\nClasses available at %s", db.getURL())
+                );
+
+            for( OClass cls: db.getMetadata().getSchema().getClasses()){
+                builder.append("\n\t")
+                    .append(cls.getName());
+            }
+
+            logger.info(builder.toString());
+        } finally {
+            db.close();
+        }
+    }
+
+//    @Ignore("Ignoring  a strange error somewhere into the ODB internals")
+    @Test
+    public void checkThatNewlyCreatedClassIsAvailableOnEachClusterNode() throws Exception {
+
+        // -- preparation
+        embeddedOrientDB.executeSQLCommandWithParams("create class V1 extends V");
+        embeddedOrientDB.executeSQLCommandWithParams("create vertex V1 set prop = '12'");
+
+
+        // -- verification
+        for(int i= embeddedOrientDB.nodesCount() - 1; i<=0; --i){
+            final ODatabaseDocumentTx db = embeddedOrientDB.remoteDocumentDBFromGPool(i);
+            try{
+                final OSchema schema = db.getMetadata().getSchema();
+                final OClass oclass = schema.getClass("V2");
+
+                assertNotNull(String.format("Class V1 doesn't exists on node %d", i), oclass);
+            }finally {
+                db.close();
+            }
+        }
+    }
+}

--- a/unit/src/test/resources/logback-test.xml
+++ b/unit/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false" scan="false">
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-mm-dd HH:mm:ss:SSS} %-5p %m [%c#%M]%n</pattern>
+        </encoder>
+    </appender>
+  
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="com.orientechnologies.orient.unit" level="TRACE"/>
+</configuration>

--- a/unit/src/test/resources/test-orientdb.properties
+++ b/unit/src/test/resources/test-orientdb.properties
@@ -1,0 +1,1 @@
+cluster-base-dir=${project.build.directory}/orientdb


### PR DESCRIPTION
@lvca  Here is an initial integration with JUnit. I would like you to look on a test wich is currently ignored EmbeddedOrientDBRuleTest.checkThatNewlyCreatedClassIsAvailableOnEachClusterNode, it fails because of an internal ClassCastException:

```
The database 'testdb' has been created (on behalf of user 'admin') and ready to use.
The following command might be used to establish connection: connect remote:localhost:2424/testdb admin admin [com.orientechnologies.orient.unit.EmbeddedOrientDBRule#before]

com.orientechnologies.orient.core.exception.ODatabaseException: Cannot open database
    at com.orientechnologies.orient.core.db.record.ODatabaseRecordAbstract.open(ODatabaseRecordAbstract.java:340)
    at com.orientechnologies.orient.core.db.ODatabaseWrapperAbstract.open(ODatabaseWrapperAbstract.java:49)
    at com.orientechnologies.orient.core.db.document.ODatabaseDocumentTxPooled.<init>(ODatabaseDocumentTxPooled.java:47)
    at com.orientechnologies.orient.core.db.document.ODatabaseDocumentPool.createResource(ODatabaseDocumentPool.java:44)
    at com.orientechnologies.orient.core.db.document.ODatabaseDocumentPool.createResource(ODatabaseDocumentPool.java:20)
    at com.orientechnologies.orient.core.db.ODatabasePoolBase$1.createNewResource(ODatabasePoolBase.java:72)
    at com.orientechnologies.orient.core.db.ODatabasePoolBase$1.createNewResource(ODatabasePoolBase.java:61)
    at com.orientechnologies.common.concur.resource.OResourcePool.getResource(OResourcePool.java:82)
    at com.orientechnologies.common.concur.resource.OReentrantResourcePool.getResource(OReentrantResourcePool.java:63)
    at com.orientechnologies.orient.core.db.ODatabasePoolAbstract.acquire(ODatabasePoolAbstract.java:149)
    at com.orientechnologies.orient.core.db.ODatabasePoolAbstract.acquire(ODatabasePoolAbstract.java:134)
    at com.orientechnologies.orient.core.db.ODatabasePoolBase.acquire(ODatabasePoolBase.java:119)
    at com.orientechnologies.orient.unit.ODBTestSupportRule.remoteDocumentDBFromGPool(ODBTestSupportRule.java:60)
    at com.orientechnologies.orient.unit.ODBTestSupportRule.remoteDocumentDBFromGPool(ODBTestSupportRule.java:66)
    at com.orientechnologies.orient.unit.ODBTestSupportRule.executeSQLCommandWithParams(ODBTestSupportRule.java:81)
    at com.orientechnologies.orient.unit.EmbeddedOrientDBRuleTest.checkThatNewlyCreatedClassIsAvailableOnEachClusterNode(EmbeddedOrientDBRuleTest.java:53)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
Caused by: java.lang.ClassCastException: com.orientechnologies.orient.client.remote.OStorageRemoteThread cannot be cast to com.orientechnologies.orient.core.storage.OStorageEmbedded
    at com.orientechnologies.orient.server.distributed.ODistributedAbstractPlugin.onOpen(ODistributedAbstractPlugin.java:157)
    at com.orientechnologies.orient.core.db.record.ODatabaseRecordAbstract.callOnOpenListeners(ODatabaseRecordAbstract.java:1532)
    at com.orientechnologies.orient.core.db.record.ODatabaseRecordAbstract.open(ODatabaseRecordAbstract.java:333)
    ... 38 more

```
