### PR TITLE
-fxied: issue with 'in' operator filter when array contains string sequences with comma character or hex character

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/parser/OBaseParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OBaseParser.java
@@ -527,6 +527,7 @@ public abstract class OBaseParser {
 
             if (nextChar == 'u') {
               parserCurrentPos = OStringParser.readUnicode(text2Use, parserCurrentPos + 2, parserLastWord);
+              parserEscapeSequnceCount+=5;
             } else {
 							if (nextChar == 'n')
 								parserLastWord.append('\n');

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
@@ -544,7 +544,8 @@ public abstract class OStringSerializerHelper {
 
     final StringBuilder buffer = new StringBuilder(128);
 
-    boolean escape = false, insideQuote = false;
+    boolean escape = false;
+    char insideQuote = ' ';
     int currentPos, deep;
     int maxPos = iText.length() - 1;
     for (currentPos = openPos + 1, deep = 1; deep > 0; currentPos++) {
@@ -567,15 +568,15 @@ public abstract class OStringSerializerHelper {
         deep--;
       } else if (c == iCollectionSeparator) {
         // SEPARATOR
-        if (deep > 1 || insideQuote) {
+        if (deep > 1 || insideQuote != ' ') {
           buffer.append(c);
         } else {
           iCollection.add(buffer.toString().trim());
           buffer.setLength(0);
         }
       }
-      else if (!escape && (c == '"' || c == '\'')) {
-        insideQuote = !insideQuote;
+      else if (!escape && ((insideQuote == ' ' && (c == '"' || c == '\'')) || (insideQuote==c))) {
+        insideQuote = insideQuote == ' ' ? c : ' ';
         buffer.append(c);
       } else {
         // COLLECT

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
@@ -544,7 +544,7 @@ public abstract class OStringSerializerHelper {
 
     final StringBuilder buffer = new StringBuilder(128);
 
-    boolean escape = false;
+    boolean escape = false, insideQuote = false;
     int currentPos, deep;
     int maxPos = iText.length() - 1;
     for (currentPos = openPos + 1, deep = 1; deep > 0; currentPos++) {
@@ -567,12 +567,16 @@ public abstract class OStringSerializerHelper {
         deep--;
       } else if (c == iCollectionSeparator) {
         // SEPARATOR
-        if (deep > 1) {
+        if (deep > 1 || insideQuote) {
           buffer.append(c);
         } else {
           iCollection.add(buffer.toString().trim());
           buffer.setLength(0);
         }
+      }
+      else if (!escape && (c == '"' || c == '\'')) {
+        insideQuote = !insideQuote;
+        buffer.append(c);
       } else {
         // COLLECT
         if (!escape && c == '\\' && (currentPos + 1 <= maxPos)) {

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
@@ -1400,9 +1400,14 @@ public class ONetworkProtocolBinary extends OBinaryNetworkProtocolAbstract {
     beginResponse();
     try {
       final ORecordMetadata metadata = connection.database.getRecordMetadata(rid);
-      sendOk(clientTxId);
-      channel.writeRID(metadata.getRecordId());
-      channel.writeVersion(metadata.getRecordVersion());
+      if (metadata!=null) {
+        sendOk(clientTxId);
+        channel.writeRID(metadata.getRecordId());
+        channel.writeVersion(metadata.getRecordVersion());
+      }else
+      {
+        throw new ODatabaseException(String.format("Record metadata for RID: %s, Not found",rid));
+      }
     } finally {
       endResponse();
     }


### PR DESCRIPTION
Related to issue #3322.

Issue with the escaped \uxxxx and comma characters inside a string.

USE CASE:

INSERT INTO default CONTENT { value: "testing, command failure" }

SELECT FROM cluster:default
WHERE value IN [ "testing, command failure"]

SELECT FROM cluster:default
WHERE value IN ["testing\u002c command failure"]

both of them will return empty result. the parser fails, cause of looking for a first ',' encounter, 
causing to split prematurely moving to the next item, without testing if it inside valid string phrase.