### PR TITLE
Support for one-to-one lazy fetch on detachAll. Issue #4032

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/object/OObjectLazyMultivalueElement.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/object/OObjectLazyMultivalueElement.java
@@ -26,7 +26,7 @@ public interface OObjectLazyMultivalueElement<T> {
 
   public void detach(boolean nonProxiedInstance);
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects);
 
   public T getNonOrientInstance();
 

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
@@ -312,7 +312,7 @@ public class OObjectDatabaseTx extends ODatabasePojoAbstract<Object> implements 
    * @return the object serialized or with detached data
    */
   public <RET> RET detachAll(final Object iPojo, boolean returnNonProxiedInstance) {
-    return detachAll(iPojo, returnNonProxiedInstance, new HashMap<Object, Object>());
+    return detachAll(iPojo, returnNonProxiedInstance, new HashMap<Object, Object>(), new HashMap<Object, Object>());
   }
 
   public <RET> RET load(final Object iPojo, final String iFetchPlan, final boolean iIgnoreCache) {
@@ -777,8 +777,8 @@ public class OObjectDatabaseTx extends ODatabasePojoAbstract<Object> implements 
     underlying.resetInitialization();
   }
 
-  protected <RET> RET detachAll(final Object iPojo, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached) {
-    return (RET) OObjectEntitySerializer.detachAll(iPojo, this, returnNonProxiedInstance, alreadyDetached);
+  protected <RET> RET detachAll(final Object iPojo, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
+    return (RET) OObjectEntitySerializer.detachAll(iPojo, this, returnNonProxiedInstance, alreadyDetached, lazyObjects);
   }
 
   protected void deleteCascade(final ODocument record) {

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
@@ -420,21 +420,21 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
     }
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
-    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached, lazyObjects);
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     if (converted || !convertToRecord)
       return;
 
     for (int i = 0; i < size(); ++i)
-      convertAndDetachAll(i, nonProxiedInstance, alreadyDetached);
+      convertAndDetachAll(i, nonProxiedInstance, alreadyDetached, lazyObjects);
 
     converted = true;
   }
 
-  private void convertAndDetachAll(final int iIndex, boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  private void convertAndDetachAll(final int iIndex, boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     if (converted || !convertToRecord)
       return;
 
@@ -459,7 +459,7 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
       }
       o = OObjectEntityEnhancer.getInstance().getProxiedInstance(doc.getClassName(), getDatabase().getEntityManager(), doc,
           sourceRecord);
-      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached);
+      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached, lazyObjects);
       super.set(iIndex, (TYPE) o);
     }
   }

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyMap.java
@@ -237,8 +237,8 @@ public class OObjectLazyMap<TYPE> extends HashMap<Object, Object> implements Ser
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
-    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached, lazyObjects);
 
   }
 
@@ -264,13 +264,13 @@ public class OObjectLazyMap<TYPE> extends HashMap<Object, Object> implements Ser
     converted = true;
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     if (converted || !convertToRecord)
       return;
 
     for (java.util.Map.Entry<Object, OIdentifiable> e : underlying.entrySet()) {
       Object o = getDatabase().getUserObjectByRecord((ORecord) ((OIdentifiable) e.getValue()).getRecord(), null);
-      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached);
+      o = ((OObjectDatabaseTx) getDatabase()).detachAll(o, nonProxiedInstance, alreadyDetached, lazyObjects);
       super.put(e.getKey(), o);
     }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazySet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazySet.java
@@ -226,8 +226,8 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
-    convertAndDetachAll(nonProxiedInstance, alreadyDetached);
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
+    convertAndDetachAll(nonProxiedInstance, alreadyDetached, lazyObjects);
   }
 
   @Override
@@ -285,7 +285,7 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
     converted = true;
   }
 
-  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  protected void convertAndDetachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     if (converted || !convertToRecord)
       return;
 
@@ -297,10 +297,10 @@ public class OObjectLazySet<TYPE> extends HashSet<TYPE> implements OLazyObjectSe
         if (e instanceof ORID) {
           e = database.getUserObjectByRecord(((ODatabaseDocument) getDatabase().getUnderlying()).load((ORID) e, fetchPlan),
                   fetchPlan);
-          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached));
+          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached, lazyObjects));
         } else if (e instanceof ODocument) {
           e = database.getUserObjectByRecord((ORecord) e, fetchPlan);
-          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached));
+          super.add((TYPE) ((OObjectDatabaseTx) getDatabase()).detachAll(e, nonProxiedInstance, alreadyDetached, lazyObjects));
         } else
           add((TYPE) e);
       }

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -37,6 +37,7 @@ import javassist.util.proxy.Proxy;
 import javassist.util.proxy.ProxyObject;
 
 import javax.persistence.CascadeType;
