### PR TITLE
Changed to use hazelcast and hazelcast-cloud instead of hazelcast-all

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -118,7 +118,12 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-cloud</artifactId>
             <version>3.5.2</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
As discussed with lvca, changed to use `hazelcast` and `hazelcast-cloud` instead of `hazelcast-all` to reduce the number of dependencies being pulled in unnecessarily.  Also reduces the risk of conflicts with other projects using Hazelcast but adding only dependencies on individual modules.
Unit tests passed successfully.  Consider back-porting to 2.1.x if there is going to be another release before 2.2.0 is released.