### PR TITLE
Fixing bug when using a token issued for a user in subclass of OUser

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/token/JsonWebToken.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/token/JsonWebToken.java
@@ -92,7 +92,7 @@ public class JsonWebToken implements OJsonWebToken, OToken {
     ORID userRid = ((OrientJwtPayload) payload).getUserRid();
     ODocument result;
     result = db.load(userRid, "roles:1");
-    if (!result.getClassName().equals(OUser.CLASS_NAME)) {
+    if (!result.getSchemaClass().isSubClassOf(OUser.CLASS_NAME)) {
       result = null;
     }
     return new OUser(result);


### PR DESCRIPTION
If a user record is contained with a subclass of OUser, then an authorization token can be issued however a NullPointerException is returned when an attempt is made to use it.

This is down to a condition in the JsonWebToken class which only returns an OUser object if the RID contained in the token is in the OUser class itself and doesn't take into consideration classes that may extend OUser. This pull request addresses this issue.