### PR TITLE
#2525 fix for detachAll so it supports cycles

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/object/OObjectLazyMultivalueElement.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/object/OObjectLazyMultivalueElement.java
@@ -16,6 +16,8 @@
  */
 package com.orientechnologies.orient.core.db.object;
 
+import java.util.Map;
+
 /**
  * @author luca.molino
  * 
@@ -24,7 +26,7 @@ public interface OObjectLazyMultivalueElement<T> {
 
   public void detach(boolean nonProxiedInstance);
 
-  public void detachAll(boolean nonProxiedInstance);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached);
 
   public T getNonOrientInstance();
 

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.object.db;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -298,7 +299,11 @@ public class OObjectDatabaseTx extends ODatabasePojoAbstract<Object> implements 
    * @return the object serialized or with detached data
    */
   public <RET> RET detachAll(final Object iPojo, boolean returnNonProxiedInstance) {
-    return (RET) OObjectEntitySerializer.detachAll(iPojo, this, returnNonProxiedInstance);
+    return detachAll(iPojo, returnNonProxiedInstance, new HashMap<Object, Object>());
+  }
+
+  protected <RET> RET detachAll(final Object iPojo, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached) {
+    return (RET) OObjectEntitySerializer.detachAll(iPojo, this, returnNonProxiedInstance, alreadyDetached);
   }
 
   public <RET> RET load(final Object iPojo, final String iFetchPlan, final boolean iIgnoreCache) {

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
@@ -420,21 +420,21 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
     }
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
-    convertAndDetachAll(nonProxiedInstance);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     if (converted || !convertToRecord)
       return;
 
     for (int i = 0; i < size(); ++i)
-      convertAndDetachAll(i, nonProxiedInstance);
+      convertAndDetachAll(i, nonProxiedInstance, alreadyDetached);
 
     converted = true;
   }
 
-  private void convertAndDetachAll(final int iIndex, boolean nonProxiedInstance) {
+  private void convertAndDetachAll(final int iIndex, boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     if (converted || !convertToRecord)
       return;
 
@@ -459,7 +459,7 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
       }
       o = OObjectEntityEnhancer.getInstance().getProxiedInstance(doc.getClassName(), getDatabase().getEntityManager(), doc,
           sourceRecord);
-      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance);
+      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached);
       super.set(iIndex, (TYPE) o);
     }
   }

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyMap.java
@@ -228,8 +228,8 @@ public class OObjectLazyMap<TYPE> extends HashMap<Object, Object> implements Ser
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
-    convertAndDetachAll(nonProxiedInstance);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
 
   }
 
@@ -255,13 +255,13 @@ public class OObjectLazyMap<TYPE> extends HashMap<Object, Object> implements Ser
     converted = true;
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     if (converted || !convertToRecord)
       return;
 
     for (java.util.Map.Entry<Object, OIdentifiable> e : underlying.entrySet()) {
       Object o = getDatabase().getUserObjectByRecord((ORecord) ((OIdentifiable) e.getValue()).getRecord(), null);
-      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance);
+      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached);
       super.put(e.getKey(), o);
     }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazySet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazySet.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import javassist.util.proxy.ProxyObject;
 
@@ -225,8 +226,8 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
-    convertAndDetachAll(nonProxiedInstance);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
   }
 
   @Override
@@ -252,7 +253,7 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
       if (e != null) {
         if (e instanceof ORID)
           add(database.getUserObjectByRecord(((ODatabaseDocument) getDatabase().getUnderlying()).load((ORID) e, fetchPlan),
-              fetchPlan));
+                  fetchPlan));
         else if (e instanceof ODocument)
           add(database.getUserObjectByRecord((ORecord) e, fetchPlan));
         else
@@ -284,7 +285,7 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
     converted = true;
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     if (converted || !convertToRecord)
       return;
 
@@ -295,11 +296,11 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
       if (e != null) {
         if (e instanceof ORID) {
           e = database.getUserObjectByRecord(((ODatabaseDocument) getDatabase().getUnderlying()).load((ORID) e, fetchPlan),
-              fetchPlan);
-          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance));
+                  fetchPlan);
+          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached));
         } else if (e instanceof ODocument) {
           e = database.getUserObjectByRecord((ORecord) e, fetchPlan);
-          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance));
+          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached));
         } else
           add((TYPE) e);
       }

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -195,14 +195,15 @@ public class OObjectEntitySerializer {
    *          and @Version fields it could procude data replication
    * @return the object serialized or with detached data
    */
-  public static <T> T detachAll(T o, ODatabaseObject db, boolean returnNonProxiedInstance) {
+  public static <T> T detachAll(T o, ODatabaseObject db, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached) {
     if (o instanceof Proxy) {
       OObjectProxyMethodHandler handler = (OObjectProxyMethodHandler) ((ProxyObject) o).getHandler();
       try {
         if (returnNonProxiedInstance) {
           o = getNonProxiedInstance(o);
         }
-        handler.detachAll(o, returnNonProxiedInstance);
+        alreadyDetached.put(handler.getDoc().hashCode(), o);
+        handler.detachAll(o, returnNonProxiedInstance, alreadyDetached);
       } catch (IllegalArgumentException e) {
         throw new OSerializationException("Error detaching object of class " + o.getClass(), e);
       } catch (IllegalAccessException e) {

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 
 import com.orientechnologies.orient.core.record.ORecord;
 
@@ -224,7 +225,7 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyMap.java
@@ -159,7 +159,7 @@ public class OObjectEnumLazyMap<TYPE extends Enum> extends HashMap<Object, Objec
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazySet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazySet.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import com.orientechnologies.orient.core.record.ORecord;
@@ -153,7 +154,7 @@ public class OObjectEnumLazySet<TYPE extends Enum> extends HashSet<TYPE> impleme
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerList.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.object.enhancement.OObjectEntitySerializer;
@@ -209,7 +210,7 @@ public class OObjectCustomSerializerList<TYPE> implements List<TYPE>, OObjectLaz
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerMap.java
@@ -166,7 +166,7 @@ public class OObjectCustomSerializerMap<TYPE> extends HashMap<Object, Object> im
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerSet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerSet.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import com.orientechnologies.orient.core.record.ORecord;
@@ -154,7 +155,7 @@ public class OObjectCustomSerializerSet<TYPE> extends HashSet<TYPE> implements O
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
     convertAll();
   }
 

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
@@ -43,6 +43,9 @@ import com.orientechnologies.orient.test.domain.business.Address;
 import com.orientechnologies.orient.test.domain.business.Child;
 import com.orientechnologies.orient.test.domain.business.City;
 import com.orientechnologies.orient.test.domain.business.Country;
+import com.orientechnologies.orient.test.domain.cycle.CycleChild;
+import com.orientechnologies.orient.test.domain.cycle.CycleParent;
+import com.orientechnologies.orient.test.domain.cycle.GrandChild;
 import com.orientechnologies.orient.test.domain.whiz.Profile;
 
 @Test(groups = { "object" })
@@ -739,4 +742,37 @@ public class ObjectDetachingTest extends ObjectDBBaseTest {
     database.delete(profile);
   }
 
+  public void testDetachAllWithCycles() {
+    database = new OObjectDatabaseTx(url).open("admin", "admin");
+    database.getEntityManager().registerEntityClasses("com.orientechnologies.orient.test.domain.cycle");
+
+    CycleParent parent = new CycleParent();
+    parent.setName("parent");
+    CycleChild cycleChild1 = new CycleChild();
+    cycleChild1.setParent(parent);
+    cycleChild1.setName("child1");
+    parent.getChildren().add(cycleChild1);
+    CycleChild cycleChild2 = new CycleChild();
+    cycleChild2.setName("child2");
+    cycleChild2.setParent(parent);
+    parent.getChildren().add(cycleChild2);
+    GrandChild grandChild = new GrandChild();
+    grandChild.setName("grandchild");
+    grandChild.setGrandParent(parent);
+    cycleChild1.getGrandChildren().add(grandChild);
+    CycleParent attached = database.save(parent);
+
+    CycleParent detachedParent = database.detachAll(attached, true);
+    Assert.assertEquals(detachedParent.getName(), parent.getName());
+    Assert.assertEquals(detachedParent.getChildren().getClass(), ArrayList.class);
+    CycleChild detachedCycleChild1 = detachedParent.getChildren().get(0);
+    CycleChild detachedCycleChild2 = detachedParent.getChildren().get(1);
+    Assert.assertEquals(detachedCycleChild1.getName(), cycleChild1.getName());
+    Assert.assertEquals(detachedCycleChild2.getName(), cycleChild2.getName());
+    Assert.assertEquals(detachedCycleChild1.getGrandChildren().getClass(), HashSet.class);
+    GrandChild detachedGrandChild = detachedCycleChild1.getGrandChildren().iterator().next();
+    Assert.assertEquals(detachedGrandChild.getName(), grandChild.getName());
+    Assert.assertSame(detachedGrandChild.getGrandParent(), detachedParent);
+
+  }
 }

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/CycleChild.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/CycleChild.java
@@ -1,0 +1,40 @@
+package com.orientechnologies.orient.test.domain.cycle;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Wouter de Vaal
+ */
+public class CycleChild {
+
+    private String name;
+
+    private CycleParent parent;
+
+    private Set<GrandChild> grandChildren = new HashSet<GrandChild>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CycleParent getParent() {
+        return parent;
+    }
+
+    public void setParent(CycleParent parent) {
+        this.parent = parent;
+    }
+
+    public Set<GrandChild> getGrandChildren() {
+        return grandChildren;
+    }
+
+    public void setGrandChildren(Set<GrandChild> grandChildren) {
+        this.grandChildren = grandChildren;
+    }
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/CycleParent.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/CycleParent.java
@@ -1,0 +1,30 @@
+package com.orientechnologies.orient.test.domain.cycle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Wouter de Vaal
+ */
+public class CycleParent {
+
+    private String name;
+
+    private List<CycleChild> children = new ArrayList<CycleChild>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<CycleChild> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<CycleChild> children) {
+        this.children = children;
+    }
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/GrandChild.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/cycle/GrandChild.java
@@ -1,0 +1,28 @@
+package com.orientechnologies.orient.test.domain.cycle;
+
+
+/**
+ * @author Wouter de Vaal
+ */
+public class GrandChild {
+
+    private String name;
+
+    private CycleParent grandParent;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CycleParent getGrandParent() {
+        return grandParent;
+    }
+
+    public void setGrandParent(CycleParent grandParent) {
+        this.grandParent = grandParent;
+    }
+}


### PR DESCRIPTION
I have made it so that the public api hasn't changed. Added a map that is carried along during a single detachAll call which tracks objects that have already been detached and reuses those. 

I have written a unit test to test it and I have already tried the code in my own setup and it looks like it is working fine.
