### PR TITLE
NPE on GET request to /server

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetServer.java
@@ -72,11 +72,15 @@ public class OServerCommandGetServer extends OServerCommandGetConnections {
 
   protected void writeProperties(final OJSONWriter json) throws IOException {
     json.beginCollection(2, true, "properties");
-    for (OServerEntryConfiguration entry : server.getConfiguration().properties) {
-      json.beginObject(3, true, null);
-      json.writeAttribute(4, false, "name", entry.name);
-      json.writeAttribute(4, false, "value", entry.value);
-      json.endObject(3, true);
+
+    OServerEntryConfiguration[] confProperties = server.getConfiguration().properties;
+    if (confProperties != null) {
+      for (OServerEntryConfiguration entry : confProperties) {
+        json.beginObject(3, true, null);
+        json.writeAttribute(4, false, "name", entry.name);
+        json.writeAttribute(4, false, "value", entry.value);
+        json.endObject(3, true);
+      }
     }
     json.endCollection(2, true);
   }


### PR DESCRIPTION
# The Problem

When using a minimalist configuration file ( orientdb-server-config.xml ), and trying to query server information using the http protocol, and the path "/server", the result is a null pointer expection message in the server log:

```
2015-05-28 23:48:39:375 SEVERE Internal server error:
java.lang.NullPointerException [ONetworkProtocolHttpDb]
```

and an internal server error for the client.

# Cause
The error is caused when trying to iterate over a null array of OServerEntryConfiguration .

# The Solution
Simply check if the array exists before iterating over it
