### PR TITLE
Remove reference to pipes in graphdb

### DIFF
--- a/graphdb/pom.xml
+++ b/graphdb/pom.xml
@@ -100,13 +100,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop</groupId>
-            <artifactId>pipes</artifactId>
-            <version>${blueprints.version}</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.tinkerpop.gremlin</groupId>
             <artifactId>gremlin-java</artifactId>
             <version>${blueprints.version}</version>

--- a/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionShortestPath.java
+++ b/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionShortestPath.java
@@ -19,6 +19,7 @@
  */
 package com.orientechnologies.orient.graph.sql.functions;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,7 +40,6 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Vertex;
 import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
 import com.tinkerpop.blueprints.impls.orient.OrientVertex;
-import com.tinkerpop.pipes.util.structures.ArrayQueue;
 
 /**
  * Shortest path algorithm to find the shortest path from one node to another node in a directed graph.
@@ -89,7 +89,7 @@ public class OSQLFunctionShortestPath extends OSQLFunctionMathAbstract {
       if (iParams.length > 2)
         direction = Direction.valueOf(iParams[2].toString().toUpperCase());
 
-      final ArrayQueue<OrientVertex> queue = new ArrayQueue<OrientVertex>();
+      final ArrayDeque<OrientVertex> queue = new ArrayDeque<OrientVertex>();
       final Set<ORID> visited = new HashSet<ORID>();
       final Map<ORID, ORID> previouses = new HashMap<ORID, ORID>();
 


### PR DESCRIPTION
Not sure if the use of `com.tinkerpop.pipes.util.structures.ArrayQueue` was intentional here, as AFAIK you shouldn't need to have the pipes library on the classpath in order to use the graphdb (at least wrt. minimal functionality). I replaced its use with `ArrayDeque` since orientdb now builds against a minimum of JDK6.