### PR TITLE
Enhances the "asMap()" method to handle converting an ODocument

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsMap.java
@@ -16,15 +16,17 @@
  */
 package com.orientechnologies.orient.core.sql.method.misc;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 
 /**
- * Transforms current value in a Map.
+ * Transforms current value into a Map.
  * 
  * @author Luca Garulli
  */
@@ -46,9 +48,15 @@ public class OSQLMethodAsMap extends OAbstractSQLMethod {
     }
 
     if (ioResult == null)
-    // NULL VALUE, RETURN AN EMPTY SET
+    // NULL VALUE, RETURN AN EMPTY MAP
     {
-      return new HashMap<Object, Object>();
+      return Collections.EMPTY_MAP;
+    }
+    
+    if (ioResult instanceof ODocument)
+    // CONVERT ODOCUMENT TO MAP
+    {
+      return ((ODocument) ioResult).toMap();
     }
 
     Iterator<Object> iter;

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsMapTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsMapTest.java
@@ -1,0 +1,103 @@
+package com.orientechnologies.orient.core.sql.method.misc;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.orientechnologies.orient.core.record.impl.ODocument;
+
+/**
+ * Tests the "asMap()" method implemented by the OSQLMethodAsMap class.  Note
+ * that the only input to the execute() method from the OSQLMethod interface
+ * that is used is the ioResult argument (the 4th argument).
+ * 
+ * @author Michael MacFadden
+ */
+@Test
+public class OSQLMethodAsMapTest {
+
+  private OSQLMethodAsMap function;
+
+  @BeforeMethod
+  public void setup() {
+    function = new OSQLMethodAsMap();
+  }
+
+  @Test
+  public void testMap() {
+    // The expected behavior is to return the map itself.
+    HashMap<Object, Object> aMap = new HashMap<Object, Object>();
+    aMap.put("p1", 1);
+    aMap.put("p2", 2);
+    Object result = function.execute(null, null, null, aMap, null);
+    assertEquals(result, aMap);
+  }
+
+  @Test
+  public void testNull() {
+    // The expected behavior is to return an empty map.
+    Object result = function.execute(null, null, null, null, null);
+    assertEquals(result, new HashMap<Object, Object>());
+  }
+  
+  public void testODocument() {
+    // The expected behavior is to return a map that has the field names mapped
+    // to the field values of the ODocument.
+    ODocument doc = new ODocument();
+    doc.field("f1", 1);
+    doc.field("f2", 2);
+    
+    Object result = function.execute(null, null, null, doc, null);
+    
+    assertEquals(result, doc.toMap());
+  }
+
+  @Test
+  public void testIterable() {
+    // The expected behavior is to return a map where the even values (0th,
+    // 2nd, 4th, etc) are keys and the odd values (1st, 3rd, etc.) are
+    // property values.
+    ArrayList<Object> aCollection = new ArrayList<Object>();
+    aCollection.add("p1");
+    aCollection.add(1);
+    aCollection.add("p2");
+    aCollection.add(2);
+    
+    Object result = function.execute(null, null, null, aCollection, null);
+
+    HashMap<Object, Object> expected = new HashMap<Object, Object>();
+    expected.put("p1", 1);
+    expected.put("p2", 2);
+    assertEquals(result, expected);
+  }
+
+  
+  @Test
+  public void testIterator() {
+    // The expected behavior is to return a map where the even values (0th,
+    // 2nd, 4th, etc) are keys and the odd values (1st, 3rd, etc.) are
+    // property values.
+    ArrayList<Object> aCollection = new ArrayList<Object>();
+    aCollection.add("p1");
+    aCollection.add(1);
+    aCollection.add("p2");
+    aCollection.add(2);
+    
+    Object result = function.execute(null, null, null, aCollection.iterator(), null);
+
+    HashMap<Object, Object> expected = new HashMap<Object, Object>();
+    expected.put("p1", 1);
+    expected.put("p2", 2);
+    assertEquals(result, expected);
+  }
+  
+  public void testOtherValue() {
+    // The expected behavior is to return null.
+    Object result = function.execute(null, null, null, new Integer(4), null);
+    assertEquals(result, null);
+  }
+}


### PR DESCRIPTION
The asMap method turns things in to a map.  The behavior is already that if a map is passed in, it simply returns a map.  An ODocument is already essentially a map from field names to field values.  However, ODocument does not implement a Map interface.  It only implements an Iterable interface.  therefore the asMap method does not work well on it.

For an iterable, the asMap method will take even values as keys and odd values as values.  However, the ODocument's Iterable behavoir is Iterable<Entry<String, Object>>.  This means that the iterator is iterating over entries which are already the key / values of the ODocument.

This means that currently if one had the following:

```java
ODocument doc = new ODocument()
doc.field("f1", 1);
doc.field("f2", 2);
```

Then "asMap" would return a Map like this:

```
Map{ 
  Entry("f1", 1) -> Entry ("f2", 2) 
}
```
That is, the Map would be a somewhat random mapping form one key/value entry to another.

This PR uses the ODocument's asMap method to convert to the ODocument to a map in an intelligent way.  Now calling asMap will result in:

```
Map{ 
  "f1" -> 1,
  "f2" -> 2
}
```

This seems much more desirable.

I have also included a unit test for the existing and new behavior.