### PR TITLE
Workaround for issue #5424

### DIFF
--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientBaseGraph.java
@@ -350,7 +350,10 @@ public abstract class OrientBaseGraph extends OrientConfigurableGraph implements
       iClassName = "-" + iClassName;
 
     try {
-      return URLEncoder.encode(iClassName, "UTF-8");
+        return URLEncoder.encode(iClassName, "UTF-8")    // default URL encoding
+                         .replaceAll("\\.", "%2E")       // encode invalid '.'
+                         .replaceAll("_", "%5F")         // encode reserved '_'
+                         .replaceAll("\\%", "_");        // replace invalid '%' with reserved '_'
     } catch (UnsupportedEncodingException e) {
       OLogManager.instance().error(null, "Error on encoding class name using encoding '%s'", e, "UTF-8");
       return iClassName;
@@ -368,7 +371,8 @@ public abstract class OrientBaseGraph extends OrientConfigurableGraph implements
       iClassName = iClassName.substring(1);
 
     try {
-      return URLDecoder.decode(iClassName, "UTF-8");
+        // replace reserved '_' with invalid '%' and apply default URL decoding
+        return URLDecoder.decode(iClassName.replaceAll("_", "%"), "UTF-8");
     } catch (UnsupportedEncodingException e) {
       OLogManager.instance().error(null, "Error on decoding class name using encoding '%s'", e, "UTF-8");
       return iClassName;

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientEdge.java
@@ -232,7 +232,7 @@ public class OrientEdge extends OrientElement implements Edge {
   public String getLabel() {
     if (label != null)
       // LIGHTWEIGHT EDGE
-      return label;
+      return OrientBaseGraph.decodeClassName(label);
     else if (rawElement != null) {
       if (settings != null && settings.isUseClassForEdgeLabel()) {
         final String clsName = getRecord().getClassName();


### PR DESCRIPTION
Workaround for issue #5424

The TinkerPop implementation of OrientDB uses the java.net.URLEncoder/Decoder to encode/decode class names. The default encoding for URLs, as defined in RFC 2396, will not encode the '.' character, which is invalid in class/field names. Furthermore, the default encoding uses a %-encoding for non-alpha-numeric characters, resulting in class/field names, containing '%' characters, which is invalid in OrientDB. 

The workaround extends the OrientBaseGraph.encodeClassName method for %-encoding of '.' and '_' characters and afterwards replaces all '%' characters by '_'. To achieve a bijective mapping, the encoding replaces all '_' charakters by  '%' characters and applies the default URL decoding, which already considers the correct decoding of the encoded '.' and '_' characters.

Example:
"http://tinkerpop.com#knows" is encoded into the valid class name "http_3A_2F_2Ftinkerpop_5Ecom_23name", which decodes in "http://tinkerpop.com#knows"
