### PR TITLE
Work around for NullPointerException in OpenJDK if no args

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorFunction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorFunction.java
@@ -87,6 +87,8 @@ public class OCommandExecutorFunction extends OCommandExecutorAbstract {
             int i = 0;
             for (Entry<Object, Object> arg : iArgs.entrySet())
               args[i++] = arg.getValue();
+          } else {
+        	  args = new Object[0];
           }
           result = invocableEngine.invokeFunction(parserText, args);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/schedule/OScheduler.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/schedule/OScheduler.java
@@ -181,6 +181,8 @@ public OFunction getFunctionSafe()
           int i = 0;
           for (Entry<Object, Object> arg : iArgs.entrySet())
             args[i++] = arg.getValue();
+        } else {
+        	args = new Object[0];
         }
         invocableEngine.invokeFunction(this.function.getName(), args);
       }


### PR DESCRIPTION
Guys,

There is a bug in OpenJDK: if arguments for JS function invokation were supplied as null (instead of new Object[0]) you will have NullPointerException. Everything is find on Oracle JDK in this case.

Please approve PR and release in your nearest hot-fix version.