### PR TITLE
ConcurrentLRUList.clear() should also clear the trash

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/ConcurrentLRUList.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/ConcurrentLRUList.java
@@ -275,6 +275,9 @@ public class ConcurrentLRUList implements LRUList {
 
     headReference.next.set(null);
     tailReference.set(headReference);
+
+    trash.clear();
+    trashSize.set(0);
   }
 
   @Override


### PR DESCRIPTION
When running the OrientDB tests on a machine with only one processor I kept getting assertion failures in `ReadWriteDiskCacheTest`. Looking over the code and tracing through the calls I discovered a potential issue in `ConcurrentLRUList.clear()` where it doesn't clear the trash along with the cache.

This can leave a stale sequence of nodes in the trash which eventually point back to the `headReference`. If more nodes are then moved to the trash before it is purged you can end up with two nodes whose `previous` fields both point to `headReference` (one from before clear was called, and one from after). Since the stale node appears earlier on in the trash this will be purged first, and the following assertion:
```
assert previous.next.get() == node;
```
will fail because the previous node's (ie. `headReference`'s) next field is now pointing to the node from after clear was called.

To recreate the failure more easily, temporarily set the `minTrashSize` field of `ConcurrentLRUList` to 4. You should now always get a failure running `ReadWriteDiskCacheTest`. Clearing the trash along with the cache fixes the issue (remember to set `minTrashSize` back before committing the fix!).

Note: this issue only affects unit tests which clear the `ConcurrentLRUList` and then continue using the same `ConcurrentLRUList` instance. In reality the list is cleared on shutdown and then thrown away, so this issue should not occur outside of testing.