### PR TITLE
Updates the OType.convert() to fix #5533

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OType.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OType.java
@@ -324,7 +324,7 @@ public enum OType {
     if (iTargetClass.isAssignableFrom(iValue.getClass()))
       // COMPATIBLE TYPES: DON'T CONVERT IT
       return iValue;
-
+    
     try {
       if (iValue instanceof OBinary && iTargetClass.isAssignableFrom(byte[].class))
         return ((OBinary) iValue).toByteArray();
@@ -337,25 +337,33 @@ public enum OType {
           return ((Class<Enum>) iTargetClass).getEnumConstants()[((Number) iValue).intValue()];
         return Enum.valueOf((Class<Enum>) iTargetClass, iValue.toString());
       } else if (iTargetClass.equals(Byte.TYPE) || iTargetClass.equals(Byte.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Byte)
+          return iValue;
+        else if (iValue instanceof String)
           return Byte.parseByte((String) iValue);
         else
           return ((Number) iValue).byteValue();
 
       } else if (iTargetClass.equals(Short.TYPE) || iTargetClass.equals(Short.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Short)
+          return iValue;
+        else if (iValue instanceof String)
           return Short.parseShort((String) iValue);
         else
           return ((Number) iValue).shortValue();
 
       } else if (iTargetClass.equals(Integer.TYPE) || iTargetClass.equals(Integer.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Integer)
+          return iValue;
+        else if (iValue instanceof String)
           return Integer.parseInt((String) iValue);
         else
           return ((Number) iValue).intValue();
 
       } else if (iTargetClass.equals(Long.TYPE) || iTargetClass.equals(Long.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Long)
+          return iValue;
+        else if (iValue instanceof String)
           return Long.parseLong((String) iValue);
         else if (iValue instanceof Date)
           return ((Date) iValue).getTime();
@@ -363,7 +371,9 @@ public enum OType {
           return ((Number) iValue).longValue();
 
       } else if (iTargetClass.equals(Float.TYPE) || iTargetClass.equals(Float.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Float)
+          return iValue;
+        else if (iValue instanceof String)
           return Float.parseFloat((String) iValue);
         else
           return ((Number) iValue).floatValue();
@@ -375,7 +385,9 @@ public enum OType {
           return new BigDecimal(iValue.toString());
 
       } else if (iTargetClass.equals(Double.TYPE) || iTargetClass.equals(Double.class)) {
-        if (iValue instanceof String)
+        if (iValue instanceof Double)
+          return iValue;
+        else if (iValue instanceof String)
           return Double.parseDouble((String) iValue);
         else if (iValue instanceof Float)
           // THIS IS NECESSARY DUE TO A BUG/STRANGE BEHAVIOR OF JAVA BY LOSSING PRECISION
@@ -384,7 +396,9 @@ public enum OType {
           return ((Number) iValue).doubleValue();
 
       } else if (iTargetClass.equals(Boolean.TYPE) || iTargetClass.equals(Boolean.class)) {
-        if (iValue instanceof String) {
+        if (iValue instanceof Boolean)
+          return ((Boolean) iValue).booleanValue();
+        else if (iValue instanceof String) {
           if (((String) iValue).equalsIgnoreCase("true"))
             return Boolean.TRUE;
           else if (((String) iValue).equalsIgnoreCase("false"))

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OType.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OType.java
@@ -324,7 +324,7 @@ public enum OType {
     if (iTargetClass.isAssignableFrom(iValue.getClass()))
       // COMPATIBLE TYPES: DON'T CONVERT IT
       return iValue;
-    
+
     try {
       if (iValue instanceof OBinary && iTargetClass.isAssignableFrom(byte[].class))
         return ((OBinary) iValue).toByteArray();

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OTypeConvertTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OTypeConvertTest.java
@@ -1,0 +1,422 @@
+package com.orientechnologies.orient.core.metadata.schema;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test the covert method of the OType class.
+ * 
+ * @author Michael MacFadden
+ */
+@Test
+public class OTypeConvertTest {
+
+  //
+  // General cases
+  //
+  
+  @Test
+  public void testSameType() {
+    ArrayList<Object> aList = new ArrayList<Object>();
+    aList.add(1);
+    aList.add("2");
+    Object result = OType.convert(aList, ArrayList.class);
+
+    assertEquals(result, aList);
+  }
+
+  @Test
+  public void testAssignableType() {
+    ArrayList<Object> aList = new ArrayList<Object>();
+    aList.add(1);
+    aList.add("2");
+    Object result = OType.convert(aList, List.class);
+
+    assertEquals(result, aList);
+  }
+
+  @Test
+  public void testNull() {
+    Object result = OType.convert(null, Boolean.class);
+    assertEquals(result, null);
+  }
+  
+  @Test
+  public void testCannotConvert() {
+    // Expected behavior is to not convert and return null
+    Object result = OType.convert(true, Long.class);
+    assertEquals(result, null);
+  }
+
+  
+  //
+  // To String
+  //
+
+  @Test
+  public void testToStringFromString() {
+    Object result = OType.convert("foo", String.class);
+    assertEquals(result, "foo");
+  }
+  
+  @Test
+  public void testToStringFromNumber() {
+    Object result = OType.convert(10, String.class);
+    assertEquals(result, "10");
+  }
+  
+  //
+  // To Byte
+  //
+
+  @Test
+  public void testToByteFromByte() {
+    Object result = OType.convert((byte)10, Byte.class);
+    assertEquals(result, (byte)10);
+  }
+  
+  @Test
+  public void testToByteFromString() {
+    Object result = OType.convert("10", Byte.class);
+    assertEquals(result, (byte)10);
+  }
+  
+  @Test
+  public void testToByteFromNumber() {
+    Object result = OType.convert(10.0D, Byte.class);
+    assertEquals(result, (byte)10);
+  }
+  
+  
+  //
+  // To Short
+  //
+
+  @Test
+  public void testToShortFromShort() {
+    Object result = OType.convert((short)10, Short.class);
+    assertEquals(result, (short)10);
+  }
+  
+  @Test
+  public void testToShortFromString() {
+    Object result = OType.convert("10", Short.class);
+    assertEquals(result, (short)10);
+  }
+  
+  @Test
+  public void testToShortFromNumber() {
+    Object result = OType.convert(10.0D, Short.class);
+    assertEquals(result, (short)10);
+  }
+  
+  
+  //
+  // To Integer
+  //
+
+  @Test
+  public void testToIntegerFromInteger() {
+    Object result = OType.convert(10, Integer.class);
+    assertEquals(result, 10);
+  }
+  
+  @Test
+  public void testToIntegerFromString() {
+    Object result = OType.convert("10", Integer.class);
+    assertEquals(result, 10);
+  }
+  
+  @Test
+  public void testToIntegerFromNumber() {
+    Object result = OType.convert(10.0D, Integer.class);
+    assertEquals(result, 10);
+  }
+  
+  
+  //
+  // To Long
+  //
+
+  @Test
+  public void testToLongFromLong() {
+    Object result = OType.convert(10L, Long.class);
+    assertEquals(result, 10L);
+  }
+  
+  @Test
+  public void testToLongFromString() {
+    Object result = OType.convert("10", Long.class);
+    assertEquals(result, 10L);
+  }
+  
+  @Test
+  public void testToLongFromNumber() {
+    Object result = OType.convert(10.0D, Long.class);
+    assertEquals(result, 10L);
+  }
+  
+  
+  //
+  // To Float
+  //
+
+  @Test
+  public void testToFloatFromFloat() {
+    Object result = OType.convert(10.65f, Float.class);
+    assertEquals(result, 10.65f);
+  }
+  
+  @Test
+  public void testToFloatFromString() {
+    Object result = OType.convert("10.65", Float.class);
+    assertEquals(result, 10.65f);
+  }
+  
+  @Test
+  public void testToFloatFromNumber() {
+    Object result = OType.convert(4, Float.class);
+    assertEquals(result, 4f);
+  }
+  
+  
+  //
+  // To BigDecimal
+  //
+  
+  @Test
+  public void testToBigDecimalFromBigDecimal() {
+    Object result = OType.convert(new BigDecimal("10.65"), BigDecimal.class);
+    assertEquals(result, new BigDecimal("10.65"));
+  }
+
+  @Test
+  public void testToBigDecimalFromString() {
+    Object result = OType.convert("10.65", BigDecimal.class);
+    assertEquals(result, new BigDecimal("10.65"));
+  }
+  
+  @Test
+  public void testToBigDecimalFromNumber() {
+    Object result = OType.convert(4.98D, BigDecimal.class);
+    assertEquals(result, new BigDecimal("4.98"));
+  }
+
+
+  //
+  // To Double
+  //
+
+  @Test
+  public void testToDoubleFromDouble() {
+    Object result = OType.convert(5.4D, Double.class);
+    assertEquals(result, 5.4D);
+  }
+
+  @Test
+  public void testToDoubleFromString() {
+    Object result = OType.convert("5.4", Double.class);
+    assertEquals(result, 5.4D);
+  }
+
+  @Test
+  public void testToDoubleFromFloat() {
+    Object result = OType.convert(5.4f, Double.class);
+    assertEquals(result, 5.4D);
+  }
+
+  @Test
+  public void testToDoubleFromNonFloatNumber() {
+    Object result = OType.convert(5, Double.class);
+    assertEquals(result, 5D);
+  }
+
+  //
+  // To Boolean
+  //
+
+  @Test
+  public void testToBooleanFromBoolean() {
+    Object result = OType.convert(true, Boolean.class);
+    assertEquals(result, true);
+  }
+  
+  @Test
+  public void testToBooleanFromFalseString() {
+    Object result = OType.convert("false", Boolean.class);
+    assertEquals(result, false);
+  }
+
+  @Test
+  public void testToBooleanFromTrueString() {
+    Object result = OType.convert("true", Boolean.class);
+    assertEquals(result, true);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testToBooleanFromInvalidString() {
+    OType.convert("invalid", Boolean.class);
+  }
+
+  @Test
+  public void testToBooleanFromZeroNumber() {
+    Object result = OType.convert(0, Boolean.class);
+    assertEquals(result, false);
+  }
+
+  @Test
+  public void testToBooleanFromNonZeroNumber() {
+    Object result = OType.convert(1, Boolean.class);
+    assertEquals(result, true);
+  }
+  
+  //
+  // To Date
+  //
+
+  @Test
+  public void testToDateFromDate() {
+    Date d = Calendar.getInstance().getTime();
+    Object result = OType.convert(d, Date.class);
+    assertEquals(result, d);
+  }
+  
+  @Test
+  public void testToDateFromNumber() {
+    Long time = System.currentTimeMillis();
+    Object result = OType.convert(time, Date.class);
+    assertEquals(result, new Date(time));
+  }
+  
+  @Test
+  public void testToDateFromLongString() {
+    Long time = System.currentTimeMillis();
+    Object result = OType.convert(time.toString(), Date.class);
+    assertEquals(result, new Date(time));
+  }
+  
+  @Test
+  public void testToDateFromDateString() {
+    Long time = System.currentTimeMillis();
+    Object result = OType.convert(time.toString(), Date.class);
+    assertEquals(result, new Date(time));
+  }
+  
+  //
+  // To Set
+  //
+
+  @Test
+  public void testToSetFromSet() {
+    HashSet<Object> set = new HashSet<Object>();
+    set.add(1);
+    set.add("2");
+    Object result = OType.convert(set, Set.class);
+    assertEquals(result, set);
+  }
+  
+  @Test
+  public void testToSetFromCollection() {
+    ArrayList<Object> list = new ArrayList<Object>();
+    list.add(1);
+    list.add("2");
+    
+    Object result = OType.convert(list, Set.class);
+    
+    HashSet<Object> expected = new HashSet<Object>();
+    expected.add(1);
+    expected.add("2");
+    assertEquals(result, expected);
+  }
+  
+  @Test
+  public void testToSetFromNonCollection() {
+    HashSet<Object> set = new HashSet<Object>();
+    set.add(1);
+    Object result = OType.convert(1, Set.class);
+    assertEquals(result, set);
+  }
+  
+  
+  //
+  // To List
+  //
+
+  @Test
+  public void testToListFromList() {
+    ArrayList<Object> list = new ArrayList<Object>();
+    list.add(1);
+    list.add("2");
+    Object result = OType.convert(list, List.class);
+    assertEquals(result, list);
+  }
+  
+  @Test
+  public void testToListFromCollection() {
+    HashSet<Object> set = new HashSet<Object>();
+    set.add(1);
+    set.add("2");
+    
+    @SuppressWarnings("unchecked")
+    List<Object> result = (List<Object>)OType.convert(set, List.class);
+    
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsAll(set));
+  }
+  
+  @Test
+  public void testToListFromNonCollection() {
+    ArrayList<Object> expected = new ArrayList<Object>();
+    expected.add(1);
+    Object result = OType.convert(1, List.class);
+    assertEquals(result, expected);
+  }
+  
+  
+  //
+  // To List
+  //
+
+  @Test
+  public void testToCollectionFromList() {
+    ArrayList<Object> list = new ArrayList<Object>();
+    list.add(1);
+    list.add("2");
+    Object result = OType.convert(list, Collection.class);
+    assertEquals(result, list);
+  }
+  
+  @Test
+  public void testToCollectionFromCollection() {
+    HashSet<Object> set = new HashSet<Object>();
+    set.add(1);
+    set.add("2");
+    
+    @SuppressWarnings("unchecked")
+    Collection<Object> result = (Collection<Object>)OType.convert(set, Collection.class);
+    
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsAll(set));
+  }
+  
+  @Test
+  public void testToCollectionFromNonCollection() {
+    @SuppressWarnings("unchecked")
+    Collection<Object> result = (Collection<Object>)OType.convert(1, Collection.class);
+    
+    assertEquals(result.size(), 1);
+    assertTrue(result.contains(1));
+  }
+
+}

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OTypeConvertTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OTypeConvertTest.java
@@ -81,6 +81,12 @@ public class OTypeConvertTest {
   //
 
   @Test
+  public void testToBytePrimitiveFromByte() {
+    Object result = OType.convert((byte)10, Byte.TYPE);
+    assertEquals(result, (byte)10);
+  }
+  
+  @Test
   public void testToByteFromByte() {
     Object result = OType.convert((byte)10, Byte.class);
     assertEquals(result, (byte)10);
@@ -103,6 +109,12 @@ public class OTypeConvertTest {
   // To Short
   //
 
+  @Test
+  public void testToShortPrmitveFromShort() {
+    Object result = OType.convert((short)10, Short.TYPE);
+    assertEquals(result, (short)10);
+  }
+  
   @Test
   public void testToShortFromShort() {
     Object result = OType.convert((short)10, Short.class);
@@ -127,6 +139,12 @@ public class OTypeConvertTest {
   //
 
   @Test
+  public void testToIntegerPrimitveFromInteger() {
+    Object result = OType.convert(10, Integer.TYPE);
+    assertEquals(result, 10);
+  }
+  
+  @Test
   public void testToIntegerFromInteger() {
     Object result = OType.convert(10, Integer.class);
     assertEquals(result, 10);
@@ -150,6 +168,12 @@ public class OTypeConvertTest {
   //
 
   @Test
+  public void testToLongPrimitiveFromLong() {
+    Object result = OType.convert(10L, Long.TYPE);
+    assertEquals(result, 10L);
+  }
+  
+  @Test
   public void testToLongFromLong() {
     Object result = OType.convert(10L, Long.class);
     assertEquals(result, 10L);
@@ -172,6 +196,12 @@ public class OTypeConvertTest {
   // To Float
   //
 
+  @Test
+  public void testToFloatPrimitiveFromFloat() {
+    Object result = OType.convert(10.65f, Float.TYPE);
+    assertEquals(result, 10.65f);
+  }
+  
   @Test
   public void testToFloatFromFloat() {
     Object result = OType.convert(10.65f, Float.class);
@@ -219,6 +249,12 @@ public class OTypeConvertTest {
   //
 
   @Test
+  public void testToDoublePrimitiveFromDouble() {
+    Object result = OType.convert(5.4D, Double.TYPE);
+    assertEquals(result, 5.4D);
+  }
+  
+  @Test
   public void testToDoubleFromDouble() {
     Object result = OType.convert(5.4D, Double.class);
     assertEquals(result, 5.4D);
@@ -246,6 +282,12 @@ public class OTypeConvertTest {
   // To Boolean
   //
 
+  @Test
+  public void testToBooleanPrimitiveFromBoolean() {
+    Object result = OType.convert(true, Boolean.TYPE);
+    assertEquals(result, true);
+  }
+  
   @Test
   public void testToBooleanFromBoolean() {
     Object result = OType.convert(true, Boolean.class);


### PR DESCRIPTION
This PR updates the OType.convert(Object, Class<?>) to better handle Sets, Lists, and Collections to fix #5533.  In addition the method comment was updated, dead code was removed, and unit tests were added.

Of note, at the top of the method there was the following code:

```java
if (iValue.getClass().equals(iTargetClass))
  // SAME TYPE: DON'T CONVERT IT
  return iValue;

if (iTargetClass.isAssignableFrom(iValue.getClass()))
  // COMPATIBLE TYPES: DON'T CONVERT IT
  return iValue;
```

So if the value was an instance of, or subclass of the requested type, the value is directly returned.  However, later in the code there was the following:

```java
else if (iTargetClass.equals(BigDecimal.class)) {
  if (iValue instanceof BigDecimal)
      return iValue;
  else if ...
```
The check for "if (iValue instanceof BigDecimal)" is unreachable code, since if the target type is BigDecimal and the value is BigDecimal, the code would have short circuited above.


The main thrust of the PR was later handling the List, Set, and Collection specifically.  If the caller is asking for a List type, they will get a list.  If they are asking for a Set, they will get a Set.  If the user is asking for a collection, they will get a collection, but as a List.  A list was chosen because it can preserve multiple identical items, whereas a set can not.

There is one change that this PR does impart.  That is we don't handle a generic collection any more.  Previously, the caller could request ANY kind of collection, and they would wind up with a SET.  This is dangerous and can cause class cast exceptions.  For example, before the caller could execute:

```java
List<?,?> converted = (List<?,?>)OType.convert(4, List.class)
```

The problem, is that the check previously was "Collection.class.isAssignableFrom(iTargetClass)".  This is saying, does the caller want ANY kind of collection.  Since they wanted a List, this would be true.  However, the code would then give them a HashSet, which is unexpected.  In this model, the caller could essentially never ask for a collection other than a Set.  Lists and Maps would not work.

In the new code, the user must ask for a Set, or List specifically, and will get one of those.  If they don't care what kind of collection they want, the can specifically ask for a Collection.  So while the logic is different, there is nothing that used to work before, that does not work now.  The only thing that is somewhat missing here is converting into a Map.  However, this was not supported before, and it is a bit harder to imagine the logic for converting something into a Map from the OType class.  We could do the even/odd mapping from the "asMap" SQL function, but this doesn't seem to quite make sense here.  So I have left that for another PR.  This at least makes Sets, Lists, and Collections behave.

I added a new unit test for this method.  It covers most of logic.  I did not cover all Date conversion logic, since it requires a database on the thread to get the date format.  I also did not cover all of the Binary type handling since I am not familiar with the workings of those. However, since the Binary and Date logic was not changed, I don't see this as an issue.  Plus there were NO unit tests before.

mvn:test passes all unit tests

Feedback welcome.