### PR TITLE
- make inner classes static (use little bit less memory & less prone to ...

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -23,6 +23,7 @@ import com.orientechnologies.common.concur.lock.OModificationOperationProhibited
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OIOException;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.client.remote.OStorageRemoteThreadLocal.OStorageRemoteSession;
 import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.Orient;
@@ -108,7 +109,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
   private int                           connectionRetryDelay;
   @Deprecated
   private int                           networkPoolCursor    = 0;
-  private OCluster[]                    clusters             = new OCluster[0];
+  private OCluster[]                    clusters             = OCommonConst.EMPTY_CLUSTER_ARRAY;
   private int                           defaultClusterId;
   @Deprecated
   private int                           minPool;
@@ -736,7 +737,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           final int positionsCount = network.readInt();
 
           if (positionsCount == 0) {
-            return new OPhysicalPosition[0];
+            return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
           } else {
             return readPhysicalPositions(network, positionsCount);
           }
@@ -772,7 +773,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           final int positionsCount = network.readInt();
 
           if (positionsCount == 0) {
-            return new OPhysicalPosition[0];
+            return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
           } else {
             return readPhysicalPositions(network, positionsCount);
           }
@@ -809,7 +810,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           final int positionsCount = network.readInt();
 
           if (positionsCount == 0) {
-            return new OPhysicalPosition[0];
+            return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
           } else {
             return readPhysicalPositions(network, positionsCount);
           }
@@ -847,7 +848,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
           final int positionsCount = network.readInt();
 
           if (positionsCount == 0) {
-            return new OPhysicalPosition[0];
+            return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
           } else {
             return readPhysicalPositions(network, positionsCount);
           }

--- a/core/src/main/java/com/orientechnologies/common/util/OCommonConst.java
+++ b/core/src/main/java/com/orientechnologies/common/util/OCommonConst.java
@@ -1,0 +1,50 @@
+/*
+  *
+  *  *  Copyright 2015 Orient Technologies LTD (info(at)orientechnologies.com)
+  *  *
+  *  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  *  you may not use this file except in compliance with the License.
+  *  *  You may obtain a copy of the License at
+  *  *
+  *  *       http://www.apache.org/licenses/LICENSE-2.0
+  *  *
+  *  *  Unless required by applicable law or agreed to in writing, software
+  *  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  *  See the License for the specific language governing permissions and
+  *  *  limitations under the License.
+  *  *
+  *  * For more information: http://www.orientechnologies.com
+  *
+  */
+package com.orientechnologies.common.util;
+
+import com.orientechnologies.orient.core.config.OStorageFileConfiguration;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.index.hashindex.local.OHashIndexBucket;
+import com.orientechnologies.orient.core.index.hashindex.local.cache.OPageDataVerificationError;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.core.storage.OCluster;
+import com.orientechnologies.orient.core.storage.OPhysicalPosition;
+
+public final class OCommonConst {
+
+
+    public static final long[] EMPTY_LONG_ARRAY = new long[0];
+    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    public static final char[] EMPTY_CHAR_ARRAY = new char[0];
+    public static final int[] EMPTY_INT_ARRAY = new int[0];
+    public static final OCluster[] EMPTY_CLUSTER_ARRAY = new OCluster[0];
+    public static final OIdentifiable[] EMPTY_IDENTIFIABLE_ARRAY = new OIdentifiable[0];
+    public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+    public static final OType[] EMPTY_TYPES_ARRAY = new OType[0];
+    public static final OPageDataVerificationError[] EMPTY_PAGE_DATA_VERIFICATION_ARRAY = new OPageDataVerificationError[0];
+    public static final OHashIndexBucket.Entry[] EMPTY_BUCKET_ENTRY_ARRAY = new OHashIndexBucket.Entry[0];
+    public static final OPhysicalPosition[] EMPTY_PHYSICAL_POSITIONS_ARRAY = new OPhysicalPosition[0];
+    public static final OStorageFileConfiguration[] EMPTY_FILE_CONFIGURATIONS_ARRAY = new OStorageFileConfiguration[0];
+
+
+
+    private OCommonConst() {
+    }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorFunction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorFunction.java
@@ -20,6 +20,7 @@
 package com.orientechnologies.orient.core.command.script;
 
 import com.orientechnologies.common.concur.resource.OPartitionedObjectPool;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.command.OCommandExecutorAbstract;
@@ -88,7 +89,7 @@ public class OCommandExecutorFunction extends OCommandExecutorAbstract {
             for (Entry<Object, Object> arg : iArgs.entrySet())
               args[i++] = arg.getValue();
           } else {
-        	  args = new Object[0];
+        	  args = OCommonConst.EMPTY_OBJECT_ARRAY;
           }
           result = invocableEngine.invokeFunction(parserText, args);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/command/script/OScriptDocumentDatabaseWrapper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/script/OScriptDocumentDatabaseWrapper.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.command.OBasicCommandContext;
 import com.orientechnologies.orient.core.db.ODatabase;
 import com.orientechnologies.orient.core.db.ODatabase.ATTRIBUTES;
@@ -90,7 +91,7 @@ public class OScriptDocumentDatabaseWrapper {
   public OIdentifiable[] query(final OSQLQuery iQuery, final Object... iParameters) {
     final List<OIdentifiable> res = database.query(iQuery, convertParameters(iParameters));
     if (res == null)
-      return new OIdentifiable[] {};
+      return OCommonConst.EMPTY_IDENTIFIABLE_ARRAY;
     return res.toArray(new OIdentifiable[res.size()]);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/command/traverse/OTraverseContext.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/traverse/OTraverseContext.java
@@ -127,7 +127,7 @@ public class OTraverseContext extends OBasicCommandContext {
     boolean isEmpty();
   }
 
-  private abstract class AbstractMemory implements Memory {
+  private abstract static class AbstractMemory implements Memory {
     protected Deque<OTraverseAbstractProcess<?>> deque = new ArrayDeque<OTraverseAbstractProcess<?>>();
 
     public AbstractMemory() {
@@ -164,7 +164,7 @@ public class OTraverseContext extends OBasicCommandContext {
     }
   }
 
-  private class StackMemory extends AbstractMemory {
+  private static class StackMemory extends AbstractMemory {
     public StackMemory() {
       super();
     }
@@ -179,7 +179,7 @@ public class OTraverseContext extends OBasicCommandContext {
     }
   }
 
-  private class QueueMemory extends AbstractMemory {
+  private static class QueueMemory extends AbstractMemory {
     public QueueMemory(Memory memory) {
       super(memory);
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/config/OStorageSegmentConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OStorageSegmentConfiguration.java
@@ -21,6 +21,8 @@ package com.orientechnologies.orient.core.config;
 
 import java.io.Serializable;
 
+import com.orientechnologies.common.util.OCommonConst;
+
 @SuppressWarnings("serial")
 public class OStorageSegmentConfiguration implements Serializable {
   public transient OStorageConfiguration root;
@@ -41,14 +43,14 @@ public class OStorageSegmentConfiguration implements Serializable {
   }
 
   public OStorageSegmentConfiguration() {
-    infoFiles = new OStorageFileConfiguration[0];
+    infoFiles = OCommonConst.EMPTY_FILE_CONFIGURATIONS_ARRAY;
   }
 
   public OStorageSegmentConfiguration(final OStorageConfiguration iRoot, final String iSegmentName, final int iId) {
     root = iRoot;
     name = iSegmentName;
     id = iId;
-    infoFiles = new OStorageFileConfiguration[0];
+    infoFiles = OCommonConst.EMPTY_FILE_CONFIGURATIONS_ARRAY;
   }
 
   public OStorageSegmentConfiguration(final OStorageConfiguration iRoot, final String iSegmentName, final int iId,
@@ -57,7 +59,7 @@ public class OStorageSegmentConfiguration implements Serializable {
     name = iSegmentName;
     id = iId;
     location = iDirectory;
-    infoFiles = new OStorageFileConfiguration[0];
+    infoFiles = OCommonConst.EMPTY_FILE_CONFIGURATIONS_ARRAY;
   }
 
   public void setRoot(OStorageConfiguration iRoot) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Callable;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.listener.OListenerManger;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.cache.OCacheLevelOneLocatorImpl;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
@@ -1744,7 +1745,7 @@ public class ODatabaseDocumentTx extends OListenerManger<ODatabaseListener> impl
         try {
           // SAVE IT
           boolean updateContent = ORecordInternal.isContentChanged(record);
-          byte[] content = (stream == null) ? new byte[0] : stream;
+          byte[] content = (stream == null) ? OCommonConst.EMPTY_BYTE_ARRAY : stream;
           byte recordType = ORecordInternal.getRecordType(record);
           final int modeIndex = mode.ordinal();
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/OClassTrigger.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/OClassTrigger.java
@@ -27,6 +27,7 @@ import javax.script.ScriptException;
 import com.orientechnologies.common.concur.resource.OPartitionedObjectPool;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.script.OCommandScriptException;
 import com.orientechnologies.orient.core.command.script.OScriptManager;
@@ -297,7 +298,7 @@ public class OClassTrigger extends ODocumentHookAbstract {
         }
         if (scriptEngine instanceof Invocable) {
           final Invocable invocableEngine = (Invocable) scriptEngine;
-          Object[] EMPTY = new Object[0];
+          Object[] EMPTY = OCommonConst.EMPTY_OBJECT_ARRAY;
           result = (String) invocableEngine.invokeFunction(func.getName(), EMPTY);
         }
       } catch (ScriptException e) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.WeakHashMap;
 
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.common.util.OResettable;
 import com.orientechnologies.common.util.OSizeable;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
@@ -47,7 +48,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
   private boolean                                                      contentWasChanged = false;
   private boolean                                                      deserialized      = true;
 
-  private Object[]                                                     entries           = {};
+  private Object[]                                                     entries           = OCommonConst.EMPTY_OBJECT_ARRAY;
   private int                                                          entriesLength     = 0;
 
   private boolean                                                      convertToRecord   = true;

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchPlan.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchPlan.java
@@ -32,7 +32,7 @@ public class OFetchPlan {
   final Map<String, OFetchPlanLevel> fetchPlan           = new HashMap<String, OFetchPlanLevel>();
   final Map<String, OFetchPlanLevel> fetchPlanStartsWith = new HashMap<String, OFetchPlanLevel>();
 
-  private class OFetchPlanLevel {
+  private static class OFetchPlanLevel {
     public int depthLevelFrom;
     public int depthLevelTo;
     public int level;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/OHashTableIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/OHashTableIndexEngine.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
@@ -232,7 +233,7 @@ public final class OHashTableIndexEngine<V> implements OIndexEngine<V> {
       {
         OHashIndexBucket.Entry<Object, V> firstEntry = hashTable.firstEntry();
         if (firstEntry == null)
-          entries = new OHashIndexBucket.Entry[0];
+          entries = OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
         else
           entries = hashTable.ceilingEntries(firstEntry.key);
 
@@ -315,7 +316,7 @@ public final class OHashTableIndexEngine<V> implements OIndexEngine<V> {
       {
         OHashIndexBucket.Entry<Object, V> lastEntry = hashTable.lastEntry();
         if (lastEntry == null)
-          entries = new OHashIndexBucket.Entry[0];
+          entries = OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
         else
           entries = hashTable.floorEntries(lastEntry.key);
 
@@ -395,7 +396,7 @@ public final class OHashTableIndexEngine<V> implements OIndexEngine<V> {
       {
         OHashIndexBucket.Entry<Object, V> firstEntry = hashTable.firstEntry();
         if (firstEntry == null)
-          entries = new OHashIndexBucket.Entry[0];
+          entries = OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
         else
           entries = hashTable.ceilingEntries(firstEntry.key);
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.core.index.hashindex.local;
 
 import com.orientechnologies.common.comparator.ODefaultComparator;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.index.OIndexException;
@@ -634,7 +635,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent {
         while (bucket.size() == 0 || comparator.compare(bucket.getKey(bucket.size() - 1), key) <= 0) {
           bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
           if (bucketPath == null)
-            return new OHashIndexBucket.Entry[0];
+            return OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
 
           diskCache.release(cacheEntry);
 
@@ -894,7 +895,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent {
         while (bucket.size() == 0) {
           bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
           if (bucketPath == null)
-            return new OHashIndexBucket.Entry[0];
+            return OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
 
           diskCache.release(cacheEntry);
           final long nextPointer = directory.getNodePointer(bucketPath.nodeIndex, bucketPath.itemIndex + bucketPath.hashMapOffset);
@@ -1034,7 +1035,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent {
         while (bucket.size() == 0 || comparator.compare(bucket.getKey(0), key) >= 0) {
           final BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
           if (prevBucketPath == null)
-            return new OHashIndexBucket.Entry[0];
+            return OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
 
           diskCache.release(cacheEntry);
 
@@ -1094,7 +1095,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent {
         while (bucket.size() == 0) {
           final BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
           if (prevBucketPath == null)
-            return new OHashIndexBucket.Entry[0];
+            return OCommonConst.EMPTY_BUCKET_ENTRY_ARRAY;
 
           diskCache.release(cacheEntry);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/ConcurrentLRUList.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/ConcurrentLRUList.java
@@ -301,7 +301,7 @@ public class ConcurrentLRUList implements LRUList {
     return new OCacheEntryIterator(tailReference.get());
   }
 
-  private class OCacheEntryIterator implements Iterator<OCacheEntry> {
+  private static class OCacheEntryIterator implements Iterator<OCacheEntry> {
 
     private ListNode current;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/OReadWriteDiskCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/OReadWriteDiskCache.java
@@ -960,7 +960,7 @@ public class OReadWriteDiskCache implements ODiskCache {
     }
   }
 
-  private class PinnedPage implements Comparable<PinnedPage> {
+  private static class PinnedPage implements Comparable<PinnedPage> {
     private final long fileId;
     private final long pageIndex;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/OWOWCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/cache/OWOWCache.java
@@ -978,7 +978,7 @@ public class OWOWCache {
     }
   }
 
-  private final class GroupKey implements Comparable<GroupKey> {
+  private static final class GroupKey implements Comparable<GroupKey> {
     private final long fileId;
     private final long groupIndex;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.metadata.schema;
 import com.orientechnologies.common.listener.OProgressListener;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.util.OArrays;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.annotation.OBeforeSerialization;
 import com.orientechnologies.orient.core.command.OCommandResultListener;
 import com.orientechnologies.orient.core.db.ODatabase;
@@ -98,7 +99,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
       abstractClass = true;
 
     if (abstractClass)
-      setPolymorphicClusterIds(new int[0]);
+      setPolymorphicClusterIds(OCommonConst.EMPTY_INT_ARRAY);
     else
       setPolymorphicClusterIds(iClusterIds);
 
@@ -679,7 +680,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     Arrays.sort(clusterIds);
 
     if (clusterIds.length == 1 && clusterIds[0] == -1)
-      setPolymorphicClusterIds(new int[0]);
+      setPolymorphicClusterIds(OCommonConst.EMPTY_INT_ARRAY);
     else
       setPolymorphicClusterIds(clusterIds);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/processor/block/OIterateBlock.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/processor/block/OIterateBlock.java
@@ -72,7 +72,7 @@ public class OIterateBlock extends OAbstractBlock {
     return NAME;
   }
 
-  protected class OIterateBlockIterable implements Iterable<Object> {
+  protected static class OIterateBlockIterable implements Iterable<Object> {
 
     private final Object[]        objects;
     private final OCommandContext context;

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import com.orientechnologies.common.collection.OMultiValue;
 import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.db.ODatabase;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
@@ -888,7 +889,7 @@ public class ODocument extends ORecordAbstract implements Iterable<Entry<String,
    * @return The Record instance itself giving a "fluent interface". Useful to call multiple methods in chain.
    */
   public ODocument field(final String iFieldName, Object iPropertyValue) {
-    return field(iFieldName, iPropertyValue, new OType[0]);
+    return field(iFieldName, iPropertyValue, OCommonConst.EMPTY_TYPES_ARRAY);
   }
 
   /**

--- a/core/src/main/java/com/orientechnologies/orient/core/schedule/OScheduler.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/schedule/OScheduler.java
@@ -25,12 +25,12 @@ import javax.script.*;
 
 import com.orientechnologies.common.concur.resource.OPartitionedObjectPool;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.script.OCommandScriptException;
 import com.orientechnologies.orient.core.command.script.OScriptManager;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.exception.OConfigurationException;
 import com.orientechnologies.orient.core.metadata.function.OFunction;
@@ -182,7 +182,7 @@ public OFunction getFunctionSafe()
           for (Entry<Object, Object> arg : iArgs.entrySet())
             args[i++] = arg.getValue();
         } else {
-        	args = new Object[0];
+        	args = OCommonConst.EMPTY_OBJECT_ARRAY;
         }
         invocableEngine.invokeFunction(this.function.getName(), args);
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/OBase64Utils.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/OBase64Utils.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.serialization;
 
 import com.orientechnologies.common.io.OIOException;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 
 /**
  * <p>
@@ -1541,7 +1542,7 @@ public class OBase64Utils {
     } // end if
 
     if (len == 0) {
-      return new byte[0];
+      return OCommonConst.EMPTY_BYTE_ARRAY;
     } else if (len < 4) {
       throw new IllegalArgumentException("Base64-encoded string must have at least four characters, but length specified was "
           + len);

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/binary/impl/index/OCompositeKeySerializer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/binary/impl/index/OCompositeKeySerializer.java
@@ -24,6 +24,7 @@ import com.orientechnologies.common.directmemory.ODirectMemoryPointer;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.ONullSerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.index.OCompositeKey;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.serialization.OBinaryProtocol;
@@ -287,7 +288,7 @@ public class OCompositeKeySerializer implements OBinarySerializer<OCompositeKey>
     if (hints != null && hints.length > 0)
       types = (OType[]) hints;
     else
-      types = new OType[0];
+      types = OCommonConst.EMPTY_TYPES_ARRAY;
     return types;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/binary/impl/index/OSimpleKeySerializer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/binary/impl/index/OSimpleKeySerializer.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.serialization.serializer.binary.impl.i
 
 import com.orientechnologies.common.directmemory.ODirectMemoryPointer;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.serialization.serializer.binary.OBinarySerializerFactory;
 
@@ -87,7 +88,7 @@ public class OSimpleKeySerializer<T extends Comparable<?>> implements OBinarySer
       if (hints != null && hints.length > 0)
         types = (OType[]) hints;
       else
-        types = new OType[0];
+        types = OCommonConst.EMPTY_TYPES_ARRAY;
 
       if (types.length > 0)
         type = types[0];

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.core.serialization.serializer.record.string
 
 import com.orientechnologies.common.collection.OMultiValue;
 import com.orientechnologies.common.parser.OStringParser;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.OUserObject2RecordHandler;
@@ -81,7 +82,7 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
     void visitItem(Object item);
   }
 
-  public class FormatSettings {
+  public static class FormatSettings {
     public boolean includeVer;
     public boolean includeType;
     public boolean includeId;
@@ -242,7 +243,7 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
           } else if (fieldName.equals("value") && !(iRecord instanceof ODocument)) {
             // RECORD VALUE(S)
             if ("null".equals(fieldValue))
-              iRecord.fromStream(new byte[] {});
+              iRecord.fromStream(OCommonConst.EMPTY_BYTE_ARRAY);
             else if (iRecord instanceof ORecordBytes) {
               // BYTES
               iRecord.fromStream(OBase64Utils.decode(fieldValueAsString));

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerAnyRuntime.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerAnyRuntime.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.exception.OSerializationException;
 import com.orientechnologies.orient.core.serialization.serializer.string.OStringSerializerAnyRuntime;
 
@@ -65,7 +66,7 @@ public class OStreamSerializerAnyRuntime implements OStreamSerializer {
 
 	public byte[] toStream(final Object iObject) throws IOException {
 		if (iObject == null)
-			return new byte[0];
+			return OCommonConst.EMPTY_BYTE_ARRAY;
 
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();
 		final ObjectOutputStream oos = new ObjectOutputStream(os);

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLSelect.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLSelect.java
@@ -115,7 +115,7 @@ public class OCommandExecutorSQLSelect extends OCommandExecutorSQLResultsetAbstr
 
   }
 
-  private final class IndexUsageLog {
+  private static final class IndexUsageLog {
     OIndex<?>        index;
     List<Object>     keyParams;
     OIndexDefinition indexDefinition;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilterItemAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilterItemAbstract.java
@@ -20,6 +20,7 @@
 package com.orientechnologies.orient.core.sql.filter;
 
 import com.orientechnologies.common.parser.OBaseParser;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.common.util.OPair;
 import com.orientechnologies.orient.core.collate.OCollate;
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -56,7 +57,7 @@ public abstract class OSQLFilterItemAbstract implements OSQLFilterItem {
 
   public OSQLFilterItemAbstract(final OBaseParser iQueryToParse, final String iText) {
     final List<String> parts = OStringSerializerHelper.smartSplit(iText, new char[] { '.', '[', ']' }, new boolean[] { false,
-        false, true }, new boolean[] { false, true, false }, 0, -1, false, true, false, false, new char[] {});
+        false, true }, new boolean[] { false, true, false }, 0, -1, false, true, false, false, OCommonConst.EMPTY_CHAR_ARRAY);
 
     setRoot(iQueryToParse, parts.get(0));
 

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLQuery.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLQuery.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.sql.query;
 import java.util.*;
 import java.util.Map.Entry;
 
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.command.OCommandRequestText;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
@@ -155,7 +156,7 @@ public abstract class OSQLQuery<T> extends OQueryAbstract<T> implements OCommand
   protected byte[] serializeQueryParameters(final Map<Object, Object> params) {
     if (params == null || params.size() == 0)
       // NO PARAMETER, JUST SEND 0
-      return new byte[0];
+      return OCommonConst.EMPTY_BYTE_ARRAY;
 
     final ODocument param = new ODocument();
     param.field("params", convertToRIDsIfPossible(params));

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -26,6 +26,7 @@ import com.orientechnologies.common.concur.lock.ONewLockManager;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.types.OModifiableBoolean;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandExecutor;
 import com.orientechnologies.orient.core.command.OCommandManager;
@@ -592,7 +593,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract impleme
     checkOpeness();
     try {
       return clusters.get(iClusterId) != null ? new long[] { clusters.get(iClusterId).getFirstPosition(),
-          clusters.get(iClusterId).getLastPosition() } : new long[0];
+          clusters.get(iClusterId).getLastPosition() } : OCommonConst.EMPTY_LONG_ARRAY;
 
     } catch (IOException ioe) {
       throw new OStorageException("Can not retrieve information about data range", ioe);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
@@ -20,6 +20,7 @@
 
 package com.orientechnologies.orient.core.storage.impl.local.paginated;
 
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.index.hashindex.local.cache.OCacheEntry;
@@ -240,7 +241,7 @@ public class OClusterPositionMap extends ODurableComponent {
     acquireSharedLock();
     try {
       if (clusterPosition == Long.MAX_VALUE)
-        return new long[0];
+        return OCommonConst.EMPTY_LONG_ARRAY;
 
       return ceilingPositions(clusterPosition + 1);
     } finally {
@@ -260,7 +261,7 @@ public class OClusterPositionMap extends ODurableComponent {
       final long filledUpTo = diskCache.getFilledUpTo(fileId);
 
       if (pageIndex >= filledUpTo)
-        return new long[0];
+        return OCommonConst.EMPTY_LONG_ARRAY;
 
       long[] result = null;
       do {
@@ -296,7 +297,7 @@ public class OClusterPositionMap extends ODurableComponent {
       } while (result == null && pageIndex < filledUpTo);
 
       if (result == null)
-        result = new long[0];
+        result = OCommonConst.EMPTY_LONG_ARRAY;
 
       return result;
     } finally {
@@ -308,7 +309,7 @@ public class OClusterPositionMap extends ODurableComponent {
     acquireSharedLock();
     try {
       if (clusterPosition == 0)
-        return new long[0];
+        return OCommonConst.EMPTY_LONG_ARRAY;
 
       return floorPositions(clusterPosition - 1);
     } finally {
@@ -320,7 +321,7 @@ public class OClusterPositionMap extends ODurableComponent {
     acquireSharedLock();
     try {
       if (clusterPosition < 0)
-        return new long[0];
+        return OCommonConst.EMPTY_LONG_ARRAY;
 
       long pageIndex = clusterPosition / OClusterPositionMapBucket.MAX_ENTRIES;
       int index = (int) (clusterPosition % OClusterPositionMapBucket.MAX_ENTRIES);
@@ -363,7 +364,7 @@ public class OClusterPositionMap extends ODurableComponent {
       } while (result == null && pageIndex >= 0);
 
       if (result == null)
-        result = new long[0];
+        result = OCommonConst.EMPTY_LONG_ARRAY;
 
       return result;
     } finally {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMapBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMapBucket.java
@@ -125,7 +125,7 @@ public class OClusterPositionMapBucket extends ODurablePage {
     return getByteValue(position) == FILLED;
   }
 
-  public class PositionEntry {
+  public static class PositionEntry {
     private final long pageIndex;
     private final int  recordPosition;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OOfflineCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OOfflineCluster.java
@@ -18,6 +18,7 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated;
 import java.io.IOException;
 
 import com.orientechnologies.common.concur.lock.OModificationLock;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.config.OStorageClusterConfiguration;
 import com.orientechnologies.orient.core.conflict.ORecordConflictStrategy;
 import com.orientechnologies.orient.core.id.ORID;
@@ -234,22 +235,22 @@ public class OOfflineCluster implements OCluster {
 
   @Override
   public OPhysicalPosition[] higherPositions(OPhysicalPosition position) throws IOException {
-    return new OPhysicalPosition[0];
+    return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
   }
 
   @Override
   public OPhysicalPosition[] ceilingPositions(OPhysicalPosition position) throws IOException {
-    return new OPhysicalPosition[0];
+    return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
   }
 
   @Override
   public OPhysicalPosition[] lowerPositions(OPhysicalPosition position) throws IOException {
-    return new OPhysicalPosition[0];
+    return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
   }
 
   @Override
   public OPhysicalPosition[] floorPositions(OPhysicalPosition position) throws IOException {
-    return new OPhysicalPosition[0];
+    return OCommonConst.EMPTY_PHYSICAL_POSITIONS_ARRAY;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
@@ -21,6 +21,7 @@
 package com.orientechnologies.orient.core.storage.impl.memory;
 
 import com.orientechnologies.common.directmemory.ODirectMemoryPointer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.index.hashindex.local.cache.*;
@@ -242,7 +243,7 @@ public class ODirectMemoryOnlyDiskCache implements ODiskCache {
 
   @Override
   public OPageDataVerificationError[] checkStoredPages(OCommandOutputListener commandOutputListener) {
-    return new OPageDataVerificationError[0];
+    return OCommonConst.EMPTY_PAGE_DATA_VERIFICATION_ARRAY;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryStorage.java
@@ -20,6 +20,7 @@
 
 package com.orientechnologies.orient.core.storage.impl.memory;
 
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabase;
@@ -67,7 +68,7 @@ public class ODirectMemoryStorage extends OAbstractPaginatedStorage {
   protected void postCreateSteps() {
 		ORecordId recordId = new ORecordId();
 		recordId.clusterId = 0;
-    createRecord(recordId, new byte[0], new OSimpleVersion(), ORecordBytes.RECORD_TYPE,
+    createRecord(recordId, OCommonConst.EMPTY_BYTE_ARRAY, new OSimpleVersion(), ORecordBytes.RECORD_TYPE,
         ODatabase.OPERATION_MODE.SYNCHRONOUS.ordinal(), null);
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.object.db;
 
 import com.orientechnologies.common.collection.OMultiValue;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.conflict.ORecordConflictStrategy;
@@ -110,7 +111,7 @@ public class OObjectDatabaseTx extends ODatabasePojoAbstract<Object> implements 
   }
 
   public <T> T newInstance(final Class<T> iType) {
-    return (T) newInstance(iType.getSimpleName(), null, new Object[0]);
+    return (T) newInstance(iType.getSimpleName(), null, OCommonConst.EMPTY_OBJECT_ARRAY);
   }
 
   public <T> T newInstance(final Class<T> iType, Object... iArgs) {
@@ -118,7 +119,7 @@ public class OObjectDatabaseTx extends ODatabasePojoAbstract<Object> implements 
   }
 
   public <RET> RET newInstance(String iClassName) {
-    return (RET) newInstance(iClassName, null, new Object[0]);
+    return (RET) newInstance(iClassName, null, OCommonConst.EMPTY_OBJECT_ARRAY);
   }
 
   @Override

--- a/server/src/main/java/com/orientechnologies/orient/server/config/OServerConfiguration.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/config/OServerConfiguration.java
@@ -30,7 +30,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class OServerConfiguration {
   public static final String               FILE_NAME            = "server-config.xml";
   // private static final String HEADER = "OrientDB Server configuration";
-
+  public static final OServerStorageConfiguration[] EMPTY_CONFIG_ARRAY = new OServerStorageConfiguration[0];
   @XmlTransient
   public String                            location;
 
@@ -76,7 +76,7 @@ public class OServerConfiguration {
   public OServerConfiguration(OServerConfigurationLoaderXml iFactory) {
     location = FILE_NAME;
     network = new OServerNetworkConfiguration(iFactory);
-    storages = new OServerStorageConfiguration[0];
+    storages = EMPTY_CONFIG_ARRAY;
     security = new OServerSecurityConfiguration(iFactory);
   }
 

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
@@ -40,6 +40,7 @@ import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.common.serialization.types.OByteSerializer;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.ONullSerializer;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.client.remote.OCollectionNetworkSerializer;
 import com.orientechnologies.orient.client.remote.OEngineRemote;
 import com.orientechnologies.orient.core.OConstants;
@@ -664,7 +665,7 @@ public class ONetworkProtocolBinary extends OBinaryNetworkProtocolAbstract {
             byte[] token = tokenHandler.getSignedBinaryToken(connection.database, connection.database.getUser(), connection.data);
             channel.writeBytes(token);
           } else
-            channel.writeBytes(new byte[] {});
+            channel.writeBytes(OCommonConst.EMPTY_BYTE_ARRAY);
         }
 
         sendDatabaseInformation();
@@ -701,7 +702,7 @@ public class ONetworkProtocolBinary extends OBinaryNetworkProtocolAbstract {
         if (Boolean.TRUE.equals(tokenBased)) {
           token = tokenHandler.getSignedBinaryToken(null, null, connection.data);
         } else
-          token = new byte[] {};
+          token = OCommonConst.EMPTY_BYTE_ARRAY;
         channel.writeBytes(token);
       }
 
@@ -1752,7 +1753,7 @@ public class ONetworkProtocolBinary extends OBinaryNetworkProtocolAbstract {
       OLogManager.instance().warn(this, "Can't serialize an exception object", e);
 
       // Write empty stream for binary compatibility
-      channel.writeBytes(new byte[0]);
+      channel.writeBytes(OCommonConst.EMPTY_BYTE_ARRAY);
     }
   }
 

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostImportDatabase.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostImportDatabase.java
@@ -20,6 +20,7 @@ import java.io.StringWriter;
 import java.util.HashMap;
 
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.tool.ODatabaseImport;
@@ -104,6 +105,6 @@ public class OServerCommandPostImportDatabase extends OHttpMultipartRequestComma
   @Override
   public void onMessage(String iText) {
     final String msg = iText.startsWith("\n") ? iText.substring(1) : iText;
-    OLogManager.instance().info(this, msg, new Object[0]);
+    OLogManager.instance().info(this, msg, OCommonConst.EMPTY_OBJECT_ARRAY);
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/token/OrientTokenHandler.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/token/OrientTokenHandler.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import javax.crypto.Mac;
 
 import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.security.OSecurityUser;
@@ -267,7 +268,7 @@ public class OrientTokenHandler extends OServerPluginAbstract implements OTokenH
       final long currTime = System.currentTimeMillis();
       token.setExpiry(currTime + expiryMinutes);
     }
-    return new byte[] {};
+    return OCommonConst.EMPTY_BYTE_ARRAY;
   }
 
   public long getSessionInMills() {


### PR DESCRIPTION
...memory leaks)

- do not allocate zero-length arrays
(cherry picked from commit 71e29b3)