### PR TITLE
Using built-in constant-time comparison function to avoid timing attacks

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/security/OSecurityManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/security/OSecurityManager.java
@@ -106,7 +106,10 @@ public class OSecurityManager {
       return checkPasswordWithSalt(iPassword, s, PBKDF2_SHA256_ALGORITHM);
     }
 
-    return iPassword.equals(iHash);
+    // Do not compare raw strings against each other, to avoid timing attacks.
+    // Instead, hash them both with a cryptographic hash function and
+    // compare their hashes with a constant-time comparison method.
+    return MessageDigest.isEqual(digestSHA256(iPassword), digestSHA256(iHash));
   }
 
   public String createSHA256(final String iInput) {
@@ -199,7 +202,7 @@ public class OSecurityManager {
     final int iterations = Integer.parseInt(params[2]);
 
     final byte[] testHash = getPbkdf2(iPassword, salt, iterations, hash.length, algorithm);
-    return compareHash(hash, testHash);
+    return MessageDigest.isEqual(hash, testHash);
   }
 
   private byte[] getPbkdf2(final String iPassword, final byte[] salt, final int iterations, final int bytes,
@@ -231,13 +234,6 @@ public class OSecurityManager {
     } catch (Exception e) {
       throw OException.wrapException(new OSecurityException("Cannot create a key with '" + PBKDF2_ALGORITHM + "' algorithm"), e);
     }
-  }
-
-  private static boolean compareHash(final byte[] iFirst, final byte[] iSecond) {
-    int diff = iFirst.length ^ iSecond.length;
-    for (int i = 0; i < iFirst.length && i < iSecond.length; i++)
-      diff |= iFirst[i] ^ iSecond[i];
-    return diff == 0;
   }
 
   public static String byteArrayToHexStr(final byte[] data) {


### PR DESCRIPTION
In agreement with Luca Garulli, opening a PR to fix a timing attack vulnerability. See here for details on how to protect against such attacks:
http://stackoverflow.com/questions/33626298/messagedigest-isequal-function-use-in-java/33626618

The removed line 109 performed a regular string comparison between the supplied and expected passwords, which was vulnerable to a timing attack. I am replacing that with a constant-time check of the hashes of the two passwords, which is not able to be timed. I am also replacing the custom constant-time comparison function with the Java built-in function `MessageDigest.isEqual` which does the same thing.

As this is a security fix, it would be nice to backport this to all active releases as soon as possible.

Thanks!