### PR TITLE
HTTP API > Batch SQL > Prepared statements with parameters

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostBatch.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/post/OServerCommandPostBatch.java
@@ -153,6 +153,13 @@ public class OServerCommandPostBatch extends OServerCommandDocumentAbstract {
           if (command == null)
             throw new IllegalArgumentException("command parameter is null");
 
+          Object params = operation.get("parameters");
+          if (params instanceof Collection) {
+            final Object[] paramArray = new Object[((Collection) params).size()];
+            ((Collection) params).toArray(paramArray);
+            params = paramArray;
+          }
+
           String commandAsString = null;
           if (command != null)
             if (OMultiValue.isMultiValue(command)) {
@@ -167,7 +174,12 @@ public class OServerCommandPostBatch extends OServerCommandDocumentAbstract {
 
           final OCommandRequestText cmd = (OCommandRequestText) OCommandManager.instance().getRequester(language);
           cmd.setText(commandAsString);
-          lastResult = db.command(cmd).execute();
+
+          if(params==null){
+            lastResult = db.command(cmd).execute();
+          }else {
+            lastResult = db.command(cmd).execute(params);
+          }
         } else if (type.equals("script")) {
           // COMMAND
           final String language = (String) operation.get("language");


### PR DESCRIPTION
As mentioned in #5552 the tests on `develop` didn't work (they break @orientdb-core). I tried to run the tests on `master` too and that didn't work either (they break @orientdb-server).

I tried configuring my env on both Windows and Ubuntu both with Oracle 8 JDK, neither worked.

...so I'm opening this PR nonetheless hoping to get some help either setting up my environment (if the problem's there) or to get a notification when the tests should be working on develop (if the issue is in the code).

---

I've successfully used the [command](http://orientdb.com/docs/2.1/OrientDB-REST.html#command) functionality for running prepared statements with parameters as described in the documentation (worked with >= v2.2-alpha).

The [batch](http://orientdb.com/docs/2.1/OrientDB-REST.html#batch) functionality doesn't specify the possibility of using prepared statements with parameters. Is this possible? Is it a planned feature in a future release?

I've tested using 

```
{
    "transaction": true,
    "operations": [
        {
            "type" : "cmd",
            "language" : "sql",
            "command": "COMMAND1..."
            "parameters": {"param1": "value1", "param2": "value2"}
        },
        {
            "type" : "cmd",
            "language" : "sql",
            "command": "COMMAND2..."
            "parameters": {"param1": "value1", "param2": "value2"}
        },
    ]
}
```

But as expected (based on the documentation) it didn't work.
