### PR TITLE
No restriction on reserved keywords ('increment') ?

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -65,6 +65,10 @@ import java.util.*;
 public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   private static final long serialVersionUID        = 1L;
   private static final int  NOT_EXISTENT_CLUSTER_ID = -1;
+  public static final Set<String> RESERVED_KEYWORDS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+    new String[] { "increment" }
+  )));
+
   final OSchemaShared owner;
   private final Map<String, OProperty> properties       = new HashMap<String, OProperty>();
   private       int                    defaultClusterId = NOT_EXISTENT_CLUSTER_ID;
@@ -1974,6 +1978,10 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
 
     if (getDatabase().getTransaction().isActive())
       throw new OSchemaException("Cannot create property '" + propertyName + "' inside a transaction");
+
+    if (RESERVED_KEYWORDS.contains(propertyName.trim().toLowerCase())) {
+      throw new OSchemaException("Cannot create property '" + propertyName + "'; Reserved keywords");
+    }
 
     final ODatabaseDocumentInternal database = getDatabase();
     database.checkSecurity(ORule.ResourceGeneric.SCHEMA, ORole.PERMISSION_UPDATE);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ReservedKeywordsPropertyTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ReservedKeywordsPropertyTest.java
@@ -1,0 +1,47 @@
+package com.orientechnologies.orient.test.database.auto;
+
+import com.orientechnologies.orient.core.exception.OSchemaException;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OClassImpl;
+import com.orientechnologies.orient.core.metadata.schema.OSchema;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import org.testng.Assert;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Matan Shukry (matanshukry@gmail.com)
+ * @since 3/5/2015
+ */
+public class ReservedKeywordsPropertyTest extends DocumentDBBaseTest {
+  private final static String CLASS_NAME = "testClass";
+
+  @Parameters(value = "url")
+  public ReservedKeywordsPropertyTest(@Optional String url) {
+    super(url);
+  }
+
+  @Test
+  public void trivialTest() {
+    OSchema schema = database.getMetadata().getSchema();
+    if (schema.existsClass(CLASS_NAME)) {
+      schema.dropClass(CLASS_NAME);
+    }
+
+    OClass clz = schema.createClass(CLASS_NAME);
+    for (String keyword : OClassImpl.RESERVED_KEYWORDS) {
+      try {
+        clz.createProperty(keyword, OType.LONG);
+      } catch (OSchemaException ex) {
+        // Good
+      } catch (Throwable throwable) {
+        throwable.printStackTrace();
+        Assert.assertTrue(false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
It seems nothing stops you from using a reserved keywords on a field name.
At start this may seems fine (although design issues may come up), but it does seem to make issues;
e.g. When trying to create a property with name 'increment', you'll get an exception.

I tracked it down to the parser for a like:
SELECT FROM <class> WHERE <property>.type() not in [..] and <property> not null

which when <property> is 'increment', throws an exception.

This pull request contains a test for creating reserved keywords, and fix to throw an exception if one tries to create a property with a reserved keyword.