### PR TITLE
fix partial delete multi value index unexpected behavior

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMultiValues.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMultiValues.java
@@ -210,7 +210,10 @@ public abstract class OIndexMultiValues extends OIndexAbstract<Set<OIdentifiable
             return false;
           }
 
-          if (values.remove(value)) {
+          if (value == null) {
+            indexEngine.remove(key);
+          }
+          else if (values.remove(value)) {
             if (values.isEmpty())
               indexEngine.remove(key);
             else


### PR DESCRIPTION
manual index command, DELETE FROM index:<indexName> WHERE key = <key>
was failing on composite key, when rid wasn't specified.

expected behavior, to remove all values under specified (partial/full) key

Use case:
CREATE INDEX index:test notunique string,string
INSERT INTO index:test (key,rid) values (['test','me'],#1:1)
INSERT INTO index:test (key,rid) values (['test','me'],#1:2)

DELETE FROM index:test where key = ['test']
SELECT FROM index:test

expected return 1 row 
actual return 2 row

related to #2741