### PR TITLE
support customized cluster selection

### DIFF
--- a/core/src/main/resources/META-INF/services/com.orientechnologies.orient.core.metadata.schema.clusterselection.OClusterSelectionStrategy
+++ b/core/src/main/resources/META-INF/services/com.orientechnologies.orient.core.metadata.schema.clusterselection.OClusterSelectionStrategy
@@ -1,0 +1,4 @@
+
+com.orientechnologies.orient.core.metadata.schema.clusterselection.ORoundRobinClusterSelectionStrategy
+com.orientechnologies.orient.core.metadata.schema.clusterselection.ODefaultClusterSelectionStrategy
+com.orientechnologies.orient.core.metadata.schema.clusterselection.OBalancedClusterSelectionStrategy


### PR DESCRIPTION
According to the suggestion for pull request https://github.com/orientechnologies/orientdb/pull/3004, refactor the logic to inject customized strategies

In third part jar, create com.orientechnologies.orient.core.metadata.schema.clusterselection.OClusterSelectionStrategy
in META-INF/services, and add class path of the own implementation. 
