### PR TITLE
Fixes setting values in arrays with SQL Updates (#4272)

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
+++ b/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
@@ -220,6 +220,26 @@ public class OMultiValue {
     }
     return null;
   }
+  
+  /**
+   * Sets the value of the Multi-value object (array or collection) at iIndex 
+   * 
+   * @param iObject
+   *          Multi-value object (array, collection)
+   * @param iValue
+   *          The value to set at this specified index.      
+   * @param iIndex
+   *          integer as the position requested
+   */
+  public static void setValue(final Object iObject, final Object iValue, final int iIndex) {
+    if (iObject instanceof List<?>) {
+      ((List<Object>)iObject).set(iIndex, iValue);
+    } else if (iObject.getClass().isArray()) {
+      Array.set(iObject, iIndex, iValue);
+    } else {
+      throw new IllegalArgumentException("Can only set positional indices for Lists and Arrays");
+    }
+  }
 
   /**
    * Returns an <code>Iterable<Object></code> object to browse the multi-value instance (array, collection or map)

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentTest.java
@@ -7,6 +7,8 @@ import static org.testng.Assert.assertNull;
 
 import org.testng.annotations.Test;
 
+import java.util.*;
+
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.id.ORecordId;
@@ -221,6 +223,36 @@ public class ODocumentTest {
     } finally {
       db.drop();
     }
+  }
+  
+  @Test
+  public void testSetFieldAtListIndex() {
+      ODocument doc = new ODocument();
+      
+      Map<String, Object> data = new HashMap<String, Object>();
+      
+      List<Object> parentArray = new ArrayList<Object>();
+      parentArray.add(1);
+      parentArray.add(2);
+      parentArray.add(3);
+      
+      Map<String, Object> object4 = new HashMap<String, Object>();
+      object4.put("prop", "A");
+      parentArray.add(object4);
+      
+      data.put("array", parentArray);
+      
+      doc.field("data", data);
+      
+      assertEquals(doc.field("data.array[3].prop"), "A");
+      doc.field("data.array[3].prop", "B");
+      
+      assertEquals(doc.field("data.array[3].prop"), "B");
+      
+      assertEquals(doc.field("data.array[0]"), 1);
+      doc.field("data.array[0]", 5);
+      
+      assertEquals(doc.field("data.array[0]"), 5);
   }
   
   @Test


### PR DESCRIPTION
Fixes a bug where the following SQL would fail:
```SQL
UPDATE test SET data.array[0] = 5
```

See issue #4727. For details.