### PR TITLE
added $matches and $group context vars

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/operator/OQueryOperatorMatches.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/operator/OQueryOperatorMatches.java
@@ -19,7 +19,10 @@
   */
 package com.orientechnologies.orient.core.sql.operator;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.List;
+import java.util.ArrayList;
 
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
@@ -66,6 +69,21 @@ public class OQueryOperatorMatches extends OQueryOperatorEqualityNotNulls {
 			p = Pattern.compile(iRegex);
 			iContext.setVariable(key, p);
 		}
-		return p.matcher(iValue).matches();
+		Matcher m = p.matcher(iValue);
+		if (m.matches()) {
+			List<String> iMatches = new ArrayList<String>();
+			List<Integer> iGroups = new ArrayList<Integer>();
+			for(int i = 1; i <= m.groupCount(); i++) {
+				String match = m.group(i);
+				if (match != null) {
+					iMatches.add(match);
+					iGroups.add(i-1);
+				}
+			}
+			iContext.setVariable("matches", iMatches);
+			iContext.setVariable("groups", iGroups);
+			return true;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Adds context vars ```$matches``` and ```$group``` for ```MATCHES``` operator.
Example in GreatfulDeadConcerts:
```sql
select name, $matches, $groups from V where name matches "(Garcia.*|JA.*?)(ROE)?"
```
outputs information about the group that matched:

![image](https://cloud.githubusercontent.com/assets/8459594/10429264/93ec946e-70f7-11e5-8ffc-c71418cbd6e5.png)