+import javax.persistence.FetchType;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -97,6 +98,7 @@ public class OObjectEntitySerializer {
   private static final HashMap<Class<?>, Field>                boundDocumentFields = new HashMap<Class<?>, Field>();
   private static final HashMap<Class<?>, List<String>>         transientFields     = new HashMap<Class<?>, List<String>>();
   private static final HashMap<Class<?>, List<String>>         cascadeDeleteFields = new HashMap<Class<?>, List<String>>();
+  private static final HashMap<Class<?>, List<String>>         fetchLazyFields     = new HashMap<Class<?>, List<String>>();
   private static final HashMap<Class<?>, Map<Field, Class<?>>> serializedFields    = new HashMap<Class<?>, Map<Field, Class<?>>>();
   private static final HashMap<Class<?>, Field>                fieldIds            = new HashMap<Class<?>, Field>();
   private static final HashMap<Class<?>, Field>                fieldVersions       = new HashMap<Class<?>, Field>();
@@ -224,7 +226,7 @@ public class OObjectEntitySerializer {
    *          and @Version fields it could procude data replication
    * @return the object serialized or with detached data
    */
-  public static <T> T detachAll(T o, ODatabaseObject db, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public static <T> T detachAll(T o, ODatabaseObject db, boolean returnNonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     if (o instanceof Proxy) {
       OObjectProxyMethodHandler handler = (OObjectProxyMethodHandler) ((ProxyObject) o).getHandler();
       try {
@@ -237,7 +239,7 @@ public class OObjectEntitySerializer {
         } else if (returnNonProxiedInstance){
           return (T) alreadyDetached.get(identity);
         }
-        handler.detachAll(o, returnNonProxiedInstance, alreadyDetached);
+        handler.detachAll(o, returnNonProxiedInstance, alreadyDetached, lazyObjects);
       } catch (IllegalArgumentException e) {
         throw new OSerializationException("Error detaching object of class " + o.getClass(), e);
       } catch (IllegalAccessException e) {
@@ -343,6 +345,18 @@ public class OObjectEntitySerializer {
       currentClass = currentClass.getSuperclass();
     }
     return isTransientField;
+  }
+
+  public static boolean isFetchLazyField(Class<?> iClass, String iField) {
+    checkClassRegistration(iClass);
+    boolean isFetchLazyField = false;
+    for (Class<?> currentClass = iClass; currentClass != null && currentClass != Object.class
+        && !currentClass.equals(ODocument.class) && !isFetchLazyField;) {
+      List<String> classFetchLazyFields = fetchLazyFields.get(currentClass);
+      isFetchLazyField = classFetchLazyFields != null && classFetchLazyFields.contains(iField);
+      currentClass = currentClass.getSuperclass();
+    }
+    return isFetchLazyField;
   }
 
   public static boolean isEmbeddedField(Class<?> iClass, String iField) {
@@ -452,6 +466,9 @@ public class OObjectEntitySerializer {
               OneToOne oneToOne = ((OneToOne) ann);
               if (checkCascadeDelete(oneToOne)) {
                 addCascadeDeleteField(currentClass, fieldName);
+              }
+              if (checkFetchLazy(oneToOne)) {
+                addFetchLazyField(currentClass, fieldName);
               }
             }
           }
@@ -640,12 +657,24 @@ public class OObjectEntitySerializer {
     return false;
   }
 
+  protected static boolean checkFetchLazy(final OneToOne oneToOne) {
+    return oneToOne.fetch() == FetchType.LAZY;
+  }
+
   protected static void addCascadeDeleteField(Class<?> currentClass, final String fieldName) {
     List<String> classCascadeDeleteFields = cascadeDeleteFields.get(currentClass);
     if (classCascadeDeleteFields == null)
       classCascadeDeleteFields = new ArrayList<String>();
     classCascadeDeleteFields.add(fieldName);
     cascadeDeleteFields.put(currentClass, classCascadeDeleteFields);
+  }
+
+  protected static void addFetchLazyField(Class<?> currentClass, final String fieldName) {
+    List<String> classFetchLazyFields = fetchLazyFields.get(currentClass);
+    if (classFetchLazyFields == null)
+      classFetchLazyFields = new ArrayList<String>();
+    classFetchLazyFields.add(fieldName);
+    fetchLazyFields.put(currentClass, classFetchLazyFields);
   }
 
   public static boolean isSerializedType(final Field iField) {

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyList.java
@@ -225,7 +225,7 @@ public class OObjectEnumLazyList<TYPE extends Enum<?>> implements List<TYPE>, OO
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazyMap.java
@@ -159,7 +159,7 @@ public class OObjectEnumLazyMap<TYPE extends Enum> extends HashMap<Object, Objec
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazySet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enumerations/OObjectEnumLazySet.java
@@ -154,7 +154,7 @@ public class OObjectEnumLazySet<TYPE extends Enum> extends HashSet<TYPE> impleme
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerList.java
@@ -210,7 +210,7 @@ public class OObjectCustomSerializerList<TYPE> implements List<TYPE>, OObjectLaz
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerMap.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerMap.java
@@ -166,7 +166,7 @@ public class OObjectCustomSerializerMap<TYPE> extends HashMap<Object, Object> im
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerSet.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/serialization/OObjectCustomSerializerSet.java
@@ -155,7 +155,7 @@ public class OObjectCustomSerializerSet<TYPE> extends HashSet<TYPE> implements O
     convertAll();
   }
 
-  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached) {
+  public void detachAll(boolean nonProxiedInstance, Map<Object, Object> alreadyDetached, Map<Object, Object> lazyObjects) {
     convertAll();
   }
 

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ObjectDetachingTest.java
@@ -33,6 +33,8 @@ import com.orientechnologies.orient.test.domain.business.Country;
 import com.orientechnologies.orient.test.domain.cycle.CycleChild;
 import com.orientechnologies.orient.test.domain.cycle.CycleParent;
 import com.orientechnologies.orient.test.domain.cycle.GrandChild;
+import com.orientechnologies.orient.test.domain.lazy.LazyChild;
+import com.orientechnologies.orient.test.domain.lazy.LazyParent;
 import com.orientechnologies.orient.test.domain.whiz.Profile;
 import javassist.util.proxy.Proxy;
 import org.testng.Assert;
@@ -785,5 +787,21 @@ public class ObjectDetachingTest extends ObjectDBBaseTest {
     Assert.assertEquals(detachedGrandChild.getName(), grandChild.getName());
     Assert.assertSame(detachedGrandChild.getGrandParent(), detachedParent);
 
+  }
+
+  public void testDetachAllWithLazyOneToOne(){
+    database.getEntityManager().registerEntityClasses("com.orientechnologies.orient.test.domain.lazy");
+    LazyParent parent = new LazyParent();
+    LazyChild theChild = new LazyChild();
+    theChild.setName("name");
+    parent.setChild(theChild);
+    LazyParent saved = database.save(parent);
+    saved.setChildCopy(saved.getChild());
+    LazyParent detached = database.detachAll(saved, true);
+    Assert.assertNotNull(detached.getChild().getId());
+    Assert.assertNull(detached.getChild().getName());
+    Assert.assertSame(detached.getChild(), detached.getChildCopy());
+    LazyChild loaded = database.load(detached.getChild().getId());
+    Assert.assertEquals("name", loaded.getName());
   }
 }

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/lazy/LazyChild.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/lazy/LazyChild.java
@@ -1,0 +1,32 @@
+package com.orientechnologies.orient.test.domain.lazy;
+
+import com.orientechnologies.orient.core.id.ORID;
+
+import javax.persistence.Id;
+
+/**
+ * @author Wouter de Vaal
+ */
+public class LazyChild {
+
+    @Id
+    private ORID id;
+
+    private String name;
+
+    public ORID getId() {
+        return id;
+    }
+
+    public void setId(ORID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/domain/lazy/LazyParent.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/domain/lazy/LazyParent.java
@@ -1,0 +1,44 @@
+package com.orientechnologies.orient.test.domain.lazy;
+
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Wouter de Vaal
+ */
+public class LazyParent {
+
+    @Id
+    private String id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private LazyChild child;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private LazyChild childCopy;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public LazyChild getChild() {
+        return child;
+    }
+
+    public void setChild(LazyChild child) {
+        this.child = child;
+    }
+
+    public LazyChild getChildCopy() {
+        return childCopy;
+    }
+
+    public void setChildCopy(LazyChild childCopy) {
+        this.childCopy = childCopy;
+    }
+}


### PR DESCRIPTION
This adds support for @OneToOne(lazy=FetchType.LAZY) when calling detachAll(object, true).

I would be happy to add info to the manual, but I couldn't find how to contribute to that.