### PR TITLE
Adds unit tests for named parameters containing strings with quotes.

### DIFF
--- a/core/src/test/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdateTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLUpdateTest.java
@@ -293,5 +293,56 @@ public class OCommandExecutorSQLUpdateTest {
 
     db.close();
   }
+  
+  @Test
+  public void testSingleQuoteInNamedParameter() throws Exception {
+    final ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OCommandExecutorSQLUpdateTestSingleQuoteInNamedParameter");
+    db.create();
 
+    db.command(new OCommandSQL("CREATE class test")).execute();
+
+    final ODocument test = new ODocument("test");
+    test.field("text", "initial value");
+    
+    db.save(test);
+
+    ODocument queried = (ODocument) db.query(new OSQLSynchQuery<Object>("SELECT FROM test")).get(0);
+    assertEquals(queried.field("text"), "initial value");
+    
+    OCommandSQL command = new OCommandSQL("UPDATE test SET text = :text");
+    Map<String, Object> params = new HashMap<String,Object>();
+    params.put("text", "single \"");
+    
+    db.command(command).execute(params);
+    queried.reload(); 
+    assertEquals(queried.field("text"), "single \"");
+    
+    db.close();
+  }
+  
+  @Test
+  public void testQuotedStringInNamedParameter() throws Exception {
+    final ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OCommandExecutorSQLUpdateTestQuotedStringInNamedParameter");
+    db.create();
+
+    db.command(new OCommandSQL("CREATE class test")).execute();
+
+    final ODocument test = new ODocument("test");
+    test.field("text", "initial value");
+    
+    db.save(test);
+
+    ODocument queried = (ODocument) db.query(new OSQLSynchQuery<Object>("SELECT FROM test")).get(0);
+    assertEquals(queried.field("text"), "initial value");
+    
+    OCommandSQL command = new OCommandSQL("UPDATE test SET text = :text");
+    Map<String, Object> params = new HashMap<String,Object>();
+    params.put("text", "quoted \"value\" string");
+    
+    db.command(command).execute(params);
+    queried.reload(); 
+    assertEquals(queried.field("text"), "quoted \"value\" string");
+    
+    db.close();
+  }
 }


### PR DESCRIPTION
Issue #4885 occurs in 2.1.  Named parameters that are set to Strings with quotes in them can be problematic.  This issue has already been fixed in the develop branch.  This pull requests simply adds 2 units tests that currently fail in 2.1, but that pass in 2.2.0-SNAPSHOT.  This will help ensure there are no regressions in this area going forward.