### PR TITLE
Allow backups for file paths with spaces and fix @Transient inherited fields

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImpExpAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImpExpAbstract.java
@@ -60,6 +60,15 @@ public abstract class ODatabaseImpExpAbstract {
       final OCommandOutputListener iListener) {
     database = iDatabase;
     fileName = iFileName;
+    
+    // Fix bug where you can't backup files with spaces. Now you can wrap with quotes and the filesystem won't create
+    // directories with quotes in their name.
+    if (fileName != null) {
+    	if ((fileName.startsWith("\"") && fileName.endsWith("\"")) || (fileName.startsWith("'") && fileName.endsWith("'"))) {
+    		fileName = fileName.substring(1, fileName.length() - 1);
+    		iListener.onMessage("Detected quotes surrounding filename; new backup file: " + fileName); 
+    	}
+    }
 
     if (fileName != null && fileName.indexOf('.') == -1)
       fileName += DEFAULT_EXT;

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -1131,7 +1131,7 @@ public class OObjectEntitySerializer {
 
         fieldName = p.getName();
 
-        List<String> classTransientFields = transientFields.get(pojoClass);
+        List<String> classTransientFields = transientFields.get(currentClass);
 
         if ((idField != null && fieldName.equals(idField.getName()) || (vField != null && fieldName.equals(vField.getName())) || (classTransientFields != null && classTransientFields
             .contains(fieldName))))


### PR DESCRIPTION
1. You can now run a backup to a file that has one or more spaces in the file path.
2. There is a bug with inheriting @Transient fields where the field loses it's transient property in the subclass. For example, given the following classes if you create an Apple and save it to the database, it will persist both sweetness and color.

class Fruit {
  @Transient protected String color;
}

class Apple extends Fruit {
  private int sweetness;
}

This becomes an important issue because we can't use the transient Java keyword because we still need to be able to serialize these objects to send them over the network, we just don't want them to be persisted. That is why, I assume, OrientDB went to the trouble to support the JPA @Transient annotation. This small one variable change fixes the inheritance of these transient fields.