### PR TITLE
Fix DESC iterator for classes with multiple clusters

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClassDescendentOrder.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/iterator/ORecordIteratorClassDescendentOrder.java
@@ -33,6 +33,8 @@ public class ORecordIteratorClassDescendentOrder<REC extends ORecord> extends OR
       String iClassName, boolean iPolymorphic, boolean iUseCache, boolean iterateThroughTombstones,
       OStorage.LOCKING_STRATEGY iLockingStrategy) {
     super(iDatabase, iLowLevelDatabase, iClassName, iPolymorphic, iUseCache, iterateThroughTombstones, iLockingStrategy);
+
+    currentClusterIdx = clusterIds.length - 1; // START FROM THE LAST CLUSTER
   }
 
   @Override


### PR DESCRIPTION
The change made in 18740e01cf46c882053aa542bd09e1ed38d7d1bb for #3684 has indirectly led to a bug in `ORecordIteratorClassDescendentOrder` when dealing with classes that have multiple clusters.

Before #3684 the `begin` method was always called in the `config` method of `ORecordIteratorClass`. Since `ORecordIteratorClassDescendentOrder` overrides `begin` to instead call `last` this meant that the `currentClusterIdx` was correctly set to the last cluster before the `setRange` call.

After #3684 the `begin` method is only called for the shorthand constructors - the longer form which takes a locking strategy doesn't call `begin`. Instead it expects that the `setRange` method will subsequently be called - and that this will call `begin` and complete initialization of the iterator, as done in:

https://github.com/orientechnologies/orientdb/blob/develop/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLResultsetAbstract.java#L447

Unfortunately because `begin` is only called at the end of the `setRange` method the `currentClusterIdx` will be left set to the first cluster (0) when we first enter `setRange`, which causes all sorts of interesting issues depending on the number of clusters attached to the class and their relative bounds. For example the attached test will hang using the latest code in the develop branch.

The simplest solution is to ensure that `currentClusterIdx` is always set to the last cluster at the end of the `ORecordIteratorClassDescendentOrder` constructor which then means that the right bounds will be checked in the `setRange` method.