### PR TITLE
Fixes for speeding up when registering a lot of classes

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManager.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -128,7 +129,11 @@ public class OEntityManager {
   }
 
   public synchronized void registerEntityClass(final Class<?> iClass) {
-    classHandler.registerEntityClass(iClass);
+    registerEntityClass(iClass, true);
+  }
+
+  public synchronized void registerEntityClass(final Class<?> iClass, boolean forceSchemaReload) {
+    classHandler.registerEntityClass(iClass, forceSchemaReload);
   }
 
   /**
@@ -221,7 +226,6 @@ public class OEntityManager {
       for (Field declaredField : declaredFields) {
         Class<?> declaredFieldType = declaredField.getType();
           if (!classHandler.containsEntityClass(declaredFieldType)) {
-//            classHandler.registerEntityClass(declaredFieldType);
             registerEntityClasses(declaredFieldType, recursive);
           }
       }
@@ -238,8 +242,11 @@ public class OEntityManager {
    * @param iClassHandler
    */
   public synchronized void setClassHandler(final OEntityManagerClassHandler iClassHandler) {
-    for (Entry<String, Class<?>> entry : classHandler.getClassesEntrySet()) {
-      iClassHandler.registerEntityClass(entry.getValue());
+    Iterator<Entry<String, Class<?>>> iterator = iClassHandler.getClassesEntrySet().iterator();
+    while (iterator.hasNext()){
+      Entry<String, Class<?>> entry = iterator.next();
+      boolean forceSchemaReload = !iterator.hasNext();
+      iClassHandler.registerEntityClass(entry.getValue(), forceSchemaReload);
     }
     this.classHandler = iClassHandler;
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManager.java
@@ -242,7 +242,7 @@ public class OEntityManager {
    * @param iClassHandler
    */
   public synchronized void setClassHandler(final OEntityManagerClassHandler iClassHandler) {
-    Iterator<Entry<String, Class<?>>> iterator = iClassHandler.getClassesEntrySet().iterator();
+    Iterator<Entry<String, Class<?>>> iterator = classHandler.getClassesEntrySet().iterator();
     while (iterator.hasNext()){
       Entry<String, Class<?>> entry = iterator.next();
       boolean forceSchemaReload = !iterator.hasNext();

--- a/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManagerClassHandler.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/entity/OEntityManagerClassHandler.java
@@ -47,7 +47,15 @@ public class OEntityManagerClassHandler {
     entityClasses.put(iClass.getSimpleName(), iClass);
   }
 
+  public synchronized void registerEntityClass(final Class<?> iClass, boolean forceSchemaReload) {
+    entityClasses.put(iClass.getSimpleName(), iClass);
+  }
+
   public synchronized void registerEntityClass(final String iClassName, final Class<?> iClass) {
+    entityClasses.put(iClassName, iClass);
+  }
+
+  public synchronized void registerEntityClass(final String iClassName, final Class<?> iClass, boolean forceSchemaReload) {
     entityClasses.put(iClassName, iClass);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -81,6 +81,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   private int[]                              clusterIds;
   private List<OClassImpl>                   superClasses            = new ArrayList<OClassImpl>();
   private int[]                              polymorphicClusterIds;
+  private SortedSet<Integer>                 polymorphicClusterIdsSet = new TreeSet<Integer>();
   private List<OClass>                       subclasses;
   private float                              overSize                = 0f;
   private String                             shortName;
@@ -309,7 +310,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
 
   @Override
   public boolean hasPolymorphicClusterId(final int clusterId) {
-    return Arrays.binarySearch(polymorphicClusterIds, clusterId) >= 0;
+    return polymorphicClusterIdsSet.contains(clusterId);
   }
 
   @Override
@@ -1005,6 +1006,9 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   public int[] getPolymorphicClusterIds() {
     acquireSchemaReadLock();
     try {
+      if (polymorphicClusterIds.length != polymorphicClusterIdsSet.size()){
+        updatePolymorphicClusterIdsArray();
+      }
       return polymorphicClusterIds;
     } finally {
       releaseSchemaReadLock();
@@ -1012,8 +1016,11 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   }
 
   private void setPolymorphicClusterIds(final int[] iClusterIds) {
-    polymorphicClusterIds = iClusterIds;
-    Arrays.sort(polymorphicClusterIds);
+    polymorphicClusterIdsSet = new TreeSet<Integer>();
+    for (int clusterid: iClusterIds){
+      polymorphicClusterIdsSet.add(clusterid);
+    }
+    updatePolymorphicClusterIdsArray();
   }
 
   public void renameProperty(final String iOldName, final String iNewName) {
@@ -1444,7 +1451,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     acquireSchemaReadLock();
     try {
       if (isPolymorphic)
-        return getDatabase().countClusterElements(readableClusters(getDatabase(), polymorphicClusterIds));
+        return getDatabase().countClusterElements(readableClusters(getDatabase(), getPolymorphicClusterIds()));
 
       return getDatabase().countClusterElements(readableClusters(getDatabase(), clusterIds));
     } finally {
@@ -1742,7 +1749,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
       final OIndexDefinition indexDefinition = OIndexDefinitionFactory.createIndexDefinition(this, Arrays.asList(fields),
           extractFieldTypes(fields), null, type, algorithm);
 
-      return getDatabase().getMetadata().getIndexManager().createIndex(name, type, indexDefinition, polymorphicClusterIds,
+      return getDatabase().getMetadata().getIndexManager().createIndex(name, type, indexDefinition, getPolymorphicClusterIds(),
           progressListener, metadata, algorithm);
     } finally {
       releaseSchemaReadLock();
@@ -2200,17 +2207,26 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   }
 
   private void addPolymorphicClusterId(int clusterId) {
-    if (Arrays.binarySearch(polymorphicClusterIds, clusterId) >= 0)
+    if (polymorphicClusterIdsSet.contains(clusterId)){
       return;
+    }
 
-    polymorphicClusterIds = OArrays.copyOf(polymorphicClusterIds, polymorphicClusterIds.length + 1);
-    polymorphicClusterIds[polymorphicClusterIds.length - 1] = clusterId;
-    Arrays.sort(polymorphicClusterIds);
+    polymorphicClusterIdsSet.add(clusterId);
+//    updatePolymorphicClusterIdsArray();
 
     addClusterIdToIndexes(clusterId);
 
     for (OClassImpl superClass : superClasses) {
       superClass.addPolymorphicClusterId(clusterId);
+    }
+  }
+
+  private void updatePolymorphicClusterIdsArray() {
+    polymorphicClusterIds = new int[polymorphicClusterIdsSet.size()];
+    int i = 0;
+    for (Integer clusterId: polymorphicClusterIdsSet){
+      polymorphicClusterIds[i] = clusterId;
+      i++;
     }
   }
 
@@ -2477,19 +2493,15 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   }
 
   private void removePolymorphicClusterIds(final OClassImpl iBaseClass) {
-    for (final int clusterId : iBaseClass.polymorphicClusterIds)
+    for (final int clusterId : iBaseClass.getPolymorphicClusterIds())
       removePolymorphicClusterId(clusterId);
   }
 
   private void removePolymorphicClusterId(final int clusterId) {
-    final int index = Arrays.binarySearch(polymorphicClusterIds, clusterId);
-    if (index < 0)
+    if (!polymorphicClusterIdsSet.remove(clusterId)){
       return;
-
-    if (index < polymorphicClusterIds.length - 1)
-      System.arraycopy(polymorphicClusterIds, index + 1, polymorphicClusterIds, index, polymorphicClusterIds.length - (index + 1));
-
-    polymorphicClusterIds = Arrays.copyOf(polymorphicClusterIds, polymorphicClusterIds.length - 1);
+    }
+    updatePolymorphicClusterIdsArray();
 
     removeClusterFromIndexes(clusterId);
     for (OClassImpl superClass : superClasses) {
@@ -2527,7 +2539,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
    * Add different cluster id to the "polymorphic cluster ids" array.
    */
   private void addPolymorphicClusterIds(final OClassImpl iBaseClass) {
-    for (int clusterId : iBaseClass.polymorphicClusterIds) {
+    for (int clusterId : iBaseClass.getPolymorphicClusterIds()) {
       addPolymorphicClusterId(clusterId);
     }
   }

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -412,15 +412,20 @@ public class OObjectEntitySerializer {
       registerClass(iClass);
   }
 
+  public static synchronized void registerClass(final Class<?> iClass) {
+    registerClass(iClass, true);
+  }
+
   /**
    * Registers the class informations that will be used in serialization, deserialization and lazy loading of it. If already
    * registered does nothing.
    *
    * @param iClass
    *          :- the Class<?> to register
+   * @param forceReload whether or not to force the reload of the schema before registering
    */
   @SuppressWarnings("unchecked")
-  public static synchronized void registerClass(final Class<?> iClass) {
+  public static synchronized void registerClass(final Class<?> iClass, boolean forceReload) {
     final OObjectEntitySerializedSchema serializedSchema = getCurrentSerializedSchema();
     if (serializedSchema == null)
       return;
@@ -438,7 +443,9 @@ public class OObjectEntitySerializer {
 
     final ODatabaseDocumentInternal db = ODatabaseRecordThreadLocal.INSTANCE.get();
     final OSchema oSchema = db.getMetadata().getSchema();
-    oSchema.reload();
+    if (forceReload){
+      oSchema.reload();
+    }
 
     if (!oSchema.existsClass(iClass.getSimpleName())) {
       if (Modifier.isAbstract(iClass.getModifiers()))

--- a/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/enhancement/OObjectEntitySerializer.java
@@ -655,7 +655,6 @@ public class OObjectEntitySerializer {
           reloadSchema = true;
         } else {
           oSuperClass = oSchema.getClass(currentClass.getSimpleName());
-          reloadSchema = true;
         }
 
         if (!currentOClass.getSuperClasses().contains(oSuperClass)) {

--- a/object/src/main/java/com/orientechnologies/orient/object/entity/OObjectEntityClassHandler.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/entity/OObjectEntityClassHandler.java
@@ -31,14 +31,24 @@ public class OObjectEntityClassHandler extends OEntityManagerClassHandler {
 
   @Override
   public void registerEntityClass(Class<?> iClass) {
-    if (!OObjectEntitySerializer.isToSerialize(iClass) && !iClass.isEnum())
-      registerEntityClass(iClass.getSimpleName(), iClass);
+    registerEntityClass(iClass, true);
   }
 
   @Override
-  public void registerEntityClass(String iClassName, Class<?> iClass) {
+  public synchronized void registerEntityClass(Class<?> iClass, boolean forceSchemaReload) {
+    if (!OObjectEntitySerializer.isToSerialize(iClass) && !iClass.isEnum())
+      registerEntityClass(iClass.getSimpleName(), iClass, forceSchemaReload);
+  }
+
+  @Override
+  public synchronized void registerEntityClass(String iClassName, Class<?> iClass) {
+    registerEntityClass(iClassName, iClass, true);
+  }
+
+  @Override
+  public synchronized void registerEntityClass(String iClassName, Class<?> iClass, boolean forceSchemaReload) {
     if (!OObjectEntitySerializer.isToSerialize(iClass) && !iClass.isEnum()) {
-      OObjectEntitySerializer.registerClass(iClass);
+      OObjectEntitySerializer.registerClass(iClass, forceSchemaReload);
       super.registerEntityClass(iClassName, iClass);
     }
   }


### PR DESCRIPTION
Throughout the registration code, the schema is reloaded way to many times.
- Added extra method to avoid this. 
- Removed one unnecessary reload
- On OEntityManager initialization, only reload the schema when the last class has been registered

Also in OClassImpl the polymorphic cluster ids were kept in an array, which needed to be sorted over and over again, which is very expensive. Added a helper SortedSet next to it so the sorting is now fast.