### PR TITLE
Widen InterruptedException cause check to cover other exceptions.

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
@@ -144,7 +144,9 @@ public class ODistributedWorker extends Thread {
               message != null ? message.getTask() : "-");
       } finally {
         // CLEAR SERIALIZATION TL TO AVOID MEMORY LEAKS
-        OSerializationSetThreadLocal.clear();
+        if (OSerializationSetThreadLocal.INSTANCE != null) {
+          OSerializationSetThreadLocal.clear();
+        }
       }
     }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/ODistributedWorker.java
@@ -135,17 +135,13 @@ public class ODistributedWorker extends Thread {
       } catch (HazelcastInstanceNotActiveException e) {
         Thread.interrupted();
         break;
-      } catch (HazelcastException e) {
+      } catch (Throwable e) {
         if (e.getCause() instanceof InterruptedException)
           Thread.interrupted();
         else
           ODistributedServerLog.error(this, manager.getLocalNodeName(), senderNode, DIRECTION.IN,
               "error on executing distributed request %d: %s", e, message != null ? message.getId() : -1,
               message != null ? message.getTask() : "-");
-      } catch (Throwable e) {
-        ODistributedServerLog.error(this, getLocalNodeName(), senderNode, DIRECTION.IN,
-            "error on executing distributed request %d: %s", e, message != null ? message.getId() : -1,
-            message != null ? message.getTask() : "-");
       } finally {
         // CLEAR SERIALIZATION TL TO AVOID MEMORY LEAKS
         OSerializationSetThreadLocal.clear();


### PR DESCRIPTION
For example when running distributed OrientDB under OSGi the worker might throw a runtime exception whose cause is InterruptedException if it happens to be interrupted when loading classes/resources.

Also include a safety-check during cleanup due to https://github.com/hazelcast/hazelcast/issues/5526