### PR TITLE
Change to ensure list order on save

### DIFF
--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectLazyList.java
@@ -125,13 +125,13 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
       record = (OIdentifiable) OObjectEntitySerializer.getDocument((Proxy) element);
       if (orphanRemoval && record != null && sourceRecord != null)
         ((OObjectProxyMethodHandler) sourceRecord.getHandler()).getOrphans().remove(record.getIdentity());
-      recordList.add(record);
+      recordList.add(index, record);
     } else {
       element = (TYPE) OObjectEntitySerializer.serializeObject(element, getDatabase());
       record = (OIdentifiable) OObjectEntitySerializer.getDocument((Proxy) element);
       if (orphanRemoval && record != null && sourceRecord != null)
         ((OObjectProxyMethodHandler) sourceRecord.getHandler()).getOrphans().remove(record.getIdentity());
-      recordList.add(record);
+      recordList.add(index, record);
     }
     super.add(index, element);
   }
@@ -386,7 +386,7 @@ public class OObjectLazyList<TYPE> extends ArrayList<TYPE> implements OLazyObjec
 
   /**
    * Convert the item requested.
-   * 
+   *
    * @param iIndex
    *          Position of the item to convert
    */

--- a/object/src/test/java/com/orientechnologies/orient/object/db/OObjectLazyListTest.java
+++ b/object/src/test/java/com/orientechnologies/orient/object/db/OObjectLazyListTest.java
@@ -1,0 +1,101 @@
+package com.orientechnologies.orient.object.db;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Anders Heintz on 20/06/15.
+ */
+public class OObjectLazyListTest {
+  private OObjectDatabaseTx databaseTx;
+
+  @BeforeClass protected void setUp() throws Exception {
+    databaseTx = new OObjectDatabaseTx("memory:OObjectEnumLazyListTest");
+    databaseTx.create();
+
+    databaseTx.getEntityManager().registerEntityClass(EntityObject.class);
+    databaseTx.getEntityManager().registerEntityClass(EntityObjectWithList.class);
+
+  }
+
+  @AfterClass protected void tearDown() {
+
+    databaseTx.drop();
+  }
+
+  @Test public void positionTest() {
+    EntityObjectWithList listObject = getTestObject();
+
+    listObject = databaseTx.save(listObject);
+
+    EntityObject newObject = new EntityObject();
+    newObject.setFieldValue("NewObject");
+    EntityObject newObject2 = new EntityObject();
+    newObject2.setFieldValue("NewObject2");
+    listObject.getEntityObjects().add(0, newObject);
+    listObject.getEntityObjects().add(listObject.getEntityObjects().size(), newObject2);
+
+    listObject = databaseTx.save(listObject);
+
+    assert (listObject.getEntityObjects().get(0).getFieldValue().equals("NewObject"));
+    assert (listObject.getEntityObjects().get(listObject.getEntityObjects().size()-1).getFieldValue().equals("NewObject2"));
+  }
+
+  private EntityObjectWithList getTestObject() {
+
+    EntityObject entityObject1 = new EntityObject();
+    entityObject1.setFieldValue("Object 1");
+    EntityObject entityObject2 = new EntityObject();
+    entityObject2.setFieldValue("Object 1");
+    EntityObject entityObject3 = new EntityObject();
+    entityObject3.setFieldValue("Object 1");
+    EntityObject entityObject4 = new EntityObject();
+    entityObject4.setFieldValue("Object 1");
+    EntityObject entityObject5 = new EntityObject();
+    entityObject5.setFieldValue("Object 1");
+
+    EntityObjectWithList listObject = new EntityObjectWithList();
+    listObject.getEntityObjects().add(entityObject1);
+    listObject.getEntityObjects().add(entityObject2);
+    listObject.getEntityObjects().add(entityObject3);
+    listObject.getEntityObjects().add(entityObject4);
+    listObject.getEntityObjects().add(entityObject5);
+
+    return listObject;
+  }
+
+  private static class EntityObjectWithList {
+    public EntityObjectWithList() {
+    }
+
+    private List<EntityObject> entityObjects = new ArrayList<EntityObject>();
+
+    public List<EntityObject> getEntityObjects() {
+      return entityObjects;
+    }
+
+    public void setEntityObjects(List<EntityObject> entityObjects) {
+      this.entityObjects = entityObjects;
+    }
+  }
+
+  private static class EntityObject {
+    public EntityObject() {
+    }
+
+    private String fieldValue = null;
+
+    public String getFieldValue() {
+      return fieldValue;
+    }
+
+    public void setFieldValue(String fieldValue) {
+      this.fieldValue = fieldValue;
+    }
+  }
+
+}


### PR DESCRIPTION
Currently, when adding an object to a list using add(int, Object), the item is, in the database and on retrieval, added to the end of the list. This change fixes this problem. Unit test provided.