### PR TITLE
Use new InternalError().initCause(e) for < java8 compat

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/util/MersenneTwister.java
+++ b/core/src/main/java/com/orientechnologies/common/util/MersenneTwister.java
@@ -227,7 +227,7 @@ public strictfp class MersenneTwister extends java.util.Random implements Serial
       f.mag01 = (int[]) (mag01.clone());
       return f;
     } catch (CloneNotSupportedException e) {
-      throw new InternalError(e);
+      throw (Error)new InternalError().initCause(e);
     } // should never happen
   }
 

--- a/core/src/main/java/com/orientechnologies/common/util/MersenneTwisterFast.java
+++ b/core/src/main/java/com/orientechnologies/common/util/MersenneTwisterFast.java
@@ -219,7 +219,7 @@ public class MersenneTwisterFast implements Serializable, Cloneable {
       f.mag01 = (int[]) (mag01.clone());
       return f;
     } catch (CloneNotSupportedException e) {
-      throw new InternalError(e);
+      throw (Error)new InternalError().initCause(e);
     } // should never happen
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTree.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTree.java
@@ -1909,7 +1909,7 @@ public abstract class OMVRBTree<K, V> extends AbstractMap<K, V> implements ONavi
     try {
       clone = (OMVRBTree<K, V>) super.clone();
     } catch (CloneNotSupportedException e) {
-      throw new InternalError(e);
+      throw (Error)new InternalError().initCause(e);
     }
 
     // Put clone into "virgin" state (except for comparator)

--- a/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTreeSet.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/mvrbtree/OMVRBTreeSet.java
@@ -411,7 +411,7 @@ public class OMVRBTreeSet<E> extends AbstractSet<E> implements ONavigableSet<E>,
 		try {
 			clone = (OMVRBTreeSet<E>) super.clone();
 		} catch (CloneNotSupportedException e) {
-      throw new InternalError(e);
+		  throw (Error)new InternalError().initCause(e);
 		}
 
 		clone.m = new OMVRBTreeMemory<E, Object>(m);


### PR DESCRIPTION
This should restore buildability with java7.

Highly recommend you look this related PR to help avoid brining in incompatible JDK usage in the future:

https://github.com/orientechnologies/orientdb/pull/4661
