### PR TITLE
orientdb-api.js: fix ODatabase.open()

### DIFF
--- a/server/src/site/js/orientdb-api.js
+++ b/server/src/site/js/orientdb-api.js
@@ -177,7 +177,7 @@ function ODatabase(databasePath) {
       					return xhr.setRequestHeader('Authorization', 'BASIC ' + btoa(userName+':'+userPass));
     			},
 			type : type,
-			url : this.urlPrefix + 'connect/' + this.encodedDatabaseName
+			url : this.urlPrefix + 'database/' + this.encodedDatabaseName
 					+ this.urlSuffix,
 			context : this,
 			username : userName,


### PR DESCRIPTION
ODatabase.open() made an ajax request for /connect/, but that doesn't return data (any more?). Requesting /database/ gets us the expected reply with the database info object.
