### PR TITLE
Use $ORIENTDB_HOME to calculate where to change directories

### DIFF
--- a/graphdb/script/console.sh
+++ b/graphdb/script/console.sh
@@ -3,9 +3,6 @@
 # Copyright (c) Orient Technologies LTD (http://www.orientechnologies.com)
 #
 
-#set current working directory
-cd `dirname $0`
-
 # resolve links - $0 may be a softlink
 PRG="$0"
 
@@ -25,6 +22,7 @@ PRGDIR=`dirname "$PRG"`
 # Only set ORIENTDB_HOME if not already set
 [ -f "$ORIENTDB_HOME"/lib/orientdb-tools-@VERSION@.jar ] || ORIENTDB_HOME=`cd "$PRGDIR/.." ; pwd`
 export ORIENTDB_HOME
+cd "$ORIENTDB_HOME/bin"
 
 # Set JavaHome if it exists
 if [ -f "${JAVA_HOME}/bin/java" ]; then 

--- a/server/script/server.sh
+++ b/server/script/server.sh
@@ -28,8 +28,6 @@ echo "       \`\`        \`.                                                    
 echo "                 \`\`                                         www.orientdb.org "
 echo "                 \`                                    "
 
-cd `dirname $0`
-
 # resolve links - $0 may be a softlink
 PRG="$0"
 
@@ -49,6 +47,7 @@ PRGDIR=`dirname "$PRG"`
 # Only set ORIENTDB_HOME if not already set
 [ -f "$ORIENTDB_HOME"/bin/server.sh ] || ORIENTDB_HOME=`cd "$PRGDIR/.." ; pwd`
 export ORIENTDB_HOME
+cd "$ORIENTDB_HOME/bin"
 
 if [ ! -f "${CONFIG_FILE}" ]
 then


### PR DESCRIPTION
Change where directory is changed so that you can run server.sh and console.sh outside of the bin directory.

After this change, these commands should work:
```
./target/orientdb-community-2.0-SNAPSHOT/bin/server.sh
./target/orientdb-community-2.0-SNAPSHOT/bin/console.sh
```

... where previously you'd need to be in the 'bin' directory.

```
cd ./target/orientdb-community-2.0-SNAPSHOT/bin
./server.sh
./console.sh
```

NOTE: lots of other quoting issues in these scripts which could fail if the installation directory had spaces... may want to tidy these up generally.