### PR TITLE
Added a test case(distributed) and a fix

### DIFF
--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/AbstractServerClusterMergeUpdateTest.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/AbstractServerClusterMergeUpdateTest.java
@@ -1,0 +1,99 @@
+package com.orientechnologies.orient.server.distributed;
+
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePoolFactory;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.exception.OConcurrentModificationException;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import org.junit.Assert;
+
+/**
+ * @author Matan Shukry (matanshukry@gmail.com)
+ * @since 3/9/2015
+ *
+ * Events:
+ * 0. Create new document with value 2L
+ * 1. Node 0 starts a transaction, and loads document with version 0 and value 2
+ * 2. Node 1 starts a transaction, loads the document with version 0 and value 2, updates it to value 4, and commit(v1)
+ * 3*. Node 1 starts a transaction, loads the document with version 1 and value 4, updates it to value 5, and commit(v2)
+ * 4. Node 0 update his document (v0, 2) to value 5, and commit.
+ * 5. An exception SHOULD be raised, even though the value is the same, because the versions aren't.
+ *
+ * Note: event 3 is not required, it is just to show the versions don't match nor do they have to be
+ * sequential; As long as the content match, the commit will succeed
+ */
+public abstract class AbstractServerClusterMergeUpdateTest  extends AbstractServerClusterTest {
+  private static final String FIELD_NAME = "number";
+
+  private final OPartitionedDatabasePoolFactory poolFactory = new OPartitionedDatabasePoolFactory();
+
+  protected abstract String getDatabaseURL(ServerRun server);
+
+  public String getDatabaseName() {
+    return "distributed";
+  }
+
+  public void executeTest() throws Exception {
+    ODatabaseDocumentTx db0 = poolFactory.get(getDatabaseURL(serverInstance.get(0)), "admin", "admin").acquire();
+    try {
+      ODatabaseDocumentTx db1 = poolFactory.get(getDatabaseURL(serverInstance.get(1)), "admin", "admin").acquire();
+      try {
+        executeTest(db0, db1);
+      } finally {
+        db0.close();
+      }
+    } finally {
+      db0.close();
+    }
+  }
+
+  private void executeTest(ODatabaseDocumentTx db0, ODatabaseDocumentTx db1) {
+
+    // Event #0: Create new document with value 2L
+    ODocument doc = new ODocument("Paper").field(FIELD_NAME, 0L);
+    db0.save(doc);
+    ORID orid = doc.getIdentity().copy();
+
+    // Event #1: Node 0 starts a transaction, and loads document with version 0 and value 2
+    db0.begin();
+    ODocument doc0 = db0.load(orid);
+
+    // Event #2: Node 1 starts a transaction, loads the document with
+    // version 0 and value 2, updates it to value 4, and commit(v1)
+    {
+      db1.begin();
+      ODocument doc1 = db1.load(orid);
+      doc1.field(FIELD_NAME, 4L);
+      db1.save(doc1);
+      db1.commit();
+    }
+
+    // Event #3: Node 1 starts a transaction, loads the document with
+    // version 1 and value 4, updates it to value 5, and commit(v2)
+    {
+      db1.begin();
+      ODocument doc1 = db1.load(orid);
+      doc1.field(FIELD_NAME, 5L);
+      db1.save(doc1);
+      db1.commit();
+    }
+
+    // Event #4: Node 0 update his document (v0, 2) to value 5, and commit.
+    doc0.field(FIELD_NAME, 5L);
+    db0.save(doc0);
+
+    boolean anyConflictException = false;
+    try {
+      db0.commit();
+
+      // Event #5: An exception SHOULD be raised, even though the value is the same, because the versions aren't.
+    } catch (RuntimeException ex) {
+      if (ex instanceof OConcurrentModificationException) {
+        anyConflictException = true;
+      } else {
+        throw ex;
+      }
+    }
+    Assert.assertTrue(anyConflictException);
+  }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ServerClusterLocalMergeUpdateTest.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ServerClusterLocalMergeUpdateTest.java
@@ -1,0 +1,21 @@
+package com.orientechnologies.orient.server.distributed;
+
+import org.junit.Test;
+
+/**
+ * @author Matan Shukry (matanshukry@gmail.com)
+ * @since 3/9/2015
+ */
+public class ServerClusterLocalMergeUpdateTest extends AbstractServerClusterMergeUpdateTest {
+  @Test
+  public void test() throws Exception {
+    init(2);
+    prepare(false);
+    execute();
+  }
+
+  @Override
+  protected String getDatabaseURL(ServerRun server) {
+    return "plocal:" + server.getDatabasePath(getDatabaseName());
+  }
+}

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/task/OUpdateRecordTask.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/task/OUpdateRecordTask.java
@@ -75,7 +75,13 @@ public class OUpdateRecordTask extends OAbstractRecordReplicatedTask {
     if (loadedRecord instanceof ODocument) {
       // APPLY CHANGES FIELD BY FIELD TO MARK DIRTY FIELDS FOR INDEXES/HOOKS
       final ODocument newDocument = new ODocument().fromStream(content);
-      ((ODocument) loadedRecord).merge(newDocument, false, false).getRecordVersion().copyFrom(version);
+
+      ODocument loadedDocument = (ODocument) loadedRecord;
+      ORecordVersion loadedRecordVersion = loadedDocument.merge(newDocument, false, false).getRecordVersion();
+      if (loadedRecordVersion.getCounter() != version.getCounter()) {
+        loadedDocument.setDirty();
+      }
+      loadedRecordVersion.copyFrom(version);
     } else
       ORecordInternal.fill(loadedRecord, rid, version, content, true);
 


### PR DESCRIPTION
### The Problem (User perspective)
The problem is an edge case of a distributed record update in a transaction.
Consider the following series of events:
 * 0. Create new document with value 2L
 * 1. Node 0 starts a transaction, and loads document with version 0 and value 2
 * 2. Node 1 starts a transaction, loads the document with version 0 and value 2, updates it to value 4, and commit(v1)
 * 3*. Node 1 starts a transaction, loads the document with version 1 and value 4, updates it to value 5, and commit(v2)
 * 4. Node 0 update his document (v0, 2) to value 5, and commit.

Note: event 3 isn't necessary, it just shows the versions don't have to be consecutive nor have any relation. They have no impact on the result what so ever.

At the last commit of node 0, an exception should be raised. Even though the content is the same, the versions in the beginning of the transactions aren't, and we do not know the intention of the transaction.

For example, consider the use case of two people trying to increment the same field, starting at 0. The result should always be 2, even if the above scenario happens, which currently, it isn't.

### The problem (code perspective)
When we try to commit a new update to a document it is distributed to the nodes.
Each node will attempt to merge the new document with the old one, and if the _content_ is different, it will set it as dirty.
If the result document is not dirty, it won't even check the versions.

### The solution
When a node will attempt to merge a new document with an old one, on a distributed update task, it will now also check if the versions match. If not, it will set it as dirty.

Not sure how 'correct' it is, but it definitely works, and not a performance hit either.

### Extra: a test case
I also added a test case, which you can run, and see it fails (don't forget to comment out the fix part).