### PR TITLE
GraphSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ out
 *.iml
 .idea/
 
+*.DS_Store
+
 tests/src/test/java/com/orientechnologies/orient/test/database/auto/_*.xml

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElementIterable.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElementIterable.java
@@ -22,14 +22,17 @@ package com.tinkerpop.blueprints.impls.orient;
 
 import com.tinkerpop.blueprints.CloseableIterable;
 import com.tinkerpop.blueprints.Element;
+import com.tinkerpop.blueprints.util.io.graphson.IGraphSONIterable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class OrientElementIterable<T extends Element> implements CloseableIterable<T> {
+public class OrientElementIterable<T extends Element> implements CloseableIterable<T>, IGraphSONIterable {
 
   private final Iterable<?>     iterable;
   private final OrientBaseGraph graph;
@@ -51,4 +54,13 @@ public class OrientElementIterable<T extends Element> implements CloseableIterab
 
   }
 
+	@Override
+	public List<? extends Element> getList() {
+		List<T> result = new ArrayList<T>();
+		for (Iterator<T> iterator = iterator(); iterator.hasNext();) {
+			T e = (T) iterator.next();
+			result.add(e);
+		}
+		return result;
+	}
 }

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElementIterable.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientElementIterable.java
@@ -20,19 +20,16 @@
 
 package com.tinkerpop.blueprints.impls.orient;
 
-import com.tinkerpop.blueprints.CloseableIterable;
-import com.tinkerpop.blueprints.Element;
-import com.tinkerpop.blueprints.util.io.graphson.IGraphSONIterable;
-
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
+
+import com.tinkerpop.blueprints.CloseableIterable;
+import com.tinkerpop.blueprints.Element;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-public class OrientElementIterable<T extends Element> implements CloseableIterable<T>, IGraphSONIterable {
+public class OrientElementIterable<T extends Element> implements CloseableIterable<T> {
 
   private final Iterable<?>     iterable;
   private final OrientBaseGraph graph;
@@ -53,14 +50,4 @@ public class OrientElementIterable<T extends Element> implements CloseableIterab
   public void close() {
 
   }
-
-	@Override
-	public List<? extends Element> getList() {
-		List<T> result = new ArrayList<T>();
-		for (Iterator<T> iterator = iterator(); iterator.hasNext();) {
-			T e = (T) iterator.next();
-			result.add(e);
-		}
-		return result;
-	}
 }

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
@@ -1,9 +1,0 @@
-package com.tinkerpop.blueprints.util.io.graphson;
-
-import java.util.List;
-
-import com.tinkerpop.blueprints.Element;
-
-public interface IGraphSONIterable {
-	public List<? extends Element> getList();
-}

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/util/io/graphson/IGraphSONIterable.java
@@ -1,0 +1,9 @@
+package com.tinkerpop.blueprints.util.io.graphson;
+
+import java.util.List;
+
+import com.tinkerpop.blueprints.Element;
+
+public interface IGraphSONIterable {
+	public List<? extends Element> getList();
+}


### PR DESCRIPTION
New Interface IGraphSONIterable

The change allows GraphSONUtility to use any kind of type that implements IGraphSONIterable. In this way not only List, Map, Array or Element, but all the wrapper that implements IGraphSONIterable, such as OrientElementIterable, will return a valid value from the jsonFromElement method.