### PR TITLE
Fix for UPDATE INCREMENT with dot notation fields (#4784)

### DIFF
--- a/core/src/main/grammar/OrientSQL.jjt
+++ b/core/src/main/grammar/OrientSQL.jjt
@@ -1289,7 +1289,10 @@ OUpdateIncrementItem UpdateIncrementItem():
 {}
 {
     (
-	    jjtThis.left = Identifier() <EQ> jjtThis.right = Expression()
+	    jjtThis.left = Identifier() 
+	    [ jjtThis.leftModifier = Modifier() ]
+	    <EQ> 
+	    jjtThis.right = Expression()
 	)
 	{ return jjtThis; }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OUpdateIncrementItem.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OUpdateIncrementItem.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public class OUpdateIncrementItem extends SimpleNode {
   protected OIdentifier left;
+  protected OModifier   leftModifier;
   protected OExpression right;
 
   public OUpdateIncrementItem(int id) {
@@ -24,6 +25,9 @@ public class OUpdateIncrementItem extends SimpleNode {
 
   public void toString(Map<Object, Object> params, StringBuilder builder) {
     left.toString(params, builder);
+    if (leftModifier != null) {
+      leftModifier.toString(params, builder);
+    }
     builder.append(" = ");
     right.toString(params, builder);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OrientSql.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OrientSql.java
@@ -2348,6 +2348,15 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
   jjtn000.jjtSetFirstToken(getToken(1));
     try {
       jjtn000.left = Identifier();
+      switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
+      case LBRACKET:
+      case DOT:
+        jjtn000.leftModifier = Modifier();
+        break;
+      default:
+        jj_la1[98] = jj_gen;
+        ;
+      }
       jj_consume_token(EQ);
       jjtn000.right = Expression();
           jjtree.closeNodeScope(jjtn000, true);
@@ -2391,7 +2400,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.right = Expression();
         break;
       default:
-        jj_la1[98] = jj_gen;
+        jj_la1[99] = jj_gen;
         ;
       }
       jjtree.closeNodeScope(jjtn000, true);
@@ -2537,7 +2546,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.targetClusterName = Identifier();
           break;
         default:
-          jj_la1[99] = jj_gen;
+          jj_la1[100] = jj_gen;
           ;
         }
         break;
@@ -2551,7 +2560,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.targetIndex = IndexIdentifier();
         break;
       default:
-        jj_la1[100] = jj_gen;
+        jj_la1[101] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2566,7 +2575,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.returnStatement = Projection();
         break;
       default:
-        jj_la1[101] = jj_gen;
+        jj_la1[102] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -2579,7 +2588,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                    jjtn000.selectWithFrom = true;
           break;
         default:
-          jj_la1[102] = jj_gen;
+          jj_la1[103] = jj_gen;
           ;
         }
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -2587,7 +2596,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.selectStatement = SelectStatement();
           break;
         default:
-          jj_la1[103] = jj_gen;
+          jj_la1[104] = jj_gen;
           if (jj_2_28(2)) {
             jj_consume_token(LPAREN);
             jjtn000.selectStatement = SelectStatement();
@@ -2600,7 +2609,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[104] = jj_gen;
+        jj_la1[105] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -2609,7 +2618,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                  jjtn000.unsafe = true;
         break;
       default:
-        jj_la1[105] = jj_gen;
+        jj_la1[106] = jj_gen;
         ;
       }
     jjtree.closeNodeScope(jjtn000, true);
@@ -2660,7 +2669,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[106] = jj_gen;
+            jj_la1[107] = jj_gen;
             break label_14;
           }
           jj_consume_token(COMMA);
@@ -2682,7 +2691,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[107] = jj_gen;
+            jj_la1[108] = jj_gen;
             break label_15;
           }
           jj_consume_token(COMMA);
@@ -2697,7 +2706,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[108] = jj_gen;
+            jj_la1[109] = jj_gen;
             break label_16;
           }
           jj_consume_token(COMMA);
@@ -2713,7 +2722,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[109] = jj_gen;
+              jj_la1[110] = jj_gen;
               break label_17;
             }
             jj_consume_token(COMMA);
@@ -2737,7 +2746,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[110] = jj_gen;
+            jj_la1[111] = jj_gen;
             break label_18;
           }
           jj_consume_token(COMMA);
@@ -2754,7 +2763,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.content = Json();
           break;
         default:
-          jj_la1[111] = jj_gen;
+          jj_la1[112] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2824,7 +2833,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.targetClusterName = Identifier();
         break;
       default:
-        jj_la1[112] = jj_gen;
+        jj_la1[113] = jj_gen;
         ;
       }
       jjtree.closeNodeScope(jjtn000, true);
@@ -2871,7 +2880,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.targetClusterName = Identifier();
           break;
         default:
-          jj_la1[113] = jj_gen;
+          jj_la1[114] = jj_gen;
           ;
         }
       } else if (jj_2_32(2147483647)) {
@@ -2886,7 +2895,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.returnStatement = Projection();
         break;
       default:
-        jj_la1[114] = jj_gen;
+        jj_la1[115] = jj_gen;
         ;
       }
       if (jj_2_33(2147483647)) {
@@ -2998,12 +3007,12 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.targetClusterName = Identifier();
           break;
         default:
-          jj_la1[115] = jj_gen;
+          jj_la1[116] = jj_gen;
           ;
         }
         break;
       default:
-        jj_la1[116] = jj_gen;
+        jj_la1[117] = jj_gen;
         ;
       }
       jj_consume_token(FROM);
@@ -3029,7 +3038,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[117] = jj_gen;
+              jj_la1[118] = jj_gen;
               break label_19;
             }
             jj_consume_token(COMMA);
@@ -3038,7 +3047,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           }
           break;
         default:
-          jj_la1[118] = jj_gen;
+          jj_la1[119] = jj_gen;
           ;
         }
         jj_consume_token(RBRACKET);
@@ -3085,7 +3094,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.leftIdentifier = Identifier();
         break;
       default:
-        jj_la1[119] = jj_gen;
+        jj_la1[120] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3112,7 +3121,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[120] = jj_gen;
+              jj_la1[121] = jj_gen;
               break label_20;
             }
             jj_consume_token(COMMA);
@@ -3121,7 +3130,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           }
           break;
         default:
-          jj_la1[121] = jj_gen;
+          jj_la1[122] = jj_gen;
           ;
         }
         jj_consume_token(RBRACKET);
@@ -3168,7 +3177,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.rightIdentifier = Identifier();
         break;
       default:
-        jj_la1[122] = jj_gen;
+        jj_la1[123] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3179,7 +3188,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.body = InsertBody();
         break;
       default:
-        jj_la1[123] = jj_gen;
+        jj_la1[124] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3187,7 +3196,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.retry = Retry();
         break;
       default:
-        jj_la1[124] = jj_gen;
+        jj_la1[125] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -3195,7 +3204,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.wait = Wait();
         break;
       default:
-        jj_la1[125] = jj_gen;
+        jj_la1[126] = jj_gen;
         ;
       }
     jjtree.closeNodeScope(jjtn000, true);
@@ -3240,7 +3249,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         result = NamedParameter();
         break;
       default:
-        jj_la1[126] = jj_gen;
+        jj_la1[127] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3349,7 +3358,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[127] = jj_gen;
+          jj_la1[128] = jj_gen;
           break label_21;
         }
         jj_consume_token(COMMA);
@@ -3398,7 +3407,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.alias = Alias();
         break;
       default:
-        jj_la1[128] = jj_gen;
+        jj_la1[129] = jj_gen;
         ;
       }
    jjtree.closeNodeScope(jjtn000, true);
@@ -3531,7 +3540,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[129] = jj_gen;
+          jj_la1[130] = jj_gen;
           break label_22;
         }
         jj_consume_token(COMMA);
@@ -3585,13 +3594,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                                 jjtn000.newRange = true;
           break;
         default:
-          jj_la1[130] = jj_gen;
+          jj_la1[131] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[131] = jj_gen;
+        jj_la1[132] = jj_gen;
         ;
       }
       jjtn000.toSelector = ArrayNumberSelector();
@@ -3738,7 +3747,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[132] = jj_gen;
+            jj_la1[133] = jj_gen;
             break label_23;
           }
           jj_consume_token(COMMA);
@@ -3747,7 +3756,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[133] = jj_gen;
+        jj_la1[134] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -3838,7 +3847,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[134] = jj_gen;
+            jj_la1[135] = jj_gen;
             break label_24;
           }
           jj_consume_token(COMMA);
@@ -3847,7 +3856,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[135] = jj_gen;
+        jj_la1[136] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -3894,7 +3903,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                  jjtn000.self = true;
           break;
         default:
