### PR TITLE
One fix for "com.orientechnologies.orient.core.exception.OSerializationException: Type String cannot be serialized because is not part of registered entities. To fix this error register this class"

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectProxyMethodHandler.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectProxyMethodHandler.java
@@ -70,7 +70,7 @@ import java.util.Set;
 
 /**
  * @author Luca Molino (molino.luca--at--gmail.com)
- * 
+ *
  */
 public class OObjectProxyMethodHandler implements MethodHandler {
 
@@ -119,7 +119,7 @@ public class OObjectProxyMethodHandler implements MethodHandler {
 
   /**
    * Method that detaches all fields contained in the document to the given object
-   * 
+   *
    * @param self
    *          :- The object containing this handler instance
    * @throws InvocationTargetException
@@ -146,7 +146,7 @@ public class OObjectProxyMethodHandler implements MethodHandler {
 
   /**
    * Method that detaches all fields contained in the document to the given object
-   * 
+   *
    * @param self
    *          :- The object containing this handler instance
    * @throws InvocationTargetException
@@ -187,8 +187,8 @@ public class OObjectProxyMethodHandler implements MethodHandler {
 
   /**
    * Method that attaches all data contained in the object to the associated document
-   * 
-   * 
+   *
+   *
    * @param self
    *          :- The object containing this handler instance
    * @throws IllegalAccessException
@@ -348,11 +348,12 @@ public class OObjectProxyMethodHandler implements MethodHandler {
               Method setMethod = getSetMethod(self.getClass().getSuperclass(), getSetterFieldName(fieldName), value);
               setMethod.invoke(self, value);
             } else if ((value instanceof Set || value instanceof Map)
-                && loadedFields.get(fieldName).compareTo(doc.getRecordVersion()) < 0) {
-              if (value instanceof Set)
+                && loadedFields.get(fieldName).compareTo(doc.getRecordVersion()) < 0
+                && !OReflectionHelper.isJavaType(genericMultiValueType)) {
+              if (value instanceof Set && !(value instanceof OTrackedSet))
                 value = new OObjectLazySet(self, (Set<OIdentifiable>) docValue, OObjectEntitySerializer.isCascadeDeleteField(
                     self.getClass(), fieldName));
-              else
+              else if (!(value instanceof OTrackedMap))
                 value = new OObjectLazyMap(self, (Map<Object, OIdentifiable>) docValue,
                     OObjectEntitySerializer.isCascadeDeleteField(self.getClass(), fieldName));
               final Method setMethod = getSetMethod(self.getClass().getSuperclass(), getSetterFieldName(fieldName), value);


### PR DESCRIPTION
I'm frequently running into the error "com.orientechnologies.orient.core.exception.OSerializationException: Type String cannot be serialized because is not part of registered entities. To fix this error register this class" which is caused by a OObjectLazyMap being created when the map only contains java types. I have found that the cause for the errors occurring to me is that an OObjectLazyMap is created when the fields have a lower version number than the document version number. It's likely that the application is badly coded, I'm however porting it from a working JPA implementation.

The fix is by adding a !OReflectionHelper.isJavaType(genericMultiValueType) check which solves the problem (my problem at least).

Had a few issues with my lack of experience of creating pull requests (I'm old, this new fancy git stuff :-) and the code formatter (which by the way reformats recently cloned code) so there's a few formatting issues. The unit test is ugly, but I really haven't time to create a really nicely documented one, it do what it should, proves the error and my change).