### PR TITLE
Fix an off-by-one error in the query limit exceeded CLI logic.

### DIFF
--- a/tools/src/main/java/com/orientechnologies/orient/console/OTableFormatter.java
+++ b/tools/src/main/java/com/orientechnologies/orient/console/OTableFormatter.java
@@ -61,7 +61,7 @@ public class OTableFormatter {
       if (iAfterDump != null)
         iAfterDump.call(record);
 
-      if (limit > -1 && fetched >= limit) {
+      if (limit > -1 && fetched > limit) {
         printHeaderLine(columns);
         out.message("\nLIMIT EXCEEDED: resultset contains more items not displayed (limit=" + limit + ")");
         return;
@@ -198,7 +198,7 @@ public class OTableFormatter {
 
   /**
    * Fill the column map computing the maximum size for a field.
-   * 
+   *
    * @param resultSet
    * @param limit
    * @return


### PR DESCRIPTION
Prevents output such as the following:
```
LIMIT EXCEEDED: resultset contains more items not displayed (limit=20)

20 item(s) found. Query executed in 0.015 sec(s).
```

Note how the CLI mentions that the limit of 20 was exceeded by the 20 items found to match the query.