### PR TITLE
REST - CreateDatabase - AlreadyExists returns 500

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostDatabase.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostDatabase.java
@@ -69,18 +69,19 @@ public class OServerCommandPostDatabase extends OServerCommandAuthenticatedServe
       String url = getStoragePath(databaseName, storageMode);
       final String type = urlParts.length > 3 ? urlParts[3] : "document";
       if (url != null) {
-
         final ODatabaseDocumentTx database = Orient.instance().getDatabaseFactory().createDatabase(type, url);
-        if (database.exists())
-          throw new ODatabaseException("Database '" + database.getURL() + "' already exists");
-
-        for (OStorage stg : Orient.instance().getStorages()) {
-          if (stg.getName().equalsIgnoreCase(database.getName()) && stg.exists())
-            throw new ODatabaseException("Database named '" + database.getName() + "' already exists: " + stg);
+        if (database.exists()) {
+          iResponse.send(OHttpUtils.STATUS_CONFLICT_CODE, OHttpUtils.STATUS_CONFLICT_DESCRIPTION,
+                  OHttpUtils.CONTENT_TEXT_PLAIN, "Database '" + database.getURL() + "' already exists.", null);
+        } else {
+          for (OStorage stg : Orient.instance().getStorages()) {
+            if (stg.getName().equalsIgnoreCase(database.getName()) && stg.exists())
+              throw new ODatabaseException("Database named '" + database.getName() + "' already exists: " + stg);
+          }
+          OLogManager.instance().info(this, "Creating database " + url);
+          database.create();
+          sendDatabaseInfo(iRequest, iResponse, database);
         }
-        OLogManager.instance().info(this, "Creating database " + url);
-        database.create();
-        sendDatabaseInfo(iRequest, iResponse, database);
       } else {
         throw new OCommandExecutionException("The '" + storageMode + "' storage mode does not exists.");
       }


### PR DESCRIPTION
When trying to create a new database that already exists,
the result is http status code 500.

The result for a specific checked case should be specific,
rather than the generalized 500 code which should be used for runtime exception.

The code and the text can obviously be changed to anything.