### PR TITLE
Implementation of an numerical absolute value function.

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
@@ -19,6 +19,7 @@ import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
 import com.orientechnologies.orient.core.sql.functions.coll.*;
 import com.orientechnologies.orient.core.sql.functions.geo.OSQLFunctionDistance;
+import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionAbsoluteValue;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionAverage;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionDecimal;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionEval;
@@ -95,6 +96,7 @@ public final class ODefaultSQLFunctionFactory implements OSQLFunctionFactory {
     register(OSQLFunctionConcat.NAME, OSQLFunctionConcat.class);
     register(OSQLFunctionDecimal.NAME, OSQLFunctionDecimal.class);
     register(OSQLFunctionSequence.NAME, new OSQLFunctionSequence());
+    register(OSQLFunctionAbsoluteValue.NAME, OSQLFunctionAbsoluteValue.class);
   }
 
   public static void register(final String iName, final Object iImplementation) {

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionAbsoluteValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionAbsoluteValue.java
@@ -1,0 +1,90 @@
+/*
+ *
+ *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  * For more information: http://www.orientechnologies.com
+ *
+ */
+package com.orientechnologies.orient.core.sql.functions.math;
+
+import com.orientechnologies.orient.core.command.OCommandContext;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * Evaluates the absolute value for numeric types.  The argument must be a
+ * BigDecimal, BigInteger, Integer, Long, Double or a Float, or null.  If
+ * null is passed in the result will be null.  Otherwise the result will
+ * be the mathematical absolute value of the argument passed in and will be
+ * of the same type that was passed in.
+ * 
+ * @author Michael MacFadden
+ */
+public class OSQLFunctionAbsoluteValue extends OSQLFunctionMathAbstract {
+  public static final String NAME = "abs";
+  private Object             result;
+
+  public OSQLFunctionAbsoluteValue() {
+    super(NAME, 1, 1);
+  }
+
+  public Object execute(Object iThis, final OIdentifiable iRecord, final Object iCurrentResult, final Object[] iParams,
+      OCommandContext iContext) {
+    Object inputValue = iParams[0];
+    
+    if (inputValue == null) {
+      result = null;
+    } else if (inputValue instanceof BigDecimal) {
+      result = ((BigDecimal) inputValue).abs();
+    } else if (inputValue instanceof BigInteger) {
+      result = ((BigInteger) inputValue).abs();
+    }else if (inputValue instanceof Integer) {
+      result = Math.abs((Integer)inputValue);
+    } else if (inputValue instanceof Long) {
+      result = Math.abs((Long) inputValue);
+    } else if (inputValue instanceof Short) {
+        result = (short)Math.abs((Short) inputValue);
+    } else if (inputValue instanceof Double) {
+      result = Math.abs((Double) inputValue);
+    }  else if (inputValue instanceof Float) {
+      result = Math.abs((Float) inputValue);
+    } else {
+    	throw new IllegalArgumentException("Argument to absolute value must be a number.");
+    }
+
+    return getResult();
+  }
+
+  public boolean aggregateResults() {
+    return false;
+  }
+
+  public String getSyntax() {
+    return "abs(<number>)";
+  }
+
+  @Override
+  public Object getResult() {
+    return result;
+  }
+
+  @Override
+  public Object mergeDistributedResult(List<Object> resultsToMerge) {
+    return null;
+  }
+}

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionAbsoluteValueTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/math/OSQLFunctionAbsoluteValueTest.java
@@ -1,0 +1,172 @@
+package com.orientechnologies.orient.core.sql.functions.math;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the absolute value function.  The key is that the mathematical abs
+ * function is correctly applied and that values retain their types.
+ * 
+ * @author Michael MacFadden
+ */
+@Test
+public class OSQLFunctionAbsoluteValueTest {
+
+  private OSQLFunctionAbsoluteValue function;
+
+  @BeforeMethod
+  public void setup() {
+    function = new OSQLFunctionAbsoluteValue();
+  }
+
+  @Test
+  public void testEmpty() {
+    Object result = function.getResult();
+    assertNull(result);
+  }
+  
+  @Test
+  public void testNull() {
+	  function.execute(null, null, null, new Object[] { null }, null);
+    Object result = function.getResult();
+    assertNull(result);
+  }
+
+  @Test
+  public void testPositiveInteger() {
+    function.execute(null, null, null, new Object[] { 10 }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Integer);
+    assertEquals(result, 10);
+  }
+  
+  @Test
+  public void testNegativeInteger() {
+    function.execute(null, null, null, new Object[] { -10 }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Integer);
+    assertEquals(result, 10);
+  }
+  
+  @Test
+  public void testPositiveLong() {
+    function.execute(null, null, null, new Object[] { 10L }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Long);
+    assertEquals(result, 10L);
+  }
+  
+  @Test
+  public void testNegativeLong() {
+    function.execute(null, null, null, new Object[] { -10L }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Long);
+    assertEquals(result, 10L);
+  }
+  
+  @Test
+  public void testPositiveShort() {
+    function.execute(null, null, null, new Object[] { (short)10 }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Short);
+    assertEquals(result, (short)10);
+  }
+  
+  @Test
+  public void testNegativeShort() {
+    function.execute(null, null, null, new Object[] { (short)-10 }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Short);
+    assertEquals(result, (short)10);
+  }
+  
+  @Test
+  public void testPositiveDouble() {
+    function.execute(null, null, null, new Object[] { 10.5D }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Double);
+    assertEquals(result, 10.5D);
+  }
+  
+  @Test
+  public void testNegativeDouble() {
+    function.execute(null, null, null, new Object[] { -10.5D }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Double);
+    assertEquals(result, 10.5D);
+  }
+  
+  @Test
+  public void testPositiveFloat() {
+    function.execute(null, null, null, new Object[] { 10.5F }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Float);
+    assertEquals(result, 10.5F);
+  }
+  
+  @Test
+  public void testNegativeFloat() {
+    function.execute(null, null, null, new Object[] { -10.5F }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof Float);
+    assertEquals(result, 10.5F);
+  }
+  
+  @Test
+  public void testPositiveBigDecimal() {
+    function.execute(null, null, null, new Object[] { new BigDecimal(10.5D) }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof BigDecimal);
+    assertEquals(result, new BigDecimal(10.5D));
+  }
+  
+  @Test
+  public void testNegativeBigDecimal() {
+    function.execute(null, null, null, new Object[] { new BigDecimal(-10.5D) }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof BigDecimal);
+    assertEquals(result, new BigDecimal(10.5D));
+  }
+  
+  @Test
+  public void testPositiveBigInteger() {
+    function.execute(null, null, null, new Object[] { new BigInteger("10") }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof BigInteger);
+    assertEquals(result, new BigInteger("10"));
+  }
+  
+  @Test
+  public void testNegativeBigInteger() {
+    function.execute(null, null, null, new Object[] { new BigInteger("-10") }, null);
+    Object result = function.getResult();
+    assertTrue(result instanceof BigInteger);
+    assertEquals(result, new BigInteger("10"));
+  }
+  
+  @Test(expectedExceptions=IllegalArgumentException.class)
+  public void testNonNumber() {
+    function.execute(null, null, null, new Object[] { "abc" }, null);
+  }
+
+  public void testFromQuery() {
+    ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:testAbsFunction");
+    db.create();
+    List<ODocument> result = db.query(new OSQLSynchQuery<ODocument>("select abs(-45.4)"));
+    ODocument r = result.get(0);
+    assertEquals(result.size(), 1);
+    assertEquals(r.field("abs"), 45.4D);
+    db.close();
+  }
+}


### PR DESCRIPTION
This PR implements a basic 'abs' function for OrientDB.  It can be use as follows:

```SQL
SELECT abs(-5)
SELECT abs(property) FROM MyClass
```

The function supports the following types:
* null
* Integer
* Long
* Short
* Double
* Float
* BigInteger
* BigDecimal

I believe this covers the main numeric types that OrientDB Supports.  One could argue that Byte could be implemented as well, but I have left that off for now.  If need be that can be added later.

The function as well as the unit tests are supplied.
  