### PR TITLE
Fix for NPE on client shutdown

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -292,6 +292,20 @@ public class Orient extends OListenerManger<OOrientListener> {
       // NOTE: DON'T REMOVE PROFILER TO AVOID NPE AROUND THE CODE IF ANY THREADS IS STILL WORKING
       profiler.shutdown();
 
+      purgeWeakShutdownListeners();
+      for (final WeakHashSetValueHolder<OOrientShutdownListener> wl : weakShutdownListeners)
+        try {
+          if (wl != null) {
+            final OOrientShutdownListener l = wl.get();
+            if (l != null) {
+              l.onShutdown();
+            }
+          }
+
+        } catch (Exception e) {
+          OLogManager.instance().error(this, "Error during orient shutdown.", e);
+        }
+      
       // CALL THE SHUTDOWN ON ALL THE LISTENERS
       for (OOrientListener l : browseListeners()) {
         if (l != null)
@@ -302,19 +316,6 @@ public class Orient extends OListenerManger<OOrientListener> {
           }
 
       }
-
-      purgeWeakShutdownListeners();
-      for (final WeakHashSetValueHolder<OOrientShutdownListener> wl : weakShutdownListeners)
-        try {
-          if (wl != null) {
-            final OOrientShutdownListener l = wl.get();
-            if (l != null)
-              l.onShutdown();
-          }
-
-        } catch (Exception e) {
-          OLogManager.instance().error(this, "Error during orient shutdown.", e);
-        }
 
       OLogManager.instance().info(this, "OrientDB Engine shutdown complete");
       OLogManager.instance().flush();

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentValidationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentValidationTest.java
@@ -128,7 +128,7 @@ public class ODocumentValidationTest {
       clazz.createProperty("binary", OType.BINARY).setMax("11");
       clazz.createProperty("byte", OType.BYTE).setMax("11");
       Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.HOUR, 1);
+      cal.add(Calendar.HOUR, cal.get(Calendar.HOUR) == 11 ? 0 : 1);
       SimpleDateFormat format = ((ODatabaseDocumentTx) db).getStorage().getConfiguration().getDateFormatInstance();
       clazz.createProperty("date", OType.DATE).setMax(format.format(cal.getTime()));
       format = ((ODatabaseDocumentTx) db).getStorage().getConfiguration().getDateTimeFormatInstance();
@@ -228,7 +228,7 @@ public class ODocumentValidationTest {
       clazz.createProperty("binary", OType.BINARY).setMin("11");
       clazz.createProperty("byte", OType.BYTE).setMin("11");
       Calendar cal = Calendar.getInstance();
-      cal.add(Calendar.HOUR, 1);
+      cal.add(Calendar.HOUR, cal.get(Calendar.HOUR) == 11 ? 0 : 1);
       SimpleDateFormat format = ((ODatabaseDocumentTx) db).getStorage().getConfiguration().getDateFormatInstance();
       clazz.createProperty("date", OType.DATE).setMin(format.format(cal.getTime()));
       format = ((ODatabaseDocumentTx) db).getStorage().getConfiguration().getDateTimeFormatInstance();


### PR DESCRIPTION
This is strictly related to #3700 : NPE still happens on client side (reproduced with a spring boot application). Calling onShutdown() on the weak listeners first does the trick.

Moreover: fixed a couple of tests that fail when executed at 11 PM.