### PR TITLE
Warnings public constructors

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/db/ODatabaseHelper.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/db/ODatabaseHelper.java
@@ -161,4 +161,7 @@ public class ODatabaseHelper {
               + new File(".").getAbsolutePath());
     return file;
   }
+
+  private ODatabaseHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
+++ b/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
@@ -697,4 +697,7 @@ public class OMultiValue {
 
     return -1;
   }
+
+  private OMultiValue() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/hash/OMurmurHash3.java
+++ b/core/src/main/java/com/orientechnologies/common/hash/OMurmurHash3.java
@@ -143,4 +143,7 @@ public class OMurmurHash3 {
 
     return state.h1;
   }
+
+  private OMurmurHash3() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/io/OFileUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OFileUtils.java
@@ -203,4 +203,7 @@ public class OFileUtils {
 
     return OFileUtilsJava7.delete(file);
   }
+
+  private OFileUtils() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/io/OFileUtilsJava7.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OFileUtilsJava7.java
@@ -44,4 +44,7 @@ public class OFileUtilsJava7 {
 			return false;
 		}
 	}
+
+  private OFileUtilsJava7() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
@@ -283,4 +283,7 @@ public class OIOUtils {
     }
     return isLong;
   }
+
+  private OIOUtils() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/io/OUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OUtils.java
@@ -32,4 +32,7 @@ public class OUtils {
   public static String camelCase(final String iText) {
     return Character.toUpperCase(iText.charAt(0)) + iText.substring(1);
   }
+
+  private OUtils() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
@@ -394,4 +394,7 @@ public class OStringParser {
 
     return iText.substring(0, iToFind.length()).equalsIgnoreCase(iToFind);
   }
+
+  private OStringParser() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/parser/OVariableParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OVariableParser.java
@@ -66,4 +66,7 @@ public class OVariableParser {
 
     return resolved;
   }
+
+  private OVariableParser() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/reflection/OReflectionHelper.java
+++ b/core/src/main/java/com/orientechnologies/common/reflection/OReflectionHelper.java
@@ -243,4 +243,7 @@ public class OReflectionHelper {
       return true;
     return false;
   }
+
+  private OReflectionHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/serialization/OBinaryConverterFactory.java
+++ b/core/src/main/java/com/orientechnologies/common/serialization/OBinaryConverterFactory.java
@@ -50,4 +50,7 @@ public class OBinaryConverterFactory {
 
     return OSafeBinaryConverter.INSTANCE;
   }
+
+  private OBinaryConverterFactory() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/util/OArrays.java
+++ b/core/src/main/java/com/orientechnologies/common/util/OArrays.java
@@ -109,4 +109,7 @@ public class OArrays {
     return hash;
   }
 
+  private OArrays() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/common/util/OByteBufferUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/util/OByteBufferUtils.java
@@ -156,4 +156,7 @@ public class OByteBufferUtils {
       buffer1.put((byte) (iValue >> SIZE_OF_BYTE_IN_BITS * (SIZE_OF_LONG - i - j - 1)));
     }
   }
+
+  private OByteBufferUtils() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/util/OClassLoaderHelper.java
+++ b/core/src/main/java/com/orientechnologies/common/util/OClassLoaderHelper.java
@@ -56,4 +56,7 @@ public class OClassLoaderHelper {
     }
   }
 
+  private OClassLoaderHelper() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/common/util/OCollections.java
+++ b/core/src/main/java/com/orientechnologies/common/util/OCollections.java
@@ -75,4 +75,7 @@ public class OCollections {
     builder.append(']');
     return builder.toString();
   }
+
+  private OCollections() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/nio/MemoryLocker.java
+++ b/core/src/main/java/com/orientechnologies/nio/MemoryLocker.java
@@ -89,4 +89,7 @@ public class MemoryLocker {
           System.getProperty("os.name"));
     }
   }
+
+  private MemoryLocker() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/OConstants.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/OConstants.java
@@ -46,4 +46,7 @@ public class OConstants {
 
     return buildNumber;
   }
+
+  private OConstants() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorUtility.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/command/script/OCommandExecutorUtility.java
@@ -67,4 +67,7 @@ public class OCommandExecutorUtility {
     } catch (Exception e) {}
     return result;
   }
+
+  private OCommandExecutorUtility() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/compression/impl/OZIPCompressionUtil.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/compression/impl/OZIPCompressionUtil.java
@@ -168,4 +168,7 @@ public class OZIPCompressionUtil {
     }
     return total;
   }
+
+  private OZIPCompressionUtil() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ORecordMultiValueHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ORecordMultiValueHelper.java
@@ -67,4 +67,7 @@ public class ORecordMultiValueHelper {
 		iMultivalue.setAutoConvertToRecord(previousAutoConvertSetting);
 		return result;
 	}
+
+  private ORecordMultiValueHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
@@ -557,4 +557,7 @@ public class OFetchHelper {
   protected static void removeParsedFromMap(final Map<ORID, Integer> parsedRecords, OIdentifiable d) {
     parsedRecords.remove(d.getIdentity());
   }
+
+  private OFetchHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -93,6 +93,9 @@ public abstract class OIndexAbstract<T> implements OIndexInternal<T> {
 
   protected static final class RemovedValue {
     public static final RemovedValue INSTANCE = new RemovedValue();
+
+    private RemovedValue() {
+    }
   }
 
   protected static final class IndexTxSnapshot {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexDefinitionFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexDefinitionFactory.java
@@ -192,4 +192,7 @@ public class OIndexDefinitionFactory {
     else
       return fieldName;
   }
+
+  private OIndexDefinitionFactory() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/security/ODatabaseSecurityResources.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/security/ODatabaseSecurityResources.java
@@ -40,4 +40,7 @@ public class ODatabaseSecurityResources {
   public final static String BYPASS_RESTRICTED = "database.bypassRestricted";
   public final static String RECORD_HOOK       = "database.hook.record";
   public final static String SERVER_ADMIN      = "server.admin";
+
+  private ODatabaseSecurityResources() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/query/OQueryHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/query/OQueryHelper.java
@@ -65,4 +65,7 @@ public class OQueryHelper {
 
 		return false;
 	}
+
+  private OQueryHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordListenerManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordListenerManager.java
@@ -30,5 +30,8 @@ public class ORecordListenerManager {
     record.removeListener(listener);
   }
 
+  private ORecordListenerManager() {
+  }
+
   
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/DirtyFinder.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/DirtyFinder.java
@@ -59,4 +59,7 @@ public class DirtyFinder {
 
   }
 
+  private DirtyFinder() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentHelper.java
@@ -1398,4 +1398,7 @@ public class ODocumentHelper {
     ODatabaseRecordThreadLocal.INSTANCE.set(databaseRecord);
     return function.call();
   }
+
+  private ODocumentHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentInternal.java
@@ -59,4 +59,7 @@ public class ODocumentInternal {
     oDocument.fillClassIfNeed(className);
   }
 
+  private ODocumentInternal() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/OBinaryProtocol.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/OBinaryProtocol.java
@@ -318,4 +318,7 @@ public class OBinaryProtocol {
   public static char bytes2char(final byte[] b, final int offset) {
     return (char) ((b[offset] << 8) + (b[offset + 1] & 0xff));
   }
+
+  private OBinaryProtocol() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/ONetworkThreadLocalSerializer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/ONetworkThreadLocalSerializer.java
@@ -51,4 +51,7 @@ public class ONetworkThreadLocalSerializer {
       }
     });
   }
+
+  private ONetworkThreadLocalSerializer() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OStringSerializerHelper.java
@@ -937,4 +937,7 @@ public abstract class OStringSerializerHelper {
     }
     return lowest;
   }
+
+  private OStringSerializerHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OVarIntSerializer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OVarIntSerializer.java
@@ -132,4 +132,7 @@ public class OVarIntSerializer {
     return value | (b << i);
   }
 
+  private OVarIntSerializer() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerFactory.java
@@ -61,4 +61,7 @@ public class OStreamSerializerFactory {
       throw new OConfigurationException("Error on retrieving of Stream Serializer '" + iName + "'", e);
     }
   }
+
+  private OStreamSerializerFactory() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/stream/OStreamSerializerHelper.java
@@ -73,4 +73,7 @@ public class OStreamSerializerHelper {
 
 		return cls;
 	}
+
+  private OStreamSerializerHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OFindReferenceHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OFindReferenceHelper.java
@@ -162,4 +162,7 @@ public class OFindReferenceHelper {
     if (iSourceRIDs.contains(value.getIdentity()))
       map.get(value.getIdentity()).add(iRootObject.getIdentity());
   }
+
+  private OFindReferenceHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OSQLHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OSQLHelper.java
@@ -343,4 +343,7 @@ public class OSQLHelper {
     }
     return iDocument;
   }
+
+  private OSQLHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
@@ -27,4 +27,7 @@ public class OTransactionInternal {
     iTx.status = iStatus;
   }
 
+  private OTransactionInternal() {
+  }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/util/ODateHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/util/ODateHelper.java
@@ -80,4 +80,7 @@ public class ODateHelper {
   public static Date now() {
     return getDatabaseCalendar().getTime();
   }
+
+  private ODateHelper() {
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/util/OHostInfo.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/util/OHostInfo.java
@@ -52,4 +52,7 @@ public class OHostInfo {
     throw new IllegalStateException("Node id is possible to generate only on machine which have at least"
         + " one network interface with mac address.");
   }
+
+  private OHostInfo() {
+  }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/compression/impl/AbstractCompressionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/compression/impl/AbstractCompressionTest.java
@@ -35,4 +35,7 @@ public abstract class AbstractCompressionTest {
     System.out.println("Compression/Decompression test against " + name + " took: " + (System.currentTimeMillis() - seed)
         + "ms, total byte size: " + compressedSize);
   }
+
+  protected AbstractCompressionTest() {
+  }
 }

--- a/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryProtocol.java
+++ b/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryProtocol.java
@@ -139,4 +139,7 @@ public class OChannelBinaryProtocol {
       return record;
     }
   }
+
+  private OChannelBinaryProtocol() {
+  }
 }

--- a/graphdb/src/test/java/com/orientechnologies/orient/graph/GraphNoTxAbstractTest.java
+++ b/graphdb/src/test/java/com/orientechnologies/orient/graph/GraphNoTxAbstractTest.java
@@ -75,4 +75,7 @@ public abstract class GraphNoTxAbstractTest {
   public static void afterClass() throws Exception {
     graph.shutdown();
   }
+
+  protected GraphNoTxAbstractTest() {
+  }
 }

--- a/graphdb/src/test/java/com/orientechnologies/orient/graph/GraphTxAbstractTest.java
+++ b/graphdb/src/test/java/com/orientechnologies/orient/graph/GraphTxAbstractTest.java
@@ -77,4 +77,7 @@ public abstract class GraphTxAbstractTest {
     graph = null;
   }
 
+  protected GraphTxAbstractTest() {
+  }
+
 }

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OLazyCollectionUtil.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OLazyCollectionUtil.java
@@ -21,4 +21,7 @@ public class OLazyCollectionUtil {
     }
     throw new IllegalStateException("Current database not of expected type");
   }
+
+  private OLazyCollectionUtil() {
+  }
 }

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -1347,4 +1347,7 @@ public class OObjectEntitySerializer {
     return isEmbeddedField(f.getDeclaringClass(), f.getName());
   }
 
+  private OObjectEntitySerializer() {
+  }
+
 }

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectSerializerHelper.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectSerializerHelper.java
@@ -1140,4 +1140,7 @@ public class OObjectSerializerHelper {
     }
     return null;
   }
+
+  private OObjectSerializerHelper() {
+  }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/ShutdownHelper.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/ShutdownHelper.java
@@ -33,4 +33,7 @@ public class ShutdownHelper {
           + "), code: " + code);
     }
   }
+
+  private ShutdownHelper() {
+  }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedServerLog.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedServerLog.java
@@ -122,4 +122,7 @@ public class ODistributedServerLog {
 
     return message.toString();
   }
+
+  private ODistributedServerLog() {
+  }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpUtils.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/OHttpUtils.java
@@ -132,4 +132,7 @@ public class OHttpUtils {
     return iCurrentUrl.startsWith("/") ? iCurrentUrl.substring(iCurrentUrl.indexOf('/', 1)) : iCurrentUrl.substring(iCurrentUrl
         .indexOf("/"));
   }
+
+  private OHttpUtils() {
+  }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/multipart/OHttpMultipartHelper.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/multipart/OHttpMultipartHelper.java
@@ -59,4 +59,7 @@ public class OHttpMultipartHelper {
     return false;
   }
 
+  private OHttpMultipartHelper() {
+  }
+
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/plugin/OServerPluginHelper.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/plugin/OServerPluginHelper.java
@@ -79,4 +79,7 @@ public class OServerPluginHelper {
       }
   }
 
+  protected OServerPluginHelper() {
+  }
+
 }

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/base/OrientTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/base/OrientTest.java
@@ -25,7 +25,7 @@ public class OrientTest {
 	protected static String	url;
 
 	@Parameters(value = "url")
-	public OrientTest(String iURL) {
+	private OrientTest(String iURL) {
 		url = iURL;
 	}
 


### PR DESCRIPTION
Hiding constructors in helper classes is more elegant and avoids compiler warnings. Providing explicit constructors with minimal visibility makes detection in architecture and abstraction more easy.