### PR TITLE
fix dependency on sun.misc that prevents deployment in eclipse

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -35,7 +35,7 @@
     <name>OrientDB Tools</name>
 
     <properties>
-        <osgi.import>*</osgi.import>
+        <osgi.import>sun.misc;resolution:=optional,*</osgi.import>
         <osgi.export>com.orientechnologies.orient.console.*</osgi.export>
         <jar.manifest.mainclass>com.orientechnologies.orient.console.OConsoleDatabaseApp</jar.manifest.mainclass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
by making the import on sun.misc optional, the orientdb-tools may be
used in eclipse without dependency problems. 
This change was already made on core/pom.xml but is missing in tools/pom.xml