### PR TITLE
Added default sequence type

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/sequence/OSequenceHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/sequence/OSequenceHelper.java
@@ -8,6 +8,8 @@ import com.orientechnologies.orient.core.metadata.sequence.OSequence.SEQUENCE_TY
  * @since 3/1/2015
  */
 public class OSequenceHelper {
+  public static final SEQUENCE_TYPE DEFAULT_SEQUENCE_TYPE = SEQUENCE_TYPE.CACHED;
+
   public static OSequence createSequence(SEQUENCE_TYPE sequenceType, OSequence.CreateParams params, ODocument document) {
     switch (sequenceType) {
       case ORDERED:

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateSequence.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateSequence.java
@@ -67,6 +67,10 @@ public class OCommandExecutorSQLCreateSequence extends OCommandExecutorSQLAbstra
       }
     }
 
+    if (this.sequenceType == null) {
+      this.sequenceType = OSequenceHelper.DEFAULT_SEQUENCE_TYPE;
+    }
+
     return this;
   }
 


### PR DESCRIPTION
The current syntax should allow one to create syntax without declaring it's type, yet if you try the following:
```
CREATE SEQUENCE idseq
```
an exception will be thrown (NPE specifically).

This fixes it by using a default sequence type (cached).
I used cached as the default sequence type since it's the one that may result in better performance.