### PR TITLE
Better exception when you try to update a deleted distributed record

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedStorage.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedStorage.java
@@ -1028,7 +1028,7 @@ public class ODistributedStorage implements OStorage, OFreezableStorage, OAutosh
 
             if (previousContent.getResult() == null)
               // DELETED
-              throw new OTransactionException("Cannot update record '" + rid + "' because has been deleted");
+              throw new ORecordNotFoundException("Cannot update record '" + rid + "' because has been deleted");
 
             final ORecordVersion v = executionModeSynch ? record.getRecordVersion() : record.getRecordVersion().copy();
 


### PR DESCRIPTION
Use a more accurate exception when a distributed record couldn't be updated because it has been deleted, so clients can react accordingly. Otherwise it's hard to discern this from other instances of `OTransactionException` which typically indicate a problem with the internal transaction state.

This change also makes it more consistent with the exception used in `OUpdateRecordTask`.