### PR TITLE
the ${0/%dserver.sh/server.sh} is a bashism, not sh

### DIFF
--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) Orient Technologies LTD (http://www.orientechnologies.com)
 #


### PR DESCRIPTION
fails with
```
 % ./bin/dserver.sh                                                                                                                                                                                                                   23:48:28
./bin/dserver.sh: 5: ./bin/dserver.sh: Bad substitution
```
With bash it's splendid.