### PR TITLE
fix no output of profiler data

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/profiler/OProfilerStub.java
+++ b/core/src/main/java/com/orientechnologies/common/profiler/OProfilerStub.java
@@ -101,7 +101,7 @@ public class OProfilerStub extends OAbstractProfiler {
     final StringBuilder buffer = new StringBuilder(super.dump());
 
     if (tips.size() == 0)
-      return "";
+      return buffer.toString();
 
     buffer.append("TIPS:");
 


### PR DESCRIPTION
Since orient 2.1.7 the output of profiler is not displayed anymore. 
```
Infos:
 *****************************************************************************************************************************
 PROFILER AUTO DUMP OUTPUT (to disabled it set 'profiler.autoDump.interval' = 0):

 *****************************************************************************************************************************
```