### PR TITLE
Avoid direct dependency on com.sun.management classes

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/util/HeapDumper.java
+++ b/core/src/main/java/com/orientechnologies/common/util/HeapDumper.java
@@ -1,48 +1,25 @@
 package com.orientechnologies.common.util;
 
-import com.sun.management.HotSpotDiagnosticMXBean;
-
 import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import java.lang.management.ManagementFactory;
 
 public class HeapDumper {
   // This is the name of the HotSpot Diagnostic MBean
   private static final String                     HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic";
 
-  // field to store the hotspot diagnostic MBean
-  private static volatile HotSpotDiagnosticMXBean hotspotMBean;
-
+  /**
+   * Invoke {@code dumpHeap} operation on {@code com.sun.management:type=HotSpotDiagnostic} mbean.
+   */
   public static void dumpHeap(String fileName, boolean live) {
-    // initialize hotspot diagnostic MBean
-    initHotspotMBean();
-    try {
-      hotspotMBean.dumpHeap(fileName, live);
-    } catch (RuntimeException re) {
-      throw re;
-    } catch (Exception exp) {
-      throw new RuntimeException(exp);
-    }
-  }
-
-  // initialize the hotspot diagnostic MBean field
-  private static void initHotspotMBean() {
-    if (hotspotMBean == null) {
-      synchronized (HeapDumper.class) {
-        if (hotspotMBean == null) {
-          hotspotMBean = getHotspotMBean();
-        }
-      }
-    }
-  }
-
-  // get the hotspot diagnostic MBean from the
-  // platform MBean server
-  private static HotSpotDiagnosticMXBean getHotspotMBean() {
     try {
       MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-      HotSpotDiagnosticMXBean bean = ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME,
-          HotSpotDiagnosticMXBean.class);
-      return bean;
+      server.invoke(new ObjectName(HOTSPOT_BEAN_NAME),
+          "dumpHeap",
+          new Object[]{fileName, live},
+          new String[]{String.class.getName(), Boolean.TYPE.getName()}
+      );
     } catch (RuntimeException re) {
       throw re;
     } catch (Exception exp) {


### PR DESCRIPTION
This prevents problems with OSGI environments not having wiring information for `com.sun.management`:

```
Unable to resolve 154.0: missing requirement [154.0] osgi.wiring.package; (&(osgi.wiring.package=com.orientechnologies.common.console)(version>=2.1.0)) [caused by: Unable to resolve 164.0: missing requirement [164.0] osgi.wiring.package; (osgi.wiring.package=com.sun.management)]
```

... and should still allow HeapDumper.dumpHeap(String,boolean) to function.