### PR TITLE
Aggregative concat function with ability to specify separator

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
@@ -37,6 +37,7 @@ import com.orientechnologies.orient.core.sql.functions.stat.OSQLFunctionMode;
 import com.orientechnologies.orient.core.sql.functions.stat.OSQLFunctionPercentile;
 import com.orientechnologies.orient.core.sql.functions.stat.OSQLFunctionStandardDeviation;
 import com.orientechnologies.orient.core.sql.functions.stat.OSQLFunctionVariance;
+import com.orientechnologies.orient.core.sql.functions.text.OSQLFunctionConcat;
 import com.orientechnologies.orient.core.sql.functions.text.OSQLFunctionFormat;
 
 import java.util.HashMap;
@@ -87,6 +88,7 @@ public final class ODefaultSQLFunctionFactory implements OSQLFunctionFactory {
     register(OSQLFunctionVariance.NAME, OSQLFunctionVariance.class);
     register(OSQLFunctionStandardDeviation.NAME, OSQLFunctionStandardDeviation.class);
     register(OSQLFunctionUUID.NAME, OSQLFunctionUUID.class);
+    register(OSQLFunctionConcat.NAME, OSQLFunctionConcat.class);
   }
 
   public static void register(final String iName, final Object iImplementation) {

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/text/OSQLFunctionConcat.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/text/OSQLFunctionConcat.java
@@ -1,0 +1,45 @@
+package com.orientechnologies.orient.core.sql.functions.text;
+
+import com.orientechnologies.orient.core.command.OCommandContext;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.sql.functions.OSQLFunctionConfigurableAbstract;
+
+public class OSQLFunctionConcat extends OSQLFunctionConfigurableAbstract{
+	public static final String NAME = "concat";
+	private StringBuilder sb;
+
+	public OSQLFunctionConcat() {
+		super(NAME, 1, 2);
+	}
+
+	@Override
+	public Object execute(Object iThis, OIdentifiable iCurrentRecord,
+			Object iCurrentResult, Object[] iParams, OCommandContext iContext) {
+		if(sb==null)
+		{
+			sb = new StringBuilder();
+		}
+		else
+		{
+			if(iParams.length>1) sb.append(iParams[1]);
+		}
+		sb.append(iParams[0]);
+		return null;
+	}
+	
+	@Override
+	public Object getResult() {
+		return sb!=null?sb.toString():null;
+	}
+
+	@Override
+	public String getSyntax() {
+		return "concat(<field>, [<delim>])";
+	}
+	
+	@Override
+	public boolean aggregateResults() {
+		return true;
+	}
+
+}

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/text/OSQLFunctionConcatTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/text/OSQLFunctionConcatTest.java
@@ -1,0 +1,50 @@
+package com.orientechnologies.orient.core.sql.functions.text;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+
+@Test
+public class OSQLFunctionConcatTest {
+	
+	@Test
+	public void testConcat()
+	{
+		ODatabaseDocument db = new ODatabaseDocumentTx("memory:testConCat");
+	    try {
+	    	db.create();
+	    	OClass concat = db.getMetadata().getSchema().createClass("ConCat");
+	    	concat.createProperty("name", OType.STRING);
+	    	
+	    	ODocument doc;
+	    	for(char ch='a'; ch<='c'; ch++)
+	    	{
+	    		doc = new ODocument(concat);
+	    		doc.field("name", ""+ch);
+	    		db.save(doc);
+	    	}
+	    	List<ODocument> results =  db.query(new OSQLSynchQuery<ODocument>("select concat(name) from ConCat order by name"));
+	    	assertNotNull(results);
+	    	assertEquals(results.size(), 1);
+	    	assertEquals(results.get(0).field("concat"), "abc");
+	    	
+	    	results =  db.query(new OSQLSynchQuery<ODocument>("select concat(name, ', ') from ConCat order by name"));
+	    	assertNotNull(results);
+	    	assertEquals(results.size(), 1);
+	    	assertEquals(results.get(0).field("concat"), "a, b, c");
+	    }
+	    finally {
+	    	db.drop();
+	    	db.close();
+	    }
+	}
+}


### PR DESCRIPTION
Possible usages:

```sql
--There are 3 objects with names = a, b and c
SELECT concat(name) from MyClass order by name;  --returns 'abc'
SELECT concat(name, ', ') from MyClass order by name;  --returns 'a, b, c'
```