### PR TITLE
Use scope=test for dependencies used for testing

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -76,8 +76,8 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.4</version>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
Trivial pom change which marks newly added fluent-hc dependency ( from https://github.com/orientechnologies/orientdb/commit/923183a18bf26bd9cae5ed0e70d446c934fda1b7 ) as scope=test.