### PR TITLE
Fixing of bugs according to FindBug report

### DIFF
--- a/commons/src/main/java/com/orientechnologies/common/concur/lock/OReadersWriterSpinLock.java
+++ b/commons/src/main/java/com/orientechnologies/common/concur/lock/OReadersWriterSpinLock.java
@@ -158,7 +158,7 @@ public class OReadersWriterSpinLock extends AbstractOwnableSynchronizer {
     assert lHolds.intValue() == 0;
   }
 
-  private final class WNode {
+  private final static class WNode {
     private final Queue<Thread> waitingReaders = new ConcurrentLinkedQueue<Thread>();
 
     private volatile boolean    locked         = true;

--- a/commons/src/main/java/com/orientechnologies/common/profiler/OProfilerEntry.java
+++ b/commons/src/main/java/com/orientechnologies/common/profiler/OProfilerEntry.java
@@ -56,13 +56,13 @@ public class OProfilerEntry {
     buffer.append(String.format(Locale.ENGLISH, "\"%s\":%d,", "firstExecution", firstExecution));
     buffer.append(String.format(Locale.ENGLISH, "\"%s\":%d", "lastExecution", lastExecution));
     if (payLoad != null)
-      buffer.append(String.format(Locale.ENGLISH, "\"%s\":%d", "payload", payLoad));
+      buffer.append(String.format(Locale.ENGLISH, "\"%s\":%s", "payload", payLoad));
     buffer.append('}');
   }
 
   @Override
   public String toString() {
-    return String.format("Profiler entry [%s]: total=%d, average=%.2f, items=%d, last=%d, max=%d, min=%d", total, name, average,
+    return String.format("Profiler entry [%s]: total=%d, average=%.2f, items=%d, last=%d, max=%d, min=%d", name, total, average,
         entries, last, max, min);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/collate/OCaseInsensitiveCollate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/collate/OCaseInsensitiveCollate.java
@@ -45,7 +45,7 @@ public class OCaseInsensitiveCollate extends ODefaultComparator implements OColl
 
   @Override
   public boolean equals(Object obj) {
-    if (obj.getClass() != this.getClass())
+    if (obj==null || obj.getClass() != this.getClass())
       return false;
 
     final OCaseInsensitiveCollate that = (OCaseInsensitiveCollate) obj;

--- a/core/src/main/java/com/orientechnologies/orient/core/collate/ODefaultCollate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/collate/ODefaultCollate.java
@@ -41,7 +41,7 @@ public class ODefaultCollate extends ODefaultComparator implements OCollate {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj.getClass() != this.getClass())
+    if (obj==null || obj.getClass() != this.getClass())
       return false;
 
     final ODefaultCollate that = (ODefaultCollate) obj;

--- a/core/src/main/java/com/orientechnologies/orient/core/config/OContextConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OContextConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.orientechnologies.orient.core.config;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Luca Garulli (l.garulli--at--orientechnologies.com)
  * 
  */
-public class OContextConfiguration {
+public class OContextConfiguration implements Serializable {
   private final ConcurrentHashMap<String, Object> config = new ConcurrentHashMap<String, Object>();
 
   /**

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -218,7 +218,7 @@ public abstract class OIndexAbstract<T> extends OSharedResourceAdaptiveExternal 
       if (clustersToIndex != null)
         this.clustersToIndex = new HashSet<String>(clustersToIndex);
       else
-        this.clustersToIndex = new HashSet<String>(clustersToIndex);
+        this.clustersToIndex = new HashSet<String>();
 
       indexEngine.create(this.name, indexDefinition, clusterIndexName, valueSerializer, isAutomatic());
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTreeEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTreeEntry.java
@@ -329,6 +329,6 @@ public abstract class OMVRBTreeEntry<K, V> implements Map.Entry<K, V>, Comparabl
     int idx = tree.pageIndex;
     if (idx > -1 && idx < getSize())
       return getKeyAt(idx) + "=" + getValueAt(idx);
-    return null;
+    return "null";
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -2001,7 +2001,7 @@ public class ODocument extends ORecordAbstract implements Iterable<Entry<String,
           Object orgVal = ((ODocument) iRecord).getOriginalValue(f);
           boolean simple = fieldValue != null ? OType.isSimpleType(fieldValue) : OType.isSimpleType(orgVal);
           if ((simple) || (fieldValue != null && orgVal == null) || (fieldValue == null && orgVal != null)
-              || (!fieldValue.equals(orgVal)))
+              || (fieldValue!=null && !fieldValue.equals(orgVal)))
             throw new OValidationException("The field '" + p.getFullName()
                 + "' is immutable and cannot be altered. Field value is: " + ((ODocument) iRecord).field(f));
         }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentHelper.java
@@ -348,7 +348,7 @@ public class ODocumentHelper {
               conditionFieldValue = OType.convert(conditionFieldValue, fieldValue.getClass());
 
             if (fieldValue == null && !conditionFieldValue.equals("null") || fieldValue != null
-                & !fieldValue.equals(conditionFieldValue))
+                && !fieldValue.equals(conditionFieldValue))
               value = null;
           }
         } else if (value instanceof Map<?, ?>) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
@@ -384,7 +384,7 @@ public class OJSONWriter {
       out.append(":");
     }
 
-    if (iFormat.contains("graph") && (iName.startsWith("in_") || iName.startsWith("out_"))
+    if (iFormat.contains("graph") && iName!=null && (iName.startsWith("in_") || iName.startsWith("out_"))
         && (iValue == null || iValue instanceof OIdentifiable)) {
       // FORCE THE OUTPUT AS COLLECTION
       out.append('[');

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLDelete.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLDelete.java
@@ -176,9 +176,9 @@ public class OCommandExecutorSQLDelete extends OCommandExecutorSQLAbstract imple
         } else {
           // RETURNS ALL THE DELETED RECORDS
           OIndexCursor cursor = index.cursor();
-          Map.Entry<Object, OIdentifiable> entry = cursor.nextEntry();
+          Map.Entry<Object, OIdentifiable> entry;
 
-          while (entry != null) {
+          while ((entry=cursor.nextEntry()) != null) {
             OIdentifiable rec = entry.getValue();
             rec = rec.getRecord();
             if (rec != null)

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ORecordDuplicatedException.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ORecordDuplicatedException.java
@@ -26,8 +26,14 @@ public class ORecordDuplicatedException extends OException {
 
     return rid.equals(((ORecordDuplicatedException) obj).rid);
   }
-
+  
+  
   @Override
+  public int hashCode() {
+	return rid.hashCode();
+  }
+
+@Override
   public String toString() {
     return super.toString() + " RID=" + rid;
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/OStorageOperationResult.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/OStorageOperationResult.java
@@ -19,6 +19,12 @@ public class OStorageOperationResult<RET> implements Externalizable {
   private RET     result;
   private byte[]  modifiedRecordContent;
   private boolean isMoved;
+  
+  /**
+   * OStorageOperationResult void constructor as required for Exernalizable 
+   */
+  public OStorageOperationResult() {
+  }
 
   public OStorageOperationResult(final RET result) {
     this(result, null, false);

--- a/core/src/main/java/com/orientechnologies/orient/core/type/OBuffer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/type/OBuffer.java
@@ -68,9 +68,17 @@ public class OBuffer implements Externalizable {
 
   @Override
   public boolean equals(final Object o) {
-    if (!(o instanceof OBuffer))
+    if (o==null || !(o instanceof OBuffer))
       return false;
 
     return OIOUtils.equals(buffer, ((OBuffer) o).buffer);
   }
+
+  @Override
+  public int hashCode() {
+	// Use of reference hashCode. Usage of deep hashCode should be considered
+	return buffer!=null?buffer.hashCode():0;
+  }
+  
+  
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSchemalessBinarySerializationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSchemalessBinarySerializationTest.java
@@ -697,7 +697,7 @@ public class ODocumentSchemalessBinarySerializationTest {
 
     @Override
     public boolean equals(Object obj) {
-      return Arrays.equals(bytes, ((Custom) obj).bytes);
+      return obj!= null && Arrays.equals(bytes, ((Custom) obj).bytes);
     }
   }
 
@@ -732,7 +732,7 @@ public class ODocumentSchemalessBinarySerializationTest {
 
     @Override
     public boolean equals(Object obj) {
-      return document.field("test").equals(((CustomDocument) obj).document.field("test"));
+      return obj!=null && document.field("test").equals(((CustomDocument) obj).document.field("test"));
     }
   }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
@@ -126,7 +126,7 @@ public class ODistributedWorker extends Thread {
 
       } catch (Throwable e) {
         ODistributedServerLog.error(this, getLocalNodeName(), senderNode, DIRECTION.IN,
-            "error on executing distributed request %d: %s", e, message.getId(), message != null ? message.getTask() : "-");
+            "error on executing distributed request %d: %s", e, message!=null? message.getId() : -1, message != null ? message.getTask() : "-");
       }
     }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastDistributedResponse.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastDistributedResponse.java
@@ -105,7 +105,7 @@ public class OHazelcastDistributedResponse implements ODistributedResponse, Exte
 
   @Override
   public String toString() {
-    return payload != null ? payload.toString() : null;
+    return payload != null ? payload.toString() : "null";
   }
 
 }

--- a/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
+++ b/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
@@ -367,7 +367,7 @@ public abstract class OChannelBinary extends OChannel {
   public OChannelBinary writeCollectionString(final Collection<String> iCollection) throws IOException {
     if (debug)
       OLogManager.instance().info(this, "%s - Writing strings (4+%d=%d items): %s", socket.getRemoteSocketAddress(),
-          iCollection != null ? iCollection.size() : 0, iCollection != null ? iCollection.size() + 4 : 4, iCollection.toString());
+          iCollection != null ? iCollection.size() : 0, iCollection != null ? iCollection.size() + 4 : 4, iCollection!=null? iCollection.toString():"null");
 
     updateMetricTransmittedBytes(OBinaryProtocol.SIZE_INT);
     if (iCollection == null)

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
@@ -17,6 +17,7 @@ import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -237,7 +238,7 @@ public class OrientEdge extends OrientElement implements Edge {
     if (rawElement == null && object instanceof OrientEdge) {
       final OrientEdge other = (OrientEdge) object;
       return vOut.equals(other.vOut) && vIn.equals(other.vIn)
-          && (label == null && other.label == null || label.equals(other.label));
+          && (Objects.equals(label, other.label));
     }
     return super.equals(object);
   }

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
@@ -416,8 +416,9 @@ public abstract class OrientElement implements Element, OSerializableStream, Ext
     final ORID myRID = getIdentity();
     final ORID otherRID = iOther.getIdentity();
 
-    if (myRID == null && otherRID == null)
-      return 0;
+    if (myRID == null && otherRID == null) return 0;
+    if (myRID == null) return -1;
+    if (otherRID == null) return 1;
 
     return myRID.compareTo(otherRID);
   }

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraphQuery.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraphQuery.java
@@ -165,12 +165,12 @@ public class OrientGraphQuery extends DefaultGraphQuery {
       text.append(orderBy);
       text.append(" " + orderByDir + " ");
     }
-    if (skip > 0 && skip < Long.MAX_VALUE) {
+    if (skip > 0 && skip < Integer.MAX_VALUE) {
       text.append(SKIP);
       text.append(skip);
     }
 
-    if (limit > 0 && limit < Long.MAX_VALUE) {
+    if (limit > 0 && limit < Integer.MAX_VALUE) {
       text.append(LIMIT);
       text.append(limit);
     }
@@ -226,7 +226,7 @@ public class OrientGraphQuery extends DefaultGraphQuery {
     if (fetchPlan != null)
       query.setFetchPlan(fetchPlan);
 
-    if (limit > 0 && limit < Long.MAX_VALUE)
+    if (limit > 0 && limit < Integer.MAX_VALUE)
       query.setLimit((int) limit);
 
     return new OrientElementIterable<Edge>(((OrientBaseGraph) graph), ((OrientBaseGraph) graph).getRawGraph().query(query));

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedConfiguration.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedConfiguration.java
@@ -442,9 +442,9 @@ public class ODistributedConfiguration {
         // CREATE IT
         cluster = createCluster(iClusterName);
 
-      final List<String> serverList = getOriginalServers(iClusterName);
+      List<String> serverList = getOriginalServers(iClusterName);
       if (serverList == null)
-        initClusterServers(cluster);
+    	  serverList = initClusterServers(cluster);
 
       if (!serverList.isEmpty() && serverList.get(0).equals(iServerName))
         // ALREADY MASTER

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedException.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedException.java
@@ -15,6 +15,8 @@
  */
 package com.orientechnologies.orient.server.distributed;
 
+import java.util.Objects;
+
 import com.orientechnologies.common.exception.OException;
 
 /**
@@ -46,6 +48,13 @@ public class ODistributedException extends OException {
     if (obj == null || !obj.getClass().equals(getClass()))
       return false;
 
-    return getMessage().equals(((ODistributedException) obj).getMessage());
+    return Objects.equals(getMessage(), ((ODistributedException) obj).getMessage());
   }
+
+  @Override
+  public int hashCode() {
+	return Objects.hashCode(getMessage());
+  }
+  
+  
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/OServerNetworkListener.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/OServerNetworkListener.java
@@ -71,7 +71,7 @@ public class OServerNetworkListener extends Thread {
       protocolVersion = iProtocol.newInstance().getVersion();
     } catch (Exception e) {
       OLogManager.instance().error(this, "Error on reading protocol version for %s", e, ONetworkProtocolException.class,
-          protocolType);
+          iProtocol);
     }
 
     listen(iHostName, iHostPortRange, iProtocolName);

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetDatabase.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetDatabase.java
@@ -142,7 +142,7 @@ public class OServerCommandGetDatabase extends OServerCommandGetConnect {
     ODatabaseDocumentTx db = null;
     try {
       if (urlParts.length > 2) {
-        server.getDatabasePool().acquire(urlParts[1], urlParts[2], urlParts[3]);
+        db = server.getDatabasePool().acquire(urlParts[1], urlParts[2], urlParts[3]);
       } else
         db = getProfiledDatabaseInstance(iRequest);
 

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetStaticContent.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetStaticContent.java
@@ -136,7 +136,7 @@ public class OServerCommandGetStaticContent extends OServerCommandConfigurableAb
       OLogManager.instance().error(this, "Error on loading resource %s", e, iRequest.url);
 
     } finally {
-      if (staticContent.is != null)
+      if (staticContent!=null && staticContent.is != null)
         try {
           staticContent.is.close();
         } catch (IOException e) {

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostImportRecords.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostImportRecords.java
@@ -63,8 +63,8 @@ public class OServerCommandPostImportRecords extends OServerCommandDocumentAbstr
         final Locale locale = urlParts.length > 6 ? new Locale(urlParts[6]) : Locale.getDefault();
 
         final BufferedReader reader = new BufferedReader(new StringReader(iRequest.content));
-        final String header = reader.readLine().trim();
-        if (header.length() == 0)
+        String header = reader.readLine();
+        if (header==null || (header=header.trim()).length() == 0)
           throw new InputMismatchException("Missing CSV file header");
 
         final List<String> columns = OStringSerializerHelper.smartSplit(header, separator);


### PR DESCRIPTION
Guys,

I run FindBug agains OrientDB code and found 100+ different bugs.
This PR contains fixes for some of them, which were considered by me safe.

But there are some additional thoughts:

ODatabaseCompare has multiple problems. Just take a look into method compareSchama().

Multiple usage of something like "new ArrayList<Map.Entry>(hashMap.entrySet())". That might lead to problems with data consistency, because according to JDK 1.6 Map implementations can reuse the same Entry object for iterations.

Multiple incorect handling of equal(). For example: OScriptGraphWrapper.equal():

``` java
public boolean equals(Object obj) {
    return graph.equals(obj);
  }
```

If you have time, I recommend to take a look into FindBug report too.

ATTENTION: tests are passing, but, please, take a look...
