### PR TITLE
ODatabaseDocumentTx.copy() should include componentsFactory

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -497,6 +497,7 @@ public class ODatabaseDocumentTx extends OListenerManger<ODatabaseListener> impl
     db.user = this.user;
     db.properties.putAll(this.properties);
     db.serializer = this.serializer;
+    db.componentsFactory = this.componentsFactory;
     db.metadata = new OMetadataDefault();
     db.initialized = true;
     db.storage = storage;

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/NonBlockingQueryTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/NonBlockingQueryTest.java
@@ -82,4 +82,40 @@ public class NonBlockingQueryTest extends DocumentDBBaseTest {
     }
   }
 
+  @Test
+  public void testNonBlockingQueryWithCompositeIndex() {
+    database.command(new OCommandSQL("create property Foo.x integer")).execute();
+    database.command(new OCommandSQL("create property Foo.y integer")).execute();
+    database.command(new OCommandSQL("create index Foo_xy_index on Foo (x, y) notunique")).execute();
+
+    ODatabaseDocumentTx db = database;
+    final AtomicInteger counter = new AtomicInteger(0); // db.begin();
+    for (int i = 0; i < 1000; i++) {
+      db.command(new OCommandSQL("insert into Foo (a, x, y) values ('bar', ?, ?)")).execute(i, 1000 - i);
+    }
+    Future future = db.query(new OSQLNonBlockingQuery<Object>("select from Foo where x=500 and y=500", new OCommandResultListener() {
+      @Override
+      public boolean result(Object iRecord) {
+        counter.incrementAndGet();
+        return true;
+      }
+
+      @Override
+      public void end() {
+
+      }
+    }));
+    Assert.assertFalse(counter.get() == 1);
+    try {
+      future.get();
+      Assert.assertEquals(counter.get(), 1);
+    } catch (InterruptedException e) {
+      Assert.fail();
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      Assert.fail();
+      e.printStackTrace();
+    }
+  }
+
 }


### PR DESCRIPTION
Without this you get the following exception when using a composite index with NonBlockingQuery:
```
...snip... Probably you need to rebuild indexes. Now executing query using cluster scan
java.lang.NullPointerException
	at com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx.getSerializerFactory(ODatabaseDocumentTx.java:1638)
	at com.orientechnologies.orient.core.serialization.serializer.binary.OBinarySerializerFactory.getInstance(OBinarySerializerFactory.java:104)
	at com.orientechnologies.orient.core.serialization.serializer.binary.impl.index.OCompositeKeySerializer.preprocess(OCompositeKeySerializer.java:372)
	at com.orientechnologies.orient.core.serialization.serializer.binary.impl.index.OCompositeKeySerializer.preprocess(OCompositeKeySerializer.java:46)
	at com.orientechnologies.orient.core.index.sbtree.local.OSBTree.iterateEntriesBetweenAscOrder(OSBTree.java:1224)
	at com.orientechnologies.orient.core.index.sbtree.local.OSBTree.iterateEntriesBetween(OSBTree.java:743)
	at com.orientechnologies.orient.core.index.engine.OSBTreeIndexEngine.iterateEntriesBetween(OSBTreeIndexEngine.java:327)
	at com.orientechnologies.orient.core.index.OIndexMultiValues.iterateEntriesBetween(OIndexMultiValues.java:257)
	at com.orientechnologies.orient.core.index.OIndexAbstractDelegate.iterateEntriesBetween(OIndexAbstractDelegate.java:85)
	at com.orientechnologies.orient.core.index.OIndexTxAwareMultiValue.iterateEntriesBetween(OIndexTxAwareMultiValue.java:312)
	at com.orientechnologies.orient.core.sql.operator.OQueryOperatorEquals.executeIndexQuery(OQueryOperatorEquals.java:149)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.searchForIndexes(OCommandExecutorSQLSelect.java:1859)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.searchInClasses(OCommandExecutorSQLSelect.java:850)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLResultsetAbstract.assignTarget(OCommandExecutorSQLResultsetAbstract.java:207)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.assignTarget(OCommandExecutorSQLSelect.java:475)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.executeSearch(OCommandExecutorSQLSelect.java:457)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLSelect.execute(OCommandExecutorSQLSelect.java:428)
	at com.orientechnologies.orient.core.sql.OCommandExecutorSQLDelegate.execute(OCommandExecutorSQLDelegate.java:90)
	at com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage.executeCommand(OAbstractPaginatedStorage.java:1468)
	at com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage.command(OAbstractPaginatedStorage.java:1449)
	at com.orientechnologies.orient.core.sql.query.OSQLQuery.run(OSQLQuery.java:72)
	at com.orientechnologies.orient.core.query.OQueryAbstract.execute(OQueryAbstract.java:33)
	at com.orientechnologies.orient.core.sql.query.OSQLNonBlockingQuery.access$001(OSQLNonBlockingQuery.java:48)
	at com.orientechnologies.orient.core.sql.query.OSQLNonBlockingQuery$1.run(OSQLNonBlockingQuery.java:251)
	at java.lang.Thread.run(Thread.java:745)
```