### PR TITLE
[HTTP API] Exception when creating property with linkset

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostProperty.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostProperty.java
@@ -81,20 +81,27 @@ public class OServerCommandPostProperty extends OServerCommandAuthenticatedDbAbs
          throw new OHttpRequestException("Syntax error: property named " + propertyName + " is declared as " + propertyType
              + " but linked type is not declared: property/<database>/<class-name>/<property-name>/<property-type>/<link-type>");
        }
-       final OType linkType = OType.valueOf(urlParts[5]);
-       final OClass linkClass = db.getMetadata().getSchema().getClass(urlParts[5]);
-       if (linkType != null && linkClass != null) {
-         throw new IllegalArgumentException(
-             "linked type declared as "
-                 + urlParts[5]
-                 + " can be either a Type or a Class, use the JSON document usage instead. See 'http://code.google.com/p/orient/w/edit/OrientDB_REST'");
-       } else if (linkType != null) {
+
+       /* try link as OType */
+       OType linkType = null;
+       try {
+         linkType = OType.valueOf(urlParts[5]);
+       } catch (IllegalArgumentException ex) { }
+
+       if (linkType != null) {
          final OProperty prop = cls.createProperty(propertyName, propertyType, linkType);
-       } else if (linkClass != null) {
-         final OProperty prop = cls.createProperty(propertyName, propertyType, linkClass);
        } else {
-         throw new IllegalArgumentException("property named " + propertyName + " is declared as " + propertyType
-             + " but linked type is not declared");
+         /* try link as class */
+         final OClass linkClass = db.getMetadata().getSchema().getClass(urlParts[5]);
+         if (linkClass != null) {
+           final OProperty prop = cls.createProperty(propertyName, propertyType, linkClass);
+         } else {
+           /* None worked, exception */
+           throw new IllegalArgumentException(
+             "linked type declared as "
+               + urlParts[5]
+               + " can be either a Type or a Class, use the JSON document usage instead. See 'http://code.google.com/p/orient/w/edit/OrientDB_REST'");
+         }
        }
      }
        break;


### PR DESCRIPTION
Running the following
```
curl -XPOST http://localhost:2481/property/test/User/places1/LINK/place -u root:root
```

Will result in:
```
{
  "errors": [{
      "code": 500,
      "reason": 500,
      "content": "java.lang.IllegalArgumentException: No enum constant com.orientechnologies.orient.core.metadata.schema.OType.place"
      }
  ]
}
```

this PR fixes it.

Notes:
1. The problem was there was a call to OType.valueOf(), which threw the above exception. The intended behavior, at least as can be seen by the code, was to match either an OType or a custom class. Hence it is now silently ignored by surrounded in a try catch.
2. I rearranged the calls a bit, so that if OType.valueOf() succeed, there will be no lookup for a class with the same name. One less call!