### PR TITLE
[+Issue] Default value now happens on validation (require saving)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -229,6 +229,16 @@ public class ODocument extends ORecordAbstract
   protected static void validateField(ODocument iRecord, OImmutableProperty p) throws OValidationException {
     final Object fieldValue;
     ODocumentEntry entry = iRecord._fields.get(p.getName());
+    if (entry == null || !entry.exist()) {
+      final String defaultValue = p.getDefaultValue();
+      if (defaultValue != null && defaultValue.length() > 0) {
+        Object defValueParsed = OSQLHelper.parseDefaultValue(iRecord, defaultValue);
+        iRecord.field(p.getName(), defValueParsed);
+        if (entry == null) {
+          entry = iRecord._fields.get(p.getName());
+        }
+      }
+    }
     if (entry != null && entry.exist()) {
       // AVOID CONVERSIONS: FASTER!
       fieldValue = entry.value;
@@ -2593,13 +2603,6 @@ public class ODocument extends ORecordAbstract
       if (entry != null && entry.exist()) {
         if (entry.type == null || entry.type != prop.getType()) {
           field(prop.getName(), entry.value, prop.getType());
-        }
-      } else {
-        String defValue = prop.getDefaultValue();
-        if (defValue != null && defValue.length() > 0 && !containsField(prop.getName())) {
-          Object curFieldValue = OSQLHelper.parseDefaultValue(this, defValue);
-          Object fieldValue = ODocumentHelper.convertField(this, prop.getName(), prop.getType(), null, curFieldValue);
-          rawField(prop.getName(), fieldValue, prop.getType());
         }
       }
     }


### PR DESCRIPTION
## Problem

Currently, the default value is set when creating the field.
As a result, when deserializing a class, it will first set the default fields, and then try to deserialize the fields. When it encounters a field, it will ignore it since a value is already set (rough workflow).

```
1. CREATE CLASS User
2. CREATE PROPERTY User.name
3. ALTER PROPERTY User.name defaultvalue Joe

4. insert into User set name="Not Joe"
5. select from user
```

As a result, when the above is executed from the console, it will show one record in user, with name set to "Joe" rather than "Not Joe".

I Also added a test case using serializer.
## FIx

The fix I did was to move the default value from when the class initialize, to when the class saves (validation). This fixes the issue, however requires the document will be saved before one can see the default value. Since this is a new feature, I think we can still change it before it will start confusing some people. I also think it's the correct way the feature should work.