-          jj_la1[136] = jj_gen;
+          jj_la1[137] = jj_gen;
           if (jj_2_44(2147483647)) {
             jjtn000.collection = Collection();
           } else {
@@ -3948,7 +3957,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                    jjtn000.star = true;
           break;
         default:
-          jj_la1[137] = jj_gen;
+          jj_la1[138] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4046,7 +4055,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jj_consume_token(RBRACKET);
         break;
       default:
-        jj_la1[138] = jj_gen;
+        jj_la1[139] = jj_gen;
         if (jj_2_52(2147483647)) {
           jjtn000.methodCall = MethodCall();
         } else {
@@ -4056,7 +4065,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             jjtn000.suffix = SuffixIdentifier();
             break;
           default:
-            jj_la1[139] = jj_gen;
+            jj_la1[140] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4107,7 +4116,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                 jjtn000.value = null;
         break;
       default:
-        jj_la1[140] = jj_gen;
+        jj_la1[141] = jj_gen;
         if (jj_2_54(2147483647)) {
           jjtn000.value = Rid();
         } else if (jj_2_55(2147483647)) {
@@ -4128,7 +4137,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                  jjtn000.value = false;
             break;
           default:
-            jj_la1[141] = jj_gen;
+            jj_la1[142] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4188,7 +4197,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                                                                jjtn000.operators.add(OMathExpression.Operator.MINUS);
           break;
         default:
-          jj_la1[142] = jj_gen;
+          jj_la1[143] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4257,7 +4266,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                         jjtn000.operators.add( OMathExpression.Operator.REM);
           break;
         default:
-          jj_la1[143] = jj_gen;
+          jj_la1[144] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4392,7 +4401,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.statement = SelectStatement();
         break;
       default:
-        jj_la1[144] = jj_gen;
+        jj_la1[145] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4492,7 +4501,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                               jjtn000.string = token.image;
           break;
         default:
-          jj_la1[145] = jj_gen;
+          jj_la1[146] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4503,7 +4512,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[146] = jj_gen;
+        jj_la1[147] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4586,7 +4595,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[147] = jj_gen;
+          jj_la1[148] = jj_gen;
           break label_27;
         }
         jj_consume_token(COMMA);
@@ -4645,7 +4654,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               jjtn000.query = TraverseStatement();
               break;
             default:
-              jj_la1[148] = jj_gen;
+              jj_la1[149] = jj_gen;
               jj_consume_token(-1);
               throw new ParseException();
             }
@@ -4653,7 +4662,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jj_consume_token(RPAREN);
           break;
         default:
-          jj_la1[149] = jj_gen;
+          jj_la1[150] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4737,7 +4746,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             jjtn000.statement = MatchStatement();
             break;
           default:
-            jj_la1[150] = jj_gen;
+            jj_la1[151] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4783,7 +4792,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[151] = jj_gen;
+        jj_la1[152] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4879,7 +4888,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[152] = jj_gen;
+            jj_la1[153] = jj_gen;
             break label_28;
           }
           jj_consume_token(COMMA);
@@ -4888,7 +4897,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[153] = jj_gen;
+        jj_la1[154] = jj_gen;
         ;
       }
       jj_consume_token(RBRACKET);
@@ -4966,7 +4975,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                jjtn000.type = OIndexIdentifier.Type.VALUESDESC;
         break;
       default:
-        jj_la1[154] = jj_gen;
+        jj_la1[155] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5035,7 +5044,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[155] = jj_gen;
+          jj_la1[156] = jj_gen;
           break label_29;
         }
         jj_consume_token(OR);
@@ -5085,7 +5094,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[156] = jj_gen;
+          jj_la1[157] = jj_gen;
           break label_30;
         }
         jj_consume_token(AND);
@@ -5189,7 +5198,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[157] = jj_gen;
+        jj_la1[158] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5305,7 +5314,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               result = OBooleanExpression.FALSE;
           break;
         default:
-          jj_la1[158] = jj_gen;
+          jj_la1[159] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -5383,7 +5392,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         result = WithinOperator();
         break;
       default:
-        jj_la1[159] = jj_gen;
+        jj_la1[160] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5688,7 +5697,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                  jjtn000.doubleEquals = true;
         break;
       default:
-        jj_la1[160] = jj_gen;
+        jj_la1[161] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5828,7 +5837,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                                                              jjtn000.rightString = token.image;
         break;
       default:
-        jj_la1[161] = jj_gen;
+        jj_la1[162] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5935,7 +5944,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[162] = jj_gen;
+              jj_la1[163] = jj_gen;
               break label_31;
             }
             jj_consume_token(COMMA);
@@ -5944,7 +5953,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           }
           break;
         default:
-          jj_la1[163] = jj_gen;
+          jj_la1[164] = jj_gen;
           ;
         }
         jj_consume_token(RBRACKET);
@@ -6003,7 +6012,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[164] = jj_gen;
+              jj_la1[165] = jj_gen;
               break label_32;
             }
             jj_consume_token(COMMA);
@@ -6012,7 +6021,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           }
           break;
         default:
-          jj_la1[165] = jj_gen;
+          jj_la1[166] = jj_gen;
           ;
         }
         jj_consume_token(RBRACKET);
@@ -6068,7 +6077,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
               ;
               break;
             default:
-              jj_la1[166] = jj_gen;
+              jj_la1[167] = jj_gen;
               break label_33;
             }
             jj_consume_token(COMMA);
@@ -6077,13 +6086,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           }
           break;
         default:
-          jj_la1[167] = jj_gen;
+          jj_la1[168] = jj_gen;
           ;
         }
         jj_consume_token(RBRACKET);
         break;
       default:
-        jj_la1[168] = jj_gen;
+        jj_la1[169] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -6427,7 +6436,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.rightMathExpression = MathExpression();
           break;
         default:
-          jj_la1[169] = jj_gen;
+          jj_la1[170] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -6517,7 +6526,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.rightMathExpression = MathExpression();
           break;
         default:
-          jj_la1[170] = jj_gen;
+          jj_la1[171] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -6651,7 +6660,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                            jjtn000.right = token.image;
         break;
       default:
-        jj_la1[171] = jj_gen;
+        jj_la1[172] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -6759,7 +6768,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                        lastItem.modifier = lastModifier;
             break;
           default:
-            jj_la1[172] = jj_gen;
+            jj_la1[173] = jj_gen;
             ;
           }
           break;
@@ -6773,7 +6782,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                      lastItem.recordAttr = lastToken.image;
           break;
         default:
-          jj_la1[173] = jj_gen;
+          jj_la1[174] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -6790,13 +6799,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                       lastItem.type = OOrderByItem.ASC;
             break;
           default:
-            jj_la1[174] = jj_gen;
+            jj_la1[175] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
         default:
-          jj_la1[175] = jj_gen;
+          jj_la1[176] = jj_gen;
           ;
         }
         break;
@@ -6837,7 +6846,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                        lastItem.modifier = lastModifier;
             break;
           default:
-            jj_la1[176] = jj_gen;
+            jj_la1[177] = jj_gen;
             ;
           }
           break;
@@ -6851,7 +6860,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                      lastItem.recordAttr = lastToken.image;
           break;
         default:
-          jj_la1[177] = jj_gen;
+          jj_la1[178] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -6868,19 +6877,19 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                       lastItem.type = OOrderByItem.ASC;
             break;
           default:
-            jj_la1[178] = jj_gen;
+            jj_la1[179] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
           break;
         default:
-          jj_la1[179] = jj_gen;
+          jj_la1[180] = jj_gen;
           ;
         }
         jj_consume_token(RPAREN);
         break;
       default:
-        jj_la1[180] = jj_gen;
+        jj_la1[181] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -6891,7 +6900,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[181] = jj_gen;
+          jj_la1[182] = jj_gen;
           break label_34;
         }
         jj_consume_token(COMMA);
@@ -6958,7 +6967,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                            lastItem.modifier = lastModifier;
               break;
             default:
-              jj_la1[182] = jj_gen;
+              jj_la1[183] = jj_gen;
               ;
             }
             break;
@@ -6972,7 +6981,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                          lastItem.recordAttr = lastToken.image;
             break;
           default:
-            jj_la1[183] = jj_gen;
+            jj_la1[184] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -6989,13 +6998,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                           lastItem.type = OOrderByItem.ASC;
               break;
             default:
-              jj_la1[184] = jj_gen;
+              jj_la1[185] = jj_gen;
               jj_consume_token(-1);
               throw new ParseException();
             }
             break;
           default:
-            jj_la1[185] = jj_gen;
+            jj_la1[186] = jj_gen;
             ;
           }
           break;
@@ -7036,7 +7045,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                            lastItem.modifier = lastModifier;
               break;
             default:
-              jj_la1[186] = jj_gen;
+              jj_la1[187] = jj_gen;
               ;
             }
             break;
@@ -7050,7 +7059,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                          lastItem.recordAttr = lastToken.image;
             break;
           default:
-            jj_la1[187] = jj_gen;
+            jj_la1[188] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -7067,19 +7076,19 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                           lastItem.type = OOrderByItem.ASC;
               break;
             default:
-              jj_la1[188] = jj_gen;
+              jj_la1[189] = jj_gen;
               jj_consume_token(-1);
               throw new ParseException();
             }
             break;
           default:
-            jj_la1[189] = jj_gen;
+            jj_la1[190] = jj_gen;
             ;
           }
           jj_consume_token(RPAREN);
           break;
         default:
-          jj_la1[190] = jj_gen;
+          jj_la1[191] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -7129,7 +7138,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[191] = jj_gen;
+          jj_la1[192] = jj_gen;
           break label_35;
         }
         jj_consume_token(COMMA);
@@ -7180,7 +7189,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[192] = jj_gen;
+          jj_la1[193] = jj_gen;
           break label_36;
         }
         jj_consume_token(COMMA);
@@ -7232,7 +7241,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.inputParam = InputParameter();
         break;
       default:
-        jj_la1[193] = jj_gen;
+        jj_la1[194] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -7283,7 +7292,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.inputParam = InputParameter();
           break;
         default:
-          jj_la1[194] = jj_gen;
+          jj_la1[195] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -7300,13 +7309,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jjtn000.inputParam = InputParameter();
           break;
         default:
-          jj_la1[195] = jj_gen;
+          jj_la1[196] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[196] = jj_gen;
+        jj_la1[197] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -7355,7 +7364,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.inputParam = InputParameter();
         break;
       default:
-        jj_la1[197] = jj_gen;
+        jj_la1[198] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -7409,13 +7418,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                 jjtn000.failureStrategy = OTimeout.EXCEPTION;
           break;
         default:
-          jj_la1[198] = jj_gen;
+          jj_la1[199] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
       default:
-        jj_la1[199] = jj_gen;
+        jj_la1[200] = jj_gen;
         ;
       }
           jjtree.closeNodeScope(jjtn000, true);
@@ -7575,7 +7584,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[200] = jj_gen;
+            jj_la1[201] = jj_gen;
             break label_37;
           }
           jj_consume_token(COMMA);
@@ -7584,7 +7593,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[201] = jj_gen;
+        jj_la1[202] = jj_gen;
         ;
       }
       jj_consume_token(RBRACKET);
@@ -7656,7 +7665,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[202] = jj_gen;
+          jj_la1[203] = jj_gen;
           break label_38;
         }
         lastItem = FetchPlanItem();
@@ -7733,7 +7742,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           jj_consume_token(RBRACKET);
           break;
         default:
-          jj_la1[203] = jj_gen;
+          jj_la1[204] = jj_gen;
           ;
         }
         lastIdentifier = Identifier();
@@ -7744,7 +7753,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                              lastStarred = true;
           break;
         default:
-          jj_la1[204] = jj_gen;
+          jj_la1[205] = jj_gen;
           ;
         }
                 String field = lastIdentifier.getValue();
@@ -7759,7 +7768,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[205] = jj_gen;
+            jj_la1[206] = jj_gen;
             break label_39;
           }
           jj_consume_token(DOT);
@@ -7771,7 +7780,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                                                         lastStarred = true;
             break;
           default:
-            jj_la1[206] = jj_gen;
+            jj_la1[207] = jj_gen;
             ;
           }
                      field = lastIdentifier.getValue();
@@ -7782,7 +7791,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[207] = jj_gen;
+        jj_la1[208] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -7926,7 +7935,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                               lastItem.leftString = token.image.substring(1, token.image.length() - 1);
           break;
         default:
-          jj_la1[208] = jj_gen;
+          jj_la1[209] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -7940,7 +7949,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[209] = jj_gen;
+            jj_la1[210] = jj_gen;
             break label_40;
           }
           jj_consume_token(COMMA);
@@ -7980,7 +7989,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
                                                   lastItem.leftString = token.image.substring(1, token.image.length() - 1);
             break;
           default:
-            jj_la1[210] = jj_gen;
+            jj_la1[211] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -7990,7 +7999,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[211] = jj_gen;
+        jj_la1[212] = jj_gen;
         ;
       }
       jj_consume_token(RBRACE);
@@ -8036,7 +8045,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[212] = jj_gen;
+          jj_la1[213] = jj_gen;
           break label_41;
         }
         if (jj_2_100(2)) {
@@ -8089,7 +8098,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.filter = MatchFilter();
         break;
       default:
-        jj_la1[213] = jj_gen;
+        jj_la1[214] = jj_gen;
         ;
       }
        jjtree.closeNodeScope(jjtn000, true);
@@ -8132,7 +8141,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.filter = MatchFilter();
         break;
       default:
-        jj_la1[214] = jj_gen;
+        jj_la1[215] = jj_gen;
         ;
       }
        jjtree.closeNodeScope(jjtn000, true);
@@ -8180,7 +8189,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
           ;
           break;
         default:
-          jj_la1[215] = jj_gen;
+          jj_la1[216] = jj_gen;
           break label_42;
         }
         nextItem = MatchPathItem();
@@ -8192,7 +8201,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.filter = MatchFilter();
         break;
       default:
-        jj_la1[216] = jj_gen;
+        jj_la1[217] = jj_gen;
         ;
       }
        jjtree.closeNodeScope(jjtn000, true);
@@ -8246,7 +8255,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
             ;
             break;
           default:
-            jj_la1[217] = jj_gen;
+            jj_la1[218] = jj_gen;
             break label_43;
           }
           jj_consume_token(COMMA);
@@ -8255,7 +8264,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         }
         break;
       default:
-        jj_la1[218] = jj_gen;
+        jj_la1[219] = jj_gen;
         ;
       }
       jj_consume_token(RBRACE);
@@ -8329,7 +8338,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
         jjtn000.maxDepth = Integer();
         break;
       default:
-        jj_la1[219] = jj_gen;
+        jj_la1[220] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -9067,28 +9076,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     finally { jj_save(100, xla); }
   }
 
-  private boolean jj_3_11() {
-    if (jj_3R_52()) return true;
-    return false;
-  }
-
   private boolean jj_3R_358() {
     if (jj_scan_token(NEQ)) return true;
     return false;
   }
 
+  private boolean jj_3_11() {
+    if (jj_3R_52()) return true;
+    return false;
+  }
+
   private boolean jj_3_10() {
     if (jj_3R_51()) return true;
-    return false;
-  }
-
-  private boolean jj_3_9() {
-    if (jj_3R_50()) return true;
-    return false;
-  }
-
-  private boolean jj_3_12() {
-    if (jj_3R_53()) return true;
     return false;
   }
 
@@ -9099,13 +9098,23 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_8() {
-    if (jj_3R_49()) return true;
+  private boolean jj_3_9() {
+    if (jj_3R_50()) return true;
     return false;
   }
 
   private boolean jj_3R_357() {
     if (jj_scan_token(NE)) return true;
+    return false;
+  }
+
+  private boolean jj_3_12() {
+    if (jj_3R_53()) return true;
+    return false;
+  }
+
+  private boolean jj_3_8() {
+    if (jj_3R_49()) return true;
     return false;
   }
 
@@ -9120,11 +9129,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_356() {
     if (jj_scan_token(GT)) return true;
-    return false;
-  }
-
-  private boolean jj_3_7() {
-    if (jj_3R_48()) return true;
     return false;
   }
 
@@ -9152,8 +9156,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_6() {
-    if (jj_3R_47()) return true;
+  private boolean jj_3_7() {
+    if (jj_3R_48()) return true;
     return false;
   }
 
@@ -9181,6 +9185,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_305() {
     if (jj_3R_361()) return true;
+    return false;
+  }
+
+  private boolean jj_3_6() {
+    if (jj_3R_47()) return true;
     return false;
   }
 
@@ -9250,14 +9259,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_5() {
-    if (jj_3R_46()) return true;
-    return false;
-  }
-
   private boolean jj_3R_241() {
     if (jj_scan_token(CLUSTER)) return true;
     if (jj_3R_62()) return true;
+    return false;
+  }
+
+  private boolean jj_3_5() {
+    if (jj_3R_46()) return true;
     return false;
   }
 
@@ -9280,11 +9289,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     }
     }
     }
-    return false;
-  }
-
-  private boolean jj_3_4() {
-    if (jj_3R_45()) return true;
     return false;
   }
 
@@ -9336,8 +9340,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_3() {
-    if (jj_3R_44()) return true;
+  private boolean jj_3_4() {
+    if (jj_3R_45()) return true;
     return false;
   }
 
@@ -9386,6 +9390,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3_3() {
+    if (jj_3R_44()) return true;
+    return false;
+  }
+
   private boolean jj_3R_226() {
     if (jj_scan_token(FALSE)) return true;
     return false;
@@ -9403,11 +9412,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3_85() {
     if (jj_3R_101()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_351() {
-    if (jj_3R_45()) return true;
     return false;
   }
 
@@ -9434,8 +9438,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_350() {
-    if (jj_3R_44()) return true;
+  private boolean jj_3R_351() {
+    if (jj_3R_45()) return true;
     return false;
   }
 
@@ -9458,6 +9462,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_350() {
+    if (jj_3R_44()) return true;
+    return false;
+  }
+
   private boolean jj_3R_477() {
     if (jj_3R_462()) return true;
     return false;
@@ -9473,16 +9482,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_291() {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_350()) {
-    jj_scanpos = xsp;
-    if (jj_3R_351()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3R_220() {
     if (jj_3R_100()) return true;
     return false;
@@ -9493,18 +9492,28 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_108() {
-    if (jj_scan_token(MINUS)) return true;
-    return false;
-  }
-
   private boolean jj_3_80() {
     if (jj_3R_96()) return true;
     return false;
   }
 
+  private boolean jj_3R_291() {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_350()) {
+    jj_scanpos = xsp;
+    if (jj_3R_351()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3R_219() {
     if (jj_3R_99()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_108() {
+    if (jj_scan_token(MINUS)) return true;
     return false;
   }
 
@@ -9534,14 +9543,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_45() {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_108()) jj_scanpos = xsp;
-    if (jj_scan_token(FLOATING_POINT_LITERAL)) return true;
-    return false;
-  }
-
   private boolean jj_3_79() {
     if (jj_3R_95()) return true;
     return false;
@@ -9560,6 +9561,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3_77() {
     if (jj_3R_93()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_45() {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_108()) jj_scanpos = xsp;
+    if (jj_scan_token(FLOATING_POINT_LITERAL)) return true;
     return false;
   }
 
@@ -9613,11 +9622,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_107() {
-    if (jj_scan_token(MINUS)) return true;
-    return false;
-  }
-
   private boolean jj_3R_215() {
     if (jj_3R_95()) return true;
     return false;
@@ -9641,6 +9645,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_107() {
+    if (jj_scan_token(MINUS)) return true;
+    return false;
+  }
+
   private boolean jj_3R_474() {
     if (jj_3R_462()) return true;
     return false;
@@ -9657,16 +9666,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_211() {
+    if (jj_3R_91()) return true;
+    return false;
+  }
+
   private boolean jj_3R_44() {
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_107()) jj_scanpos = xsp;
     if (jj_scan_token(INTEGER_LITERAL)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_211() {
-    if (jj_3R_91()) return true;
     return false;
   }
 
@@ -10723,6 +10732,17 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_327() {
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_62()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_293() {
+    if (jj_3R_77()) return true;
+    return false;
+  }
+
   private boolean jj_3_1() {
     if (jj_scan_token(166)) return true;
     if (jj_3R_44()) return true;
@@ -10738,22 +10758,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_327() {
-    if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_62()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_293() {
-    if (jj_3R_77()) return true;
-    return false;
-  }
-
   private boolean jj_3R_208() {
     if (jj_3R_66()) return true;
     Token xsp;
     xsp = jj_scanpos;
     if (jj_3R_294()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3R_204() {
+    if (jj_3R_67()) return true;
     return false;
   }
 
@@ -10764,11 +10778,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     jj_scanpos = xsp;
     if (jj_3_2()) return true;
     }
-    return false;
-  }
-
-  private boolean jj_3R_204() {
-    if (jj_3R_67()) return true;
     return false;
   }
 
@@ -10900,6 +10909,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_203() {
+    if (jj_3R_87()) return true;
+    return false;
+  }
+
   private boolean jj_3R_163() {
     if (jj_3R_262()) return true;
     return false;
@@ -10911,16 +10925,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_203() {
-    if (jj_3R_87()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_161() {
-    if (jj_3R_62()) return true;
-    return false;
-  }
-
   private boolean jj_3R_202() {
     if (jj_3R_86()) return true;
     return false;
@@ -10928,6 +10932,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_451() {
     if (jj_3R_77()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_161() {
+    if (jj_3R_62()) return true;
     return false;
   }
 
@@ -10966,11 +10975,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_26() {
-    if (jj_3R_60()) return true;
-    return false;
-  }
-
   private boolean jj_3R_419() {
     if (jj_scan_token(ASC)) return true;
     return false;
@@ -10990,6 +10994,24 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     xsp = jj_scanpos;
     if (jj_3R_430()) jj_scanpos = xsp;
     if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_423() {
+    if (jj_3R_62()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_451()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3_26() {
+    if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_84() {
+    if (jj_scan_token(REM)) return true;
     return false;
   }
 
@@ -11013,21 +11035,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_423() {
-    if (jj_3R_62()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_451()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_84() {
-    if (jj_scan_token(REM)) return true;
-    return false;
-  }
-
   private boolean jj_3R_83() {
     if (jj_scan_token(SLASH)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_82() {
+    if (jj_scan_token(STAR)) return true;
     return false;
   }
 
@@ -11038,11 +11052,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_151() {
     if (jj_3R_262()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_82() {
-    if (jj_scan_token(STAR)) return true;
     return false;
   }
 
@@ -11062,16 +11071,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_264() {
-    if (jj_3R_54()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_148() {
-    if (jj_3R_66()) return true;
-    return false;
-  }
-
   private boolean jj_3_58() {
     Token xsp;
     xsp = jj_scanpos;
@@ -11086,14 +11085,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_79() {
-    if (jj_scan_token(PLUS)) return true;
+  private boolean jj_3R_264() {
+    if (jj_3R_54()) return true;
     return false;
   }
 
-  private boolean jj_3R_343() {
-    if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_65()) return true;
+  private boolean jj_3R_148() {
+    if (jj_3R_66()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_79() {
+    if (jj_scan_token(PLUS)) return true;
     return false;
   }
 
@@ -11112,20 +11115,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_420() {
-    if (jj_3R_77()) return true;
+  private boolean jj_3R_343() {
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_65()) return true;
     return false;
   }
 
-  private boolean jj_3R_147() {
-    if (jj_scan_token(LPAREN)) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_264()) {
-    jj_scanpos = xsp;
-    if (jj_3R_265()) return true;
-    }
-    if (jj_scan_token(RPAREN)) return true;
+  private boolean jj_3R_420() {
+    if (jj_3R_77()) return true;
     return false;
   }
 
@@ -11157,6 +11154,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_384() {
     if (jj_3R_65()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_147() {
+    if (jj_scan_token(LPAREN)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_264()) {
+    jj_scanpos = xsp;
+    if (jj_3R_265()) return true;
+    }
+    if (jj_scan_token(RPAREN)) return true;
     return false;
   }
 
@@ -11288,8 +11297,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3_55() {
+    if (jj_3R_66()) return true;
+    return false;
+  }
+
   private boolean jj_3_24() {
     if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_182() {
+    if (jj_scan_token(FALSE)) return true;
     return false;
   }
 
@@ -11326,16 +11345,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_55() {
-    if (jj_3R_66()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_182() {
-    if (jj_scan_token(FALSE)) return true;
-    return false;
-  }
-
   private boolean jj_3_54() {
     if (jj_3R_65()) return true;
     return false;
@@ -11346,13 +11355,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_180() {
+    if (jj_3R_274()) return true;
+    return false;
+  }
+
   private boolean jj_3R_160() {
     if (jj_3R_253()) return true;
     return false;
   }
 
-  private boolean jj_3R_180() {
-    if (jj_3R_274()) return true;
+  private boolean jj_3R_179() {
+    if (jj_3R_78()) return true;
     return false;
   }
 
@@ -11372,8 +11386,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_179() {
-    if (jj_3R_78()) return true;
+  private boolean jj_3R_178() {
+    if (jj_3R_66()) return true;
     return false;
   }
 
@@ -11392,18 +11406,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_178() {
-    if (jj_3R_66()) return true;
-    return false;
-  }
-
   private boolean jj_3R_177() {
-    if (jj_3R_65()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_344() {
-    if (jj_scan_token(COMMA)) return true;
     if (jj_3R_65()) return true;
     return false;
   }
@@ -11420,6 +11423,12 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     }
     xsp = jj_scanpos;
     if (jj_3R_382()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3R_344() {
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_65()) return true;
     return false;
   }
 
@@ -11491,22 +11500,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_154() {
-    if (jj_scan_token(LBRACKET)) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_266()) jj_scanpos = xsp;
-    if (jj_scan_token(RBRACKET)) return true;
-    return false;
-  }
-
   private boolean jj_3_50() {
     if (jj_3R_74()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_153() {
-    if (jj_3R_65()) return true;
     return false;
   }
 
@@ -11535,8 +11530,22 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_154() {
+    if (jj_scan_token(LBRACKET)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_266()) jj_scanpos = xsp;
+    if (jj_scan_token(RBRACKET)) return true;
+    return false;
+  }
+
   private boolean jj_3_49() {
     if (jj_3R_73()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_153() {
+    if (jj_3R_65()) return true;
     return false;
   }
 
@@ -11588,6 +11597,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_234() {
+    if (jj_3R_67()) return true;
+    return false;
+  }
+
   private boolean jj_3_22() {
     if (jj_3R_60()) return true;
     return false;
@@ -11598,8 +11612,17 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_234() {
+  private boolean jj_3R_101() {
     if (jj_3R_67()) return true;
+    if (jj_scan_token(CONTAINSTEXT)) return true;
+    if (jj_3R_67()) return true;
+    return false;
+  }
+
+  private boolean jj_3_97() {
+    if (jj_scan_token(LPAREN)) return true;
+    if (jj_3R_74()) return true;
+    if (jj_scan_token(RPAREN)) return true;
     return false;
   }
 
@@ -11632,30 +11655,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_101() {
-    if (jj_3R_67()) return true;
-    if (jj_scan_token(CONTAINSTEXT)) return true;
-    if (jj_3R_67()) return true;
-    return false;
-  }
-
-  private boolean jj_3_97() {
-    if (jj_scan_token(LPAREN)) return true;
-    if (jj_3R_74()) return true;
-    if (jj_scan_token(RPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_340() {
-    if (jj_3R_60()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_261() {
-    if (jj_3R_62()) return true;
-    return false;
-  }
-
   private boolean jj_3R_198() {
     if (jj_scan_token(LBRACKET)) return true;
     Token xsp;
@@ -11671,14 +11670,29 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_277() {
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_67()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_340() {
+    if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_261() {
+    if (jj_3R_62()) return true;
+    return false;
+  }
+
   private boolean jj_3R_339() {
     if (jj_3R_54()) return true;
     return false;
   }
 
-  private boolean jj_3R_277() {
-    if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_67()) return true;
+  private boolean jj_3_48() {
+    if (jj_3R_72()) return true;
     return false;
   }
 
@@ -11703,19 +11717,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_48() {
-    if (jj_3R_72()) return true;
+  private boolean jj_3_47() {
+    if (jj_3R_71()) return true;
     return false;
   }
 
   private boolean jj_3R_395() {
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_65()) return true;
-    return false;
-  }
-
-  private boolean jj_3_47() {
-    if (jj_3R_71()) return true;
     return false;
   }
 
@@ -11746,6 +11755,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_229() {
+    if (jj_3R_78()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_353() {
+    if (jj_3R_72()) return true;
+    return false;
+  }
+
   private boolean jj_3R_259() {
     if (jj_scan_token(LPAREN)) return true;
     Token xsp;
@@ -11758,30 +11777,10 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_229() {
-    if (jj_3R_78()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_353() {
-    if (jj_3R_72()) return true;
-    return false;
-  }
-
   private boolean jj_3_96() {
     if (jj_scan_token(LPAREN)) return true;
     if (jj_3R_66()) return true;
     if (jj_scan_token(RPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_338() {
-    if (jj_3R_65()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_395()) { jj_scanpos = xsp; break; }
-    }
     return false;
   }
 
@@ -11794,6 +11793,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     if (jj_scan_token(LPAREN)) return true;
     if (jj_3R_54()) return true;
     if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_338() {
+    if (jj_3R_65()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_395()) { jj_scanpos = xsp; break; }
+    }
     return false;
   }
 
@@ -11814,25 +11823,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3_45() {
     if (jj_3R_62()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_258() {
-    if (jj_scan_token(LBRACKET)) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_338()) jj_scanpos = xsp;
-    if (jj_scan_token(RBRACKET)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_257() {
-    if (jj_3R_65()) return true;
-    return false;
-  }
-
-  private boolean jj_3_20() {
-    if (jj_3R_60()) return true;
     return false;
   }
 
@@ -11857,13 +11847,32 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_19() {
-    if (jj_3R_54()) return true;
+  private boolean jj_3R_258() {
+    if (jj_scan_token(LBRACKET)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_338()) jj_scanpos = xsp;
+    if (jj_scan_token(RBRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_257() {
+    if (jj_3R_65()) return true;
+    return false;
+  }
+
+  private boolean jj_3_20() {
+    if (jj_3R_60()) return true;
     return false;
   }
 
   private boolean jj_3R_189() {
     if (jj_3R_70()) return true;
+    return false;
+  }
+
+  private boolean jj_3_19() {
+    if (jj_3R_54()) return true;
     return false;
   }
 
@@ -11889,6 +11898,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3_93() {
+    if (jj_scan_token(LPAREN)) return true;
+    if (jj_3R_54()) return true;
+    if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
   private boolean jj_3R_141() {
     if (jj_scan_token(TO)) return true;
     Token xsp;
@@ -11909,25 +11925,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_93() {
-    if (jj_scan_token(LPAREN)) return true;
-    if (jj_3R_54()) return true;
-    if (jj_scan_token(RPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_256() {
-    if (jj_3R_60()) return true;
-    return false;
-  }
-
   private boolean jj_3_43() {
     if (jj_3R_68()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_140() {
-    if (jj_3R_62()) return true;
     return false;
   }
 
@@ -11941,6 +11940,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     if (jj_3R_190()) return true;
     }
     }
+    return false;
+  }
+
+  private boolean jj_3R_256() {
+    if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_140() {
+    if (jj_3R_62()) return true;
     return false;
   }
 
@@ -11959,14 +11968,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_337() {
-    if (jj_scan_token(COMMA)) return true;
-    if (jj_3R_65()) return true;
+  private boolean jj_3R_186() {
+    if (jj_scan_token(THIS)) return true;
     return false;
   }
 
-  private boolean jj_3R_186() {
-    if (jj_scan_token(THIS)) return true;
+  private boolean jj_3R_337() {
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_65()) return true;
     return false;
   }
 
@@ -11982,18 +11991,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3_92() {
     if (jj_3R_67()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_138() {
-    if (jj_scan_token(LPAREN)) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_255()) {
-    jj_scanpos = xsp;
-    if (jj_3R_256()) return true;
-    }
-    if (jj_scan_token(RPAREN)) return true;
     return false;
   }
 
@@ -12018,6 +12015,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_138() {
+    if (jj_scan_token(LPAREN)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_255()) {
+    jj_scanpos = xsp;
+    if (jj_3R_256()) return true;
+    }
+    if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
   private boolean jj_3R_71() {
     Token xsp;
     xsp = jj_scanpos;
@@ -12031,22 +12040,22 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_254() {
-    if (jj_3R_65()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_337()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
   private boolean jj_3R_197() {
     if (jj_3R_67()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
       if (jj_3R_287()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_254() {
+    if (jj_3R_65()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_337()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -12078,15 +12087,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_137() {
-    if (jj_scan_token(LBRACKET)) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_254()) jj_scanpos = xsp;
-    if (jj_scan_token(RBRACKET)) return true;
-    return false;
-  }
-
   private boolean jj_3R_76() {
     if (jj_scan_token(DOT)) return true;
     if (jj_3R_62()) return true;
@@ -12095,6 +12095,15 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     xsp = jj_scanpos;
     if (jj_3R_197()) jj_scanpos = xsp;
     if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_137() {
+    if (jj_scan_token(LBRACKET)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_254()) jj_scanpos = xsp;
+    if (jj_scan_token(RBRACKET)) return true;
     return false;
   }
 
@@ -12191,11 +12200,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_134() {
-    if (jj_3R_253()) return true;
-    return false;
-  }
-
   private boolean jj_3R_93() {
     if (jj_3R_67()) return true;
     if (jj_scan_token(IS)) return true;
@@ -12203,8 +12207,18 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_134() {
+    if (jj_3R_253()) return true;
+    return false;
+  }
+
   private boolean jj_3R_70() {
     if (jj_scan_token(RECORD_ATTRIBUTE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_396() {
+    if (jj_3R_62()) return true;
     return false;
   }
 
@@ -12218,15 +12232,17 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_396() {
-    if (jj_3R_62()) return true;
-    return false;
-  }
-
   private boolean jj_3R_90() {
     if (jj_3R_67()) return true;
     if (jj_scan_token(IS)) return true;
     if (jj_scan_token(NOT)) return true;
+    if (jj_scan_token(NULL)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_91() {
+    if (jj_3R_67()) return true;
+    if (jj_scan_token(IS)) return true;
     if (jj_scan_token(NULL)) return true;
     return false;
   }
@@ -12237,13 +12253,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     xsp = jj_scanpos;
     if (jj_3R_252()) jj_scanpos = xsp;
     if (jj_scan_token(RBRACKET)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_91() {
-    if (jj_3R_67()) return true;
-    if (jj_scan_token(IS)) return true;
-    if (jj_scan_token(NULL)) return true;
     return false;
   }
 
@@ -12263,11 +12272,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_18() {
-    if (jj_3R_59()) return true;
-    return false;
-  }
-
   private boolean jj_3R_312() {
     if (jj_3R_67()) return true;
     Token xsp;
@@ -12284,8 +12288,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_17() {
-    if (jj_3R_58()) return true;
+  private boolean jj_3_18() {
+    if (jj_3R_59()) return true;
     return false;
   }
 
@@ -12295,6 +12299,21 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     if (jj_3R_67()) return true;
     if (jj_scan_token(AND)) return true;
     if (jj_3R_67()) return true;
+    return false;
+  }
+
+  private boolean jj_3_17() {
+    if (jj_3R_58()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_311() {
+    if (jj_3R_67()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_367()) { jj_scanpos = xsp; break; }
+    }
     return false;
   }
 
@@ -12317,21 +12336,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_311() {
-    if (jj_3R_67()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_367()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3_15() {
-    if (jj_3R_56()) return true;
-    return false;
-  }
-
   private boolean jj_3R_73() {
     if (jj_3R_191()) return true;
     Token xsp;
@@ -12347,24 +12351,19 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_113() {
-    if (jj_3R_59()) return true;
-    return false;
-  }
-
   private boolean jj_3R_196() {
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_195()) return true;
     return false;
   }
 
-  private boolean jj_3_14() {
-    if (jj_3R_55()) return true;
+  private boolean jj_3_15() {
+    if (jj_3R_56()) return true;
     return false;
   }
 
-  private boolean jj_3R_112() {
-    if (jj_3R_58()) return true;
+  private boolean jj_3R_113() {
+    if (jj_3R_59()) return true;
     return false;
   }
 
@@ -12389,8 +12388,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_111() {
-    if (jj_3R_57()) return true;
+  private boolean jj_3_14() {
+    if (jj_3R_55()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_112() {
+    if (jj_3R_58()) return true;
     return false;
   }
 
@@ -12404,8 +12408,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_110() {
-    if (jj_3R_56()) return true;
+  private boolean jj_3R_111() {
+    if (jj_3R_57()) return true;
     return false;
   }
 
@@ -12424,8 +12428,8 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_109() {
-    if (jj_3R_55()) return true;
+  private boolean jj_3R_110() {
+    if (jj_3R_56()) return true;
     return false;
   }
 
@@ -12441,6 +12445,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     xsp = jj_scanpos;
     if (jj_3R_310()) jj_scanpos = xsp;
     if (jj_scan_token(RBRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_109() {
+    if (jj_3R_55()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_280() {
+    if (jj_scan_token(INTEGER_LITERAL)) return true;
     return false;
   }
 
@@ -12460,11 +12474,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     }
     }
     }
-    return false;
-  }
-
-  private boolean jj_3R_280() {
-    if (jj_scan_token(INTEGER_LITERAL)) return true;
     return false;
   }
 
@@ -12519,14 +12528,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_47() {
-    if (jj_scan_token(DELETE)) return true;
-    if (jj_scan_token(VERTEX)) return true;
+  private boolean jj_3R_285() {
+    if (jj_3R_66()) return true;
     return false;
   }
 
-  private boolean jj_3R_285() {
-    if (jj_3R_66()) return true;
+  private boolean jj_3R_47() {
+    if (jj_scan_token(DELETE)) return true;
+    if (jj_scan_token(VERTEX)) return true;
     return false;
   }
 
@@ -12565,6 +12574,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3_89() {
+    if (jj_scan_token(LPAREN)) return true;
+    if (jj_3R_74()) return true;
+    if (jj_scan_token(RPAREN)) return true;
+    return false;
+  }
+
   private boolean jj_3R_450() {
     if (jj_3R_262()) return true;
     return false;
@@ -12576,22 +12592,15 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_89() {
-    if (jj_scan_token(LPAREN)) return true;
-    if (jj_3R_74()) return true;
-    if (jj_scan_token(RPAREN)) return true;
+  private boolean jj_3R_345() {
+    if (jj_scan_token(AS)) return true;
+    if (jj_3R_396()) return true;
     return false;
   }
 
   private boolean jj_3R_46() {
     if (jj_scan_token(DELETE)) return true;
     if (jj_scan_token(FROM)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_345() {
-    if (jj_scan_token(AS)) return true;
-    if (jj_3R_396()) return true;
     return false;
   }
 
@@ -12621,6 +12630,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_165() {
+    if (jj_3R_269()) return true;
+    Token xsp;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_270()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
   private boolean jj_3R_413() {
     if (jj_scan_token(MATCH)) return true;
     if (jj_3R_447()) return true;
@@ -12645,21 +12664,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_165() {
-    if (jj_3R_269()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_270()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_460() {
-    if (jj_scan_token(DEPTH_FIRST)) return true;
-    return false;
-  }
-
   private boolean jj_3R_406() {
     if (jj_scan_token(EQEQ)) return true;
     return false;
@@ -12669,6 +12673,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     if (jj_3R_67()) return true;
     if (jj_3R_230()) return true;
     if (jj_3R_67()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_460() {
+    if (jj_scan_token(DEPTH_FIRST)) return true;
     return false;
   }
 
@@ -12698,6 +12707,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_354() {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_405()) {
+    jj_scanpos = xsp;
+    if (jj_3R_406()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3R_329() {
     if (jj_3R_262()) return true;
     return false;
@@ -12721,13 +12740,9 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_354() {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_405()) {
-    jj_scanpos = xsp;
-    if (jj_3R_406()) return true;
-    }
+  private boolean jj_3R_276() {
+    if (jj_scan_token(COLON)) return true;
+    if (jj_3R_62()) return true;
     return false;
   }
 
@@ -12741,12 +12756,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_276() {
-    if (jj_scan_token(COLON)) return true;
-    if (jj_3R_62()) return true;
-    return false;
-  }
-
   private boolean jj_3R_232() {
     if (jj_scan_token(CONTAINSVALUE)) return true;
     return false;
@@ -12754,6 +12763,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_275() {
     if (jj_scan_token(HOOK)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_175() {
+    if (jj_3R_276()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_174() {
+    if (jj_3R_275()) return true;
     return false;
   }
 
@@ -12775,16 +12794,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_175() {
-    if (jj_3R_276()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_174() {
-    if (jj_3R_275()) return true;
-    return false;
-  }
-
   private boolean jj_3R_362() {
     if (jj_scan_token(CONTAINSKEY)) return true;
     return false;
@@ -12792,6 +12801,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3_37() {
     if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3_36() {
+    if (jj_3R_54()) return true;
     return false;
   }
 
@@ -12813,14 +12827,14 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_36() {
-    if (jj_3R_54()) return true;
-    return false;
-  }
-
   private boolean jj_3R_129() {
     if (jj_scan_token(LOCK)) return true;
     if (jj_scan_token(RECORD)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_365() {
+    if (jj_scan_token(WITHIN)) return true;
     return false;
   }
 
@@ -12847,16 +12861,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_127() {
-    if (jj_3R_250()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_365() {
-    if (jj_scan_token(WITHIN)) return true;
-    return false;
-  }
-
   private boolean jj_3R_66() {
     Token xsp;
     xsp = jj_scanpos;
@@ -12867,6 +12871,16 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
+  private boolean jj_3R_127() {
+    if (jj_3R_250()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_364() {
+    if (jj_scan_token(NEAR)) return true;
+    return false;
+  }
+
   private boolean jj_3R_125() {
     if (jj_3R_247()) return true;
     return false;
@@ -12874,11 +12888,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_124() {
     if (jj_3R_246()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_364() {
-    if (jj_scan_token(NEAR)) return true;
     return false;
   }
 
@@ -12900,6 +12909,11 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
 
   private boolean jj_3R_119() {
     if (jj_3R_165()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_363() {
+    if (jj_scan_token(LUCENE)) return true;
     return false;
   }
 
@@ -12935,8 +12949,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_363() {
-    if (jj_scan_token(LUCENE)) return true;
+  private boolean jj_3_35() {
+    if (jj_3R_60()) return true;
+    return false;
+  }
+
+  private boolean jj_3_34() {
+    if (jj_3R_54()) return true;
     return false;
   }
 
@@ -12945,24 +12964,19 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_35() {
-    if (jj_3R_60()) return true;
+  private boolean jj_3R_171() {
+    if (jj_scan_token(PARALLEL)) return true;
     return false;
   }
 
-  private boolean jj_3R_171() {
-    if (jj_scan_token(PARALLEL)) return true;
+  private boolean jj_3R_361() {
+    if (jj_scan_token(LIKE)) return true;
     return false;
   }
 
   private boolean jj_3R_170() {
     if (jj_scan_token(LOCK)) return true;
     if (jj_scan_token(RECORD)) return true;
-    return false;
-  }
-
-  private boolean jj_3_34() {
-    if (jj_3R_54()) return true;
     return false;
   }
 
@@ -12976,11 +12990,6 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3R_361() {
-    if (jj_scan_token(LIKE)) return true;
-    return false;
-  }
-
   private boolean jj_3R_167() {
     if (jj_3R_247()) return true;
     return false;
@@ -12991,13 +13000,13 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     return false;
   }
 
-  private boolean jj_3_13() {
-    if (jj_3R_54()) return true;
+  private boolean jj_3R_360() {
+    if (jj_scan_token(LE)) return true;
     return false;
   }
 
-  private boolean jj_3R_360() {
-    if (jj_scan_token(LE)) return true;
+  private boolean jj_3_13() {
+    if (jj_3R_54()) return true;
     return false;
   }
 
@@ -13037,7 +13046,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[220];
+  final private int[] jj_la1 = new int[221];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -13053,22 +13062,22 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
       jj_la1_init_5();
    }
    private static void jj_la1_init_0() {
-      jj_la1_0 = new int[] {0x7f10000,0x0,0x0,0x60,0x100,0x2080,0x0,0x60,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x40000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x10000,0x20000,0x0,0x0,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x7f10000,0xfe00000,0x4000,0x0,0x47f10000,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x3000000,0x8400000,0x0,0x0,0xfe00000,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x8000,0x20,0x8020,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x2200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x0,0x47f10000,0x0,0x0,0x0,0x0,0x40000000,0x0,0x0,0x0,0x47f10020,0x0,0x7f10000,0x0,0x40,0x0,0xc0,0x7f10000,0x0,0x7f10000,0x0,0x20000000,0x10000000,0x47f10000,0x0,0x0,0x0,0x7f10000,0x0,0x47f10000,0x0,0x47f10000,0x0,0x47f10000,0x0,0x7f10000,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x7f10000,0x0,0x0,0x0,0x0,0x7f10000,0x7f10000,0x0,0x7f10000,0x7f10000,0x0,0x0,0x0,0x0,0x0,0x0,0x60000,0x60000,};
+      jj_la1_0 = new int[] {0x7f10000,0x0,0x0,0x60,0x100,0x2080,0x0,0x60,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x40000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x10000,0x20000,0x0,0x0,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x7f10000,0x20000,0x0,0x0,0x7f10000,0xfe00000,0x4000,0x0,0x47f10000,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x3000000,0x8400000,0x0,0x0,0xfe00000,0x0,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x8000,0x20,0x8020,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x2200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x0,0x47f10000,0x0,0x0,0x0,0x0,0x40000000,0x0,0x0,0x0,0x47f10020,0x0,0x7f10000,0x0,0x40,0x0,0xc0,0x7f10000,0x0,0x7f10000,0x0,0x20000000,0x10000000,0x47f10000,0x0,0x0,0x0,0x7f10000,0x0,0x47f10000,0x0,0x47f10000,0x0,0x47f10000,0x0,0x7f10000,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x7f10000,0x0,0x0,0x7f10000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47f10000,0x7f10000,0x0,0x0,0x0,0x0,0x7f10000,0x7f10000,0x0,0x7f10000,0x7f10000,0x0,0x0,0x0,0x0,0x0,0x0,0x60000,0x60000,};
    }
    private static void jj_la1_init_1() {
-      jj_la1_1 = new int[] {0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000,0x20000000,0x800,0x80,0x8000,0x400000,0x100000,0x9c010043,0x80000,0x0,0x2,0x1,0x20000000,0x8,0x50,0x58,0x58,0x800,0x80,0x8000,0x400000,0x100000,0x0,0x9c010043,0x40000000,0x0,0x8,0x3000000,0x800000,0x0,0x0,0x8,0x1000,0x0,0x8,0x200000,0x1000,0x0,0x8,0x20,0x0,0x0,0x0,0x20,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x8,0x20,0x0,0x0,0x9c010043,0x0,0x8,0x20,0x0,0x0,0x9c010043,0x0,0x8,0x20,0x9c010043,0x0,0x8,0x20,0x9c010043,0x0,0x0,0x6000,0x9c010043,0x1000,0x0,0x8000,0x8,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9c010043,0x1000,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x40000,0x20000,0x0,0x0,0x200,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x9c010043,0x0,0x1c000000,0x0,0x9c010043,0x0,0x9c010043,0x0,0x9c010043,0x0,0x9c010043,0x1c000000,0x9c010043,0x9c010043,0x0,0x0,0x9c010043,0x500,0x500,0x0,0x9c010043,0x500,0x500,0x9c010043,0x0,0x0,0x9c010043,0x500,0x500,0x0,0x9c010043,0x500,0x500,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x50,0x0,0x1000,0x1000,0x0,0x9c010043,0x9c010043,0x0,0x0,0x0,0x0,0x9c010043,0x9c010043,0x0,0x9c010043,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x40000200,0x40000200,};
+      jj_la1_1 = new int[] {0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000,0x20000000,0x800,0x80,0x8000,0x400000,0x100000,0x9c010043,0x80000,0x0,0x2,0x1,0x20000000,0x8,0x50,0x58,0x58,0x800,0x80,0x8000,0x400000,0x100000,0x0,0x9c010043,0x40000000,0x0,0x8,0x3000000,0x800000,0x0,0x0,0x8,0x1000,0x0,0x8,0x200000,0x1000,0x0,0x8,0x20,0x0,0x0,0x0,0x20,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x8,0x20,0x0,0x0,0x9c010043,0x0,0x8,0x20,0x0,0x0,0x9c010043,0x0,0x8,0x20,0x9c010043,0x0,0x8,0x20,0x9c010043,0x0,0x0,0x6000,0x9c010043,0x1000,0x0,0x8000,0x8,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9c010043,0x1000,0x0,0x0,0x0,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x0,0x9c010043,0x0,0x40000,0x20000,0x0,0x0,0x200,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x0,0x9c010043,0x0,0x9c010043,0x0,0x0,0x0,0x9c010043,0x0,0x1c000000,0x0,0x9c010043,0x0,0x9c010043,0x0,0x9c010043,0x0,0x9c010043,0x1c000000,0x9c010043,0x9c010043,0x0,0x0,0x9c010043,0x500,0x500,0x0,0x9c010043,0x500,0x500,0x9c010043,0x0,0x0,0x9c010043,0x500,0x500,0x0,0x9c010043,0x500,0x500,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x50,0x0,0x1000,0x1000,0x0,0x9c010043,0x9c010043,0x0,0x0,0x0,0x0,0x9c010043,0x9c010043,0x0,0x9c010043,0x9c010043,0x0,0x0,0x0,0x0,0x0,0x0,0x40000200,0x40000200,};
    }
    private static void jj_la1_init_2() {
-      jj_la1_2 = new int[] {0x7,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x5d84401f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4000,0x4000,0x0,0x7,0x0,0x4000,0x10004007,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x0,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x10004007,0x0,0x0,0x0,0x5d84401f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x10000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x4000,0x10004007,0x0,0x4000,0x10004007,0x10000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x5d84401f,0x0,0x5d84401f,0x8,0x0,0x0,0x0,0x0,0x4c000000,0x0,0x0,0x5d84401f,0x1800000,0x184401f,0x0,0x0,0x10000000,0x0,0x1000401f,0x0,0x7,0x0,0x0,0x0,0x5d84401f,0xc000000,0x0,0x0,0x1000007,0x0,0x5d84401f,0x0,0x5d84401f,0x0,0x5d84401f,0x0,0x1184401f,0x1184401f,0x1800000,0x0,0x4017,0x0,0x0,0x0,0x4017,0x0,0x0,0x10004017,0x0,0x0,0x4017,0x0,0x0,0x0,0x4017,0x0,0x0,0x10004017,0x0,0x0,0x4000,0x4000,0x4000,0x0,0x4000,0x4,0x4,0x0,0x5d84401f,0x7,0x0,0x0,0x0,0x0,0x7,0x1800007,0x0,0x1800007,0x1800007,0x0,0x40000000,0x40000000,0x0,0x40000000,0x0,0x3,0x3,};
+      jj_la1_2 = new int[] {0x7,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x5d84401f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4000,0x4000,0x0,0x7,0x0,0x4000,0x10004007,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x0,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x0,0x4000,0x10004007,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x10004007,0x0,0x0,0x0,0x5d84401f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x10000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x4000,0x10004007,0x0,0x4000,0x10004007,0x10000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x5d84401f,0x0,0x5d84401f,0x8,0x0,0x0,0x0,0x0,0x4c000000,0x0,0x0,0x5d84401f,0x1800000,0x184401f,0x0,0x0,0x10000000,0x0,0x1000401f,0x0,0x7,0x0,0x0,0x0,0x5d84401f,0xc000000,0x0,0x0,0x1000007,0x0,0x5d84401f,0x0,0x5d84401f,0x0,0x5d84401f,0x0,0x1184401f,0x1184401f,0x1800000,0x0,0x4017,0x0,0x0,0x0,0x4017,0x0,0x0,0x10004017,0x0,0x0,0x4017,0x0,0x0,0x0,0x4017,0x0,0x0,0x10004017,0x0,0x0,0x4000,0x4000,0x4000,0x0,0x4000,0x4,0x4,0x0,0x5d84401f,0x7,0x0,0x0,0x0,0x0,0x7,0x1800007,0x0,0x1800007,0x1800007,0x0,0x40000000,0x40000000,0x0,0x40000000,0x0,0x3,0x3,};
    }
    private static void jj_la1_init_3() {
-      jj_la1_3 = new int[] {0x0,0x2000000,0x2000000,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x600c001,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x4000001,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x2000000,0x2000001,0x0,0x0,0x8,0x2000000,0x200c001,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x600c001,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x0,0x0,0x8,0x8,0x0,0x11,0x100,0x100,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x8,0x8,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0xc000,0x8,0x0,0x8,0x2000000,0x2000000,0x8,0x600c001,0x8,0x600c001,0x0,0x4000000,0x1,0x10,0x0,0x0,0x3000000,0x8c000000,0x600c001,0x0,0x600c001,0x8,0x0,0x0,0x0,0x600c001,0x8,0x0,0x0,0x0,0x0,0x600c001,0x0,0xf0f00,0x300,0x0,0x8,0x600c001,0x8,0x600c001,0x8,0x600c001,0xf0f00,0x600c001,0x600c001,0x0,0x11,0x2000000,0x0,0x0,0x11,0x2000000,0x0,0x0,0x2000000,0x8,0x11,0x2000000,0x0,0x0,0x11,0x2000000,0x0,0x0,0x2000000,0x8,0x8,0x200c000,0x200c000,0x200c000,0x0,0x200c000,0x0,0x0,0x8,0x600c001,0x4000001,0x1,0x4000000,0x10,0x4000000,0x4000001,0x0,0x8,0x0,0x0,0x10,0x0,0x0,0x10,0x0,0x8,0x0,0x0,};
+      jj_la1_3 = new int[] {0x0,0x2000000,0x2000000,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x600c001,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x4000001,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x2000000,0x2000001,0x0,0x0,0x8,0x2000000,0x200c001,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x0,0x0,0x0,0x600c001,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x0,0x0,0x8,0x8,0x0,0x11,0x100,0x11,0x100,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x8,0x8,0x8,0x8,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x2000000,0x200c001,0x8,0x2000000,0x200c001,0x0,0x0,0x0,0xc000,0x8,0x0,0x8,0x2000000,0x2000000,0x8,0x600c001,0x8,0x600c001,0x0,0x4000000,0x1,0x10,0x0,0x0,0x3000000,0x8c000000,0x600c001,0x0,0x600c001,0x8,0x0,0x0,0x0,0x600c001,0x8,0x0,0x0,0x0,0x0,0x600c001,0x0,0xf0f00,0x300,0x0,0x8,0x600c001,0x8,0x600c001,0x8,0x600c001,0xf0f00,0x600c001,0x600c001,0x0,0x11,0x2000000,0x0,0x0,0x11,0x2000000,0x0,0x0,0x2000000,0x8,0x11,0x2000000,0x0,0x0,0x11,0x2000000,0x0,0x0,0x2000000,0x8,0x8,0x200c000,0x200c000,0x200c000,0x0,0x200c000,0x0,0x0,0x8,0x600c001,0x4000001,0x1,0x4000000,0x10,0x4000000,0x4000001,0x0,0x8,0x0,0x0,0x10,0x0,0x0,0x10,0x0,0x8,0x0,0x0,};
    }
    private static void jj_la1_init_4() {
-      jj_la1_4 = new int[] {0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0xf2008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1e,0x0,0x8000000,0xf2008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8000000,0x8000000,0x0,0x8000000,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000,0x2000,0x0,0x32008000,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x32008000,0x0,0x0,0x0,0x0,0xfa008000,0x0,0x32008000,0xc0000000,0x0,0x0,0x3200c000,0x0,0x210000,0x0,0x32008000,0x0,0x32008000,0x0,0x32008000,0x0,0x32008000,0x250000,0x32008000,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x32008000,0x0,0x0,0x0,0x0,0x32008000,0x32008000,0x0,0x32008000,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+      jj_la1_4 = new int[] {0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0xf2008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1e,0x0,0x0,0x8000000,0xf2008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8000000,0x8000000,0x0,0x8000000,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000,0x2000,0x0,0x32008000,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x0,0x32008000,0x0,0x0,0x0,0x0,0xfa008000,0x0,0x32008000,0xc0000000,0x0,0x0,0x3200c000,0x0,0x210000,0x0,0x32008000,0x0,0x32008000,0x0,0x32008000,0x0,0x32008000,0x250000,0x32008000,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x32008000,0x0,0x0,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x32008000,0x32008000,0x0,0x0,0x0,0x0,0x32008000,0x32008000,0x0,0x32008000,0x32008000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
    }
    private static void jj_la1_init_5() {
-      jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x40,0x40,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x4f,0x0,0x0,0x3,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x40,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+      jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x40,0x40,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x47,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x40,0x0,0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x4f,0x0,0x0,0x3,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x40,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x0,0x40,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
    }
   final private JJCalls[] jj_2_rtns = new JJCalls[101];
   private boolean jj_rescan = false;
@@ -13080,7 +13089,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 220; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 221; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -13091,7 +13100,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     jj_ntk = -1;
     jjtree.reset();
     jj_gen = 0;
-    for (int i = 0; i < 220; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 221; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -13101,7 +13110,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 220; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 221; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -13112,7 +13121,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
     jj_ntk = -1;
     jjtree.reset();
     jj_gen = 0;
-    for (int i = 0; i < 220; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 221; i++) jj_la1[i] = -1;
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -13229,7 +13238,7 @@ public class OrientSql/*@bgen(jjtree)*/implements OrientSqlTreeConstants, Orient
       la1tokens[jj_kind] = true;
       jj_kind = -1;
     }
-    for (int i = 0; i < 220; i++) {
+    for (int i = 0; i < 221; i++) {
       if (jj_la1[i] == jj_gen) {
         for (int j = 0; j < 32; j++) {
           if ((jj_la1_0[i] & (1<<j)) != 0) {

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdateTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdateTest.java
@@ -261,5 +261,39 @@ public class OCommandExecutorSQLUpdateTest {
       db.close();
     }
   }
+  
+  @Test
+  public void testIncrementWithDotNotationField() throws Exception {
+    final ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OCommandExecutorSQLUpdateTestIncrementWithDotNotationField");
+    db.create();
+
+    db.command(new OCommandSQL("CREATE class test")).execute();
+
+    final ODocument test = new ODocument("test");
+    test.field("id", "id1");
+    test.field("count", 20);
+    
+    Map<String, Integer> nestedCound = new HashMap<String, Integer>();
+    nestedCound.put("nestedCount", 10);
+    test.field("map", nestedCound);
+
+    db.save(test);
+
+    ODocument queried = (ODocument) db.query(new OSQLSynchQuery<Object>("SELECT FROM test WHERE id = \"id1\"")).get(0);;
+    
+    db.command(new OCommandSQL("UPDATE test INCREMENT count = 2")).execute();
+    queried.reload(); 
+    assertEquals(queried.field("count"), 22);
+    
+    db.command(new OCommandSQL("UPDATE test INCREMENT `map.nestedCount` = 5")).execute();
+    queried.reload();
+    assertEquals(queried.field("map.nestedCount"), 15);
+    
+    db.command(new OCommandSQL("UPDATE test INCREMENT map.nestedCount = 5")).execute();
+    queried.reload();
+    assertEquals(queried.field("map.nestedCount"), 20);
+
+    db.close();
+  }
 
 }


### PR DESCRIPTION
Allows nested dot-notation fields in UPDATE INCREMENT such as:

```SQL
UPDATE test INCREMENT map.nestedCount = 5
```

See issue #4784 for details.