### PR TITLE
Expose extension class-loader to be used when loading classes from config

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -107,6 +107,8 @@ public class OServer {
   private String                                           databaseDirectory;
   private final boolean                                    shutdownEngineOnExit;
 
+  private ClassLoader extensionClassLoader;
+
   public OServer() throws ClassNotFoundException, MalformedObjectNameException, NullPointerException,
       InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {
     this(true);
@@ -132,6 +134,58 @@ public class OServer {
       Orient.instance().getProfiler().startRecording();
 
     shutdownHook = new OServerShutdownHook(this);
+  }
+
+  /**
+   * Set the preferred {@link ClassLoader} used to load extensions.
+   *
+   * @since 2.1
+   */
+  public void setExtensionClassLoader(/*@Nullable*/ final ClassLoader extensionClassLoader) {
+    this.extensionClassLoader = extensionClassLoader;
+  }
+
+  /**
+   * Get the preferred {@link ClassLoader} used to load extensions.
+   *
+   * @since 2.1
+   */
+  /*@Nullable*/
+  public ClassLoader getExtensionClassLoader() {
+    return extensionClassLoader;
+  }
+
+  /**
+   * Load an extension class by name.
+   */
+  private Class<?> loadClass(final String name) throws ClassNotFoundException {
+    Class<?> loaded = tryLoadClass(extensionClassLoader, name);
+    if (loaded == null) {
+      loaded = tryLoadClass(Thread.currentThread().getContextClassLoader(), name);
+      if (loaded == null) {
+        loaded = tryLoadClass(getClass().getClassLoader(), name);
+        if (loaded == null) {
+          loaded = Class.forName(name);
+        }
+      }
+    }
+    return loaded;
+  }
+
+  /**
+   * Attempt to load a class from given class-loader.
+   */
+  /*@Nullable*/
+  private Class<?> tryLoadClass(/*@Nullable*/ final ClassLoader classLoader, final String name) {
+    if (classLoader != null) {
+      try {
+        return classLoader.loadClass(name);
+      }
+      catch (ClassNotFoundException e) {
+        // ignore
+      }
+    }
+    return null;
   }
 
   public static OServer getInstance(final String iServerId) {
@@ -241,7 +295,7 @@ public class OServer {
       // REGISTER/CREATE SOCKET FACTORIES
       if (configuration.network.sockets != null) {
         for (OServerSocketFactoryConfiguration f : configuration.network.sockets) {
-          Class<? extends OServerSocketFactory> fClass = (Class<? extends OServerSocketFactory>) Class.forName(f.implementation);
+          Class<? extends OServerSocketFactory> fClass = (Class<? extends OServerSocketFactory>) loadClass(f.implementation);
           OServerSocketFactory factory = fClass.newInstance();
           try {
             factory.config(f.name, f.parameters);
@@ -254,7 +308,7 @@ public class OServer {
 
       // REGISTER PROTOCOLS
       for (OServerNetworkProtocolConfiguration p : configuration.network.protocols)
-        networkProtocols.put(p.name, (Class<? extends ONetworkProtocol>) Class.forName(p.implementation));
+        networkProtocols.put(p.name, (Class<? extends ONetworkProtocol>) loadClass(p.implementation));
 
       // STARTUP LISTENERS
       for (OServerNetworkListenerConfiguration l : configuration.network.listeners)
@@ -891,7 +945,7 @@ public class OServer {
             continue;
         }
 
-        handler = (OServerPlugin) Class.forName(h.clazz).newInstance();
+        handler = (OServerPlugin) loadClass(h.clazz).newInstance();
 
         if (handler instanceof ODistributedServerManager)
           distributedManager = (ODistributedServerManager) handler;


### PR DESCRIPTION
This should allow embedded use-case to configure the appropriate class-loader to resolve handler, protocol and socket extension impls.

I considered making a helper for this as there are current **~41** uses of `Class.forName` in the code base, and you folks may want to consider something like that for now however I opted for a localized change to allow OServer to load classes in OSGI/embedded environments better.

`Class.forName` really should be avoided generally, but fully fixing that is a much larger change and needs some insight from you guys about intended use of dynamic class loading to properly craft a solution.

Note I marked some things with `/*@Nullable*/` as the findbugs annotations where not on class-path, I may followup to fix that.

Some refs for reading about why Class.forName is bad and how to do the same thing in safer/portable ways:

* http://blog.bjhargrave.com/2007/07/why-do-classforname-and.html
* http://blog.bjhargrave.com/2007/09/classforname-caches-defined-class-in.html
* http://njbartlett.name/2010/08/30/osgi-readiness-loading-classes.html
