### PR TITLE
Add configuration/profile for invocation of the animalsniffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,23 @@
                         <arguments>-Prelease</arguments>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.13</version>
+                    <configuration>
+                        <!--
+                        Keep aligned with the maven-compiler-plugins source/target, ATM this is 1.6,
+                        so we use the java16 signature.
+                        -->
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java16</artifactId>
+                            <version>1.1</version>
+                        </signature>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -428,6 +445,28 @@
     </reporting>
 
     <profiles>
+        <!--
+        Enable animal-sniffer to verify JDK compatibility.
+        -->
+        <profile>
+            <id>animalsniffer</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>java6</id>
             <activation>


### PR DESCRIPTION
This will help you ensure that your codebase does not refer to newer JDK API.

You may need to add some annotations to mark things are not really problems, but this should help you ensure you don't accidentally leak in incompatible JDK references in the future.

ATM this will cause your build to fail if you enable the profile (but that is its job to prevent you from leaking in incompatible api), as there are several places where you are using Java7 api, and also a handful of places that use Unsafe.  Probably needs someone with understanding of why/how these are used to apply the IgnoreJRERequirement annotation as appropriate.

https://github.com/mojohaus/animal-sniffer/blob/master/animal-sniffer-annotations/src/main/java/org/codehaus/mojo/animal_sniffer/IgnoreJRERequirement.java

Profile is disabled by default, recommend you update your CI automation to add `-Panimalsniffer` to enable the check.