### PR TITLE
-fxied: issue with 'in' operator filter when array contains escaped sequence string

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/parser/OBaseParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OBaseParser.java
@@ -32,6 +32,7 @@ public abstract class OBaseParser {
   public String                   parserTextUpperCase;
 
   private transient StringBuilder parserLastWord      = new StringBuilder(256);
+  private transient int 		  parserEscapeSequnceCount  = 0;
   private transient int           parserCurrentPos    = 0;
   private transient int           parserPreviousPos   = 0;
   private transient char          parserLastSeparator = ' ';
@@ -181,6 +182,8 @@ public abstract class OBaseParser {
   public String parserGetLastWord() {
     return parserLastWord.toString();
   }
+  
+  public int getLastWordLength(){ return parserLastWord.length() + parserEscapeSequnceCount; }
 
   /**
    * Throws a syntax error exception.
@@ -327,6 +330,7 @@ public abstract class OBaseParser {
     parserPreviousPos = parserCurrentPos;
     parserSkipWhiteSpaces();
 
+    parserEscapeSequnceCount = 0;
     parserLastWord.setLength(0);
 
     final String[] processedWords = Arrays.copyOf(iCandidateWords, iCandidateWords.length);
@@ -479,6 +483,7 @@ public abstract class OBaseParser {
   protected void parserNextWord(final boolean iForceUpperCase, final String iSeparatorChars) {
     parserPreviousPos = parserCurrentPos;
     parserLastWord.setLength(0);
+    parserEscapeSequnceCount = 0;
 
     parserSkipWhiteSpaces();
     if (parserCurrentPos == -1)
@@ -533,8 +538,10 @@ public abstract class OBaseParser {
 								parserLastWord.append('\b');
 							else if(nextChar == 'f')
 								parserLastWord.append('\f');
-							else
-              	parserLastWord.append(nextChar);
+							else{
+								parserLastWord.append(nextChar);
+								parserEscapeSequnceCount++;
+							}
 
               parserCurrentPos++;
             }
@@ -580,6 +587,9 @@ public abstract class OBaseParser {
             openGraph--;
         }
 
+        if (escapePos != -1)
+        	parserEscapeSequnceCount++;
+        
         if (escapePos != parserCurrentPos)
           escapePos = -1;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLPredicate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLPredicate.java
@@ -281,7 +281,7 @@ public class OSQLPredicate extends OBaseParser implements OCommandPredicate {
         result[i] = subCondition;
       } else if (word.charAt(0) == OStringSerializerHelper.LIST_BEGIN) {
         // COLLECTION OF ELEMENTS
-        parserSetCurrentPosition(lastPosition - word.length());
+        parserSetCurrentPosition(lastPosition - getLastWordLength());
 
         final List<String> stringItems = new ArrayList<String>();
         parserSetCurrentPosition(OStringSerializerHelper.getCollection(parserText, parserGetCurrentPosition(), stringItems));


### PR DESCRIPTION
issue: when using 'IN' operator inside predicate when array contains escaped sequence string, the query failed, and query returns empty result set.

user case:
CREATE DATABASE remote:localhost/temp root 1234 memory graph
INSERT INTO cluster:default CONTENT { value:"\"" }
SELECT FROM cluster:default where value in ["\""]