### PR TITLE
JSON scientific notation parsing

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
@@ -443,7 +443,7 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
             // TRY TO AUTODETERMINE THE BEST TYPE
             if (ORecordId.isA(iFieldValue))
               iType = OType.LINK;
-            else if (OStringSerializerHelper.contains(iFieldValue, '.')) {
+            else if (iFieldValue.matches(".*[\\.Ee].*")) {
               // DECIMAL FORMAT: DETERMINE IF DOUBLE OR FLOAT
               final Double v = new Double(OStringSerializerHelper.getStringContent(iFieldValue));
 

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 @SuppressWarnings("unchecked")
 @Test
@@ -1145,5 +1146,16 @@ public class JSONTest extends DocumentDBBaseTest {
 
   public void testOtherJson(){
     new ODocument().fromJSON("{\"Salary\":1500.0,\"Type\":\"Person\",\"Address\":[{\"Zip\":\"JX2 MSX\",\"Type\":\"Home\",\"Street1\":\"13 Marge Street\",\"Country\":\"Holland\",\"Id\":\"Address-28813211\",\"City\":\"Amsterdam\",\"From\":\"1996-02-01\",\"To\":\"1998-01-01\"},{\"Zip\":\"90210\",\"Type\":\"Work\",\"Street1\":\"100 Hollywood Drive\",\"Country\":\"USA\",\"Id\":\"Address-11595040\",\"City\":\"Los Angeles\",\"From\":\"2009-09-01\"}],\"Id\":\"Person-7464251\",\"Name\":\"Stan\"}");
+  }
+  
+  @Test
+  public void testScientificNotation() {
+    ODocument doc = new ODocument();
+    doc.fromJSON("{'number1': -9.2741500e-31, 'number2': -741800E+290}");
+   	  
+    double number1 = doc.field("number1");
+    Assert.assertEquals(number1, -9.27415E-31);
+    double number2 = doc.field("number2");
+    Assert.assertEquals(number2, 741800E+290);
   }
 }


### PR DESCRIPTION
See #4445 

This allows ODocument.fromJSON to parse scientific notation as a double. I also added a unit test which demonstrates the functionality.