### PR TITLE
Allow signal handler to be uninstalled separately from the shutdown hook

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -637,6 +637,9 @@ public class Orient extends OListenerManger<OOrientListener> {
       shutdownHook.cancel();
       shutdownHook = null;
     }
+  }
+
+  public void removeSignalHandler() {
     if (signalHandler != null) {
       signalHandler.cancel();
       signalHandler = null;


### PR DESCRIPTION
... as you might want to replace the shutdown hook, but keep the signal handling

(this is an improvement to https://github.com/orientechnologies/orientdb/pull/4364)