### PR TITLE
Fir for setting the same class name

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -587,6 +587,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   }
 
   public OClass setName(final String name) {
+    if(getName().equals(name)) return this;
     getDatabase().checkSecurity(ORule.ResourceGeneric.SCHEMA, ORole.PERMISSION_UPDATE);
     final Character wrongCharacter = OSchemaShared.checkClassNameIfValid(name);
     OClass oClass = getDatabase().getMetadata().getSchema().getClass(name);


### PR DESCRIPTION
I understand, that setting the same name to a OClass is pretty strange, but system throwing exception in this case.

Btw, OClassImpl allow to have several OClasses with the same shortname. Is this a feature or bug?