### PR TITLE
Fix orientdb-tools OSGi exports

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -36,7 +36,10 @@
 
     <properties>
         <osgi.import>sun.misc;resolution:=optional,*</osgi.import>
-        <osgi.export>com.orientechnologies.orient.console.*</osgi.export>
+        <osgi.export>
+            com.orientechnologies.orient.console.*,
+            com.orientechnologies.orient.server.config.*
+        </osgi.export>
         <jar.manifest.mainclass>com.orientechnologies.orient.console.OConsoleDatabaseApp</jar.manifest.mainclass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Add 'com.orientechnologies.orient.server.config' to the packages exported from orientdb-tools.
(this package was moved from orientdb-server to orientdb-tools but the exports weren't updated)