### PR TITLE
Auto-create databases for distributed-mode OrientDB

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -253,17 +253,17 @@ public class OServer {
         networkListeners.add(new OServerNetworkListener(this, networkSocketFactories.get(l.socket), l.ipAddress, l.portRange,
             l.protocol, networkProtocols.get(l.protocol), l.parameters, l.commands));
 
-      registerPlugins();
-
-      for (OServerLifecycleListener l : lifecycleListeners)
-        l.onAfterActivate();
-
       try {
         loadStorages();
         loadUsers();
       } catch (IOException e) {
         OLogManager.instance().error(this, "Error on reading server configuration", e, OConfigurationException.class);
       }
+      
+      registerPlugins();
+
+      for (OServerLifecycleListener l : lifecycleListeners)
+        l.onAfterActivate();
 
       OLogManager.instance().info(this, "OrientDB Server v" + OConstants.getVersion() + " is active.");
     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
It seems as though, due to this bit of code in the OServer class, distributed-mode OrientDB doesn't automatically create databases defined in your `orientdb-server-config.xml` file. I've reordered the code so that storages are created prior to firing up plugins (e.g. Hazelcast).

With my particular application, I most certainly can't afford to create databases programmatically or via the console. Without this fix, distributed OrientDB crashes on startup and never gets to the point where it should create locally specified storages.

I've personally built this against the `develop` branch and while building `v2.0.10`, and all tests are successful.