### PR TITLE
dynamicImport added to avoid ClassCastException in OSGi mode

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,6 +40,7 @@
             org.xerial.snappy;resolution:=optional,
             *
         </osgi.import>
+        <osgi.dynamicImport>*</osgi.dynamicImport>
         <osgi.export>com.orientechnologies.orient.core.*,
             com.orientechnologies.common.*,com.orientechnologies.nio.*
         </osgi.export>

--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -40,7 +40,8 @@
         <javac.target.version>1.6</javac.target.version>
         <jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
         <osgi.import>com.hazelcast.*;resolution:=optional,*</osgi.import>
-        <osgi.export>com.orientechnologies.orient.server.hazelcast.*</osgi.export>
+        <osgi.export>com.orientechnologies.orient.server.hazelcast.*,
+            com.orientechnologies.orient.server.distributed.sql</osgi.export>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine>-ea -Xmx2048m -Dindex.flushAfterCreate=false
             -Dstorage.makeFullCheckpointAfterCreate=false

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -34,6 +34,7 @@
             orient.client.*;resolution:=optional,
             *
         </osgi.import>
+        <osgi.dynamicImport>*</osgi.dynamicImport>
         <osgi.export>com.orientechnologies.orient.server.*</osgi.export>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	<argLine>-ea -Xmx2048m


### PR DESCRIPTION
dynamicImport directive added to avoid ClassCastException when running in OSGi mode for the classes loaded dynamically via ServiceLoader. Package export added.
