### PR TITLE
Fixed OIOUtils.getTodayWithTime so it parses using 24hr clock.

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
@@ -129,7 +129,7 @@ public class OIOUtils {
     Calendar calParsed = Calendar.getInstance();
     calParsed.setTime(df.parse(iTime));
     Calendar cal = Calendar.getInstance();
-    cal.set(Calendar.HOUR, calParsed.get(Calendar.HOUR));
+    cal.set(Calendar.HOUR_OF_DAY, calParsed.get(Calendar.HOUR_OF_DAY));
     cal.set(Calendar.MINUTE, calParsed.get(Calendar.MINUTE));
     cal.set(Calendar.SECOND, calParsed.get(Calendar.SECOND));
     cal.set(Calendar.MILLISECOND, 0);

--- a/core/src/test/java/com/orientechnologies/common/io/OIOUtilsTest.java
+++ b/core/src/test/java/com/orientechnologies/common/io/OIOUtilsTest.java
@@ -31,7 +31,7 @@ public class OIOUtilsTest {
   @Test
   public void shoudGetRightTimeFromString() throws ParseException {
     Calendar calendar = Calendar.getInstance();
-    calendar.set(Calendar.HOUR, 5);
+    calendar.set(Calendar.HOUR_OF_DAY, 5);
     calendar.set(Calendar.MINUTE, 10);
     calendar.set(Calendar.SECOND, 0);
     calendar.set(Calendar.MILLISECOND, 0);


### PR DESCRIPTION
OIOUtils.getTodayWithTime was parsing the time with format 'HH:mm:ss' but was converting it to a 12 hour clock.

So 17:00:00 was converted to 5:00 AM instead of 5:00 PM.