### PR TITLE
Added an error callback, improved success callback and added asynchronous querying

### DIFF
--- a/server/src/site/js/orientdb-api.js
+++ b/server/src/site/js/orientdb-api.js
@@ -292,7 +292,7 @@ function ODatabase(databasePath) {
 					errorCallback(this.errorMessage);
 			}
 		});
-		return this.getCommandResult();
+		return successCallback instanceof Function ? null : this.getCommandResult();
 	}
 
 	ODatabase.prototype.load = function(iRID, iFetchPlan) {

--- a/server/src/site/js/orientdb-api.js
+++ b/server/src/site/js/orientdb-api.js
@@ -260,7 +260,7 @@ function ODatabase(databasePath) {
 
 
 	ODatabase.prototype.query = function(iQuery, iLimit, iFetchPlan,
-			successCallback) {
+			successCallback, errorCallback) {
 		if (this.databaseInfo == null)
 			this.open();
 		
@@ -276,18 +276,20 @@ function ODatabase(databasePath) {
 			type : "GET",
 			url : this.urlPrefix + url + this.urlSuffix,
 			context : this,
-			async : false,
+			async : successCallback instanceof Function,
 			contentType : "application/json; charset=utf-8",
 			processData : false,
 			success : function(msg) {
 				this.setErrorMessage(null);
 				this.handleResponse(msg);
 				if (successCallback)
-					successCallback();
+					successCallback(this.commandResult);
 			},
 			error : function(msg) {
 				this.handleResponse(null);
 				this.setErrorMessage('Query error: ' + msg.responseText);
+				if (errorCallback)
+					errorCallback(this.errorMessage);
 			}
 		});
 		return this.getCommandResult();


### PR DESCRIPTION
I am fully aware, that the change in line 279 might and probably will break existing code. The success callback however doesn't make any sense, at least I can't think of any situation where it would be needed to set a success callback, if the code is blocked anyways until success.

If there is a success callback, there probably should be an error callback as well.

To make the success callback useful, I am making the request an asynchronous one if the success callback is provided, additionally the success and error callback get a little more useful adding the data or error message as first parameter.