### PR TITLE
Fix for #3862

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/OIdentifiable.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/OIdentifiable.java
@@ -46,6 +46,8 @@ public interface OIdentifiable extends Comparable<OIdentifiable>, Comparator<OId
   public <T extends ORecord> T getRecord();
 
   public void lock(boolean iExclusive);
+  
+  public boolean isLocked();
 
   public void unlock();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/OPlaceholder.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/OPlaceholder.java
@@ -120,6 +120,11 @@ public class OPlaceholder implements OIdentifiable, Externalizable {
   }
 
   @Override
+  public boolean isLocked() {
+    return ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().isLockedRecord(this);
+  }
+
+  @Override
   public void unlock() {
     ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().unlockRecord(this);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/id/ORecordId.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/id/ORecordId.java
@@ -284,6 +284,11 @@ public class ORecordId implements ORID {
   }
 
   @Override
+  public boolean isLocked() {
+    return ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().isLockedRecord(this);
+  }
+
+  @Override
   public void unlock() {
     ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().unlockRecord(this);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
@@ -301,6 +301,11 @@ public abstract class ORecordAbstract implements ORecord {
   }
 
   @Override
+  public boolean isLocked() {
+    return ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().isLockedRecord(this);
+  }
+
+  @Override
   public void unlock() {
     ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().unlockRecord(this);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLSelect.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLSelect.java
@@ -512,12 +512,14 @@ public class OCommandExecutorSQLSelect extends OCommandExecutorSQLResultsetAbstr
       }
     } finally {
       if (record != null) {
-        if (localLockingStrategy != null)
-        // CONTEXT LOCK: lock must be released (no matter if filtered or not)
-        {
-          if (localLockingStrategy == LOCKING_STRATEGY.KEEP_EXCLUSIVE_LOCK
-              || localLockingStrategy == LOCKING_STRATEGY.KEEP_SHARED_LOCK) {
-            record.unlock();
+        if (record.isLocked()) {
+          if (localLockingStrategy != null)
+          // CONTEXT LOCK: lock must be released (no matter if filtered or not)
+          {
+            if (localLockingStrategy == LOCKING_STRATEGY.KEEP_EXCLUSIVE_LOCK
+                || localLockingStrategy == LOCKING_STRATEGY.KEEP_SHARED_LOCK) {
+              record.unlock();
+            }
           }
         }
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
@@ -146,6 +146,8 @@ public interface OTransaction {
   public void updateIdentityAfterCommit(final ORID oldRid, final ORID newRid);
 
   public int amountOfNestedTxs();
+  
+  public boolean isLockedRecord(OIdentifiable iRecord);
 
   public OTransaction lockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY iLockingStrategy);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -124,6 +124,16 @@ public abstract class OTransactionAbstract implements OTransaction {
   }
 
   @Override
+  public boolean isLockedRecord(final OIdentifiable iRecord) {
+    final ORID rid = iRecord.getIdentity();
+    OStorage.LOCKING_STRATEGY iLockingStrategy = locks.get(rid);
+    if (iLockingStrategy == null) 
+       return false;
+    else 
+       return true;
+  }
+
+  @Override
   public OTransaction unlockRecord(final OIdentifiable iRecord) {
     final OStorage stg = database.getStorage();
     if (!(stg.getUnderlying() instanceof OAbstractPaginatedStorage))

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElement.java
@@ -338,6 +338,14 @@ public abstract class OrientElement implements Element, OSerializableStream, Ext
   }
 
   /**
+   * (Blueprints Extension) Checks if an Element is locked
+   */
+  @Override
+  public boolean isLocked() {
+    return ODatabaseRecordThreadLocal.INSTANCE.get().getTransaction().isLockedRecord(this);
+  }
+
+  /**
    * (Blueprints Extension) Unlocks previous acquired @lock against the Element.
    * 
    * @see #lock(boolean)

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/asynch/OrientElementFuture.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/asynch/OrientElementFuture.java
@@ -132,6 +132,15 @@ public abstract class OrientElementFuture<T extends OrientElement> implements El
   }
 
   @Override
+  public boolean isLocked() {
+    try {
+      return future.get().isLocked();
+    } catch (Exception e) {
+      throw new OException("Cannot retrieve the requested information", e);
+    }
+  }
+
+  @Override
   public void unlock() {
     try {
       future.get().unlock();


### PR DESCRIPTION
Fix : 

While unlocking the record we are not checking whether the record is locked or not , we are just called a unlock in finally block in /OCommandExecutorSQLSelect.java , adding a new method to interfaces OIdentifiable.java
 and  
OTransaction.java

Tested for ant clean install 
ant clean test
