### PR TITLE
Mark junit and orientdb-graph as scope=test in orientdb-distributed module

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -100,13 +100,13 @@
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
junit and orientdb-graph are only used by src/test/ bits, no reason to expose these as scope=runtime, but instead should be scope=test.