### PR TITLE
Fix for #3644

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -231,7 +231,12 @@ public class OObjectEntitySerializer {
         if (returnNonProxiedInstance) {
           o = getNonProxiedInstance(o);
         }
-        alreadyDetached.put(handler.getDoc().getIdentity(), o);
+        ORID identity = handler.getDoc().getIdentity();
+          if (!alreadyDetached.containsKey(identity)){
+          alreadyDetached.put(identity, o);
+        } else if (returnNonProxiedInstance){
+          return (T) alreadyDetached.get(identity);
+        }
         handler.detachAll(o, returnNonProxiedInstance, alreadyDetached);
       } catch (IllegalArgumentException e) {
         throw new OSerializationException("Error detaching object of class " + o.getClass(), e);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
@@ -621,6 +621,8 @@ public class ObjectDetachingTest extends ObjectDBBaseTest {
 
     attach.children = new HashMap<String, Child>();
     attach.children.put("first", c);
+    attach.specialChild = c;
+    attach.specialChild2 = c;
 
     attach.enumList = new ArrayList<EnumTest>();
     attach.enumList.add(EnumTest.ENUM1);
@@ -684,6 +686,14 @@ public class ObjectDetachingTest extends ObjectDBBaseTest {
     Assert.assertTrue(loadedJavaObj.children.get("first") instanceof Child);
     Assert.assertTrue(!(loadedJavaObj.children.get("first") instanceof Proxy));
     Assert.assertEquals(loadedJavaObj.children.get("first").getName(), "Jesus");
+
+    Child cDetached = loadedJavaObj.children.get("first");
+    Assert.assertTrue(cDetached instanceof Child);
+    Assert.assertEquals(cDetached.getName(), "Jesus");
+    Assert.assertSame(loadedJavaObj.specialChild, loadedJavaObj.specialChild2);
+    Assert.assertEquals(cDetached, loadedJavaObj.specialChild);
+    Assert.assertSame(cDetached, loadedJavaObj.specialChild);
+    Assert.assertSame(cDetached, loadedJavaObj.specialChild2);
 
     Assert.assertEquals(loadedJavaObj.enumSet.size(), 2);
     it = loadedJavaObj.enumSet.iterator();

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/base/JavaAttachDetachTestClass.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/base/JavaAttachDetachTestClass.java
@@ -47,6 +47,8 @@ public class JavaAttachDetachTestClass {
   public ODocument             document;
   public ORecordBytes          byteArray;
   public String                name;
+  public Child                 specialChild;
+  public Child                 specialChild2;
   public Map<String, Child>    children     = new HashMap<String, Child>();
   public List<EnumTest>        enumList     = new ArrayList<EnumTest>();
   public Set<EnumTest>         enumSet      = new HashSet<EnumTest>();
@@ -114,6 +116,22 @@ public class JavaAttachDetachTestClass {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public Child getSpecialChild() {
+    return specialChild;
+  }
+
+  public void setSpecialChild(Child specialChild) {
+    this.specialChild = specialChild;
+  }
+
+  public Child getSpecialChild2() {
+      return specialChild;
+    }
+
+  public void setSpecialChild2(Child specialChild2) {
+    this.specialChild2 = specialChild2;
   }
 
   public Map<String, Child> getChildren() {


### PR DESCRIPTION
Have multiple refs to the same object always return the ame instance when detaching non-proxied

Extended unit test to try this case. All other tests still run smoothly. Tried it in our environment en looks good.

Candidate for 2.0.4 hotfix?