### PR TITLE
Feature/correct history location

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/console/TTYConsoleReader.java
+++ b/core/src/main/java/com/orientechnologies/common/console/TTYConsoleReader.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 public class TTYConsoleReader implements OConsoleReader {
 
-  private static final String   HISTORY_FILE_NAME   = ".orientdb_history";
+  private static final String   HISTORY_FILE_NAME   = System.getenv("HOME").append("/.orientdb_history")  ;
   public static int             END_CHAR            = 70;
   public static int             BEGIN_CHAR          = 72;
   public static int             DEL_CHAR            = 126;

--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) Orient Technologies LTD (http://www.orientechnologies.com)
 #

--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) Orient Technologies LTD (http://www.orientechnologies.com)
 #

--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -2,4 +2,4 @@
 #
 # Copyright (c) Orient Technologies LTD (http://www.orientechnologies.com)
 #
-${0/%dserver.sh/server.sh} -Ddistributed=true $*
+exec ${0/%dserver.sh/server.sh} -Ddistributed=true $*


### PR DESCRIPTION
without the exec it's forked by sh and sending a term to the sh parent does not send a term to the running java process. This corrects that so it can be properly supervised by systemd, runit, daemontools, etc.