### PR TITLE
full checkpoint listeners support added to paginated storage #5947

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -75,6 +75,7 @@ import com.orientechnologies.orient.core.version.OSimpleVersion;
 import com.orientechnologies.orient.core.version.OVersionFactory;
 
 import java.io.*;
+import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -116,6 +117,8 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       .getValueAsBoolean();
   private volatile OLowDiskSpaceInformation lowDiskSpace                               = null;
   private volatile boolean                  checkpointRequest                          = false;
+
+  private final List<WeakReference<OFullCheckpointListener>> fullCheckpointListeners = new ArrayList<WeakReference<OFullCheckpointListener>>();
 
   private final int id;
 
@@ -1628,8 +1631,56 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       writeAheadLog.cutTill(lastLSN);
 
       clearStorageDirty();
+
+      notifyFullCheckpointListeners();
     } catch (IOException ioe) {
       throw new OStorageException("Error during checkpoint creation for storage " + name, ioe);
+    }
+  }
+
+  /**
+   * Adds the giving listener to the list of the full checkpoint listeners of this storage.
+   *
+   * @param listener the listener to add.
+   */
+  public void addFullCheckpointListener(OFullCheckpointListener listener) {
+    synchronized (fullCheckpointListeners) {
+      fullCheckpointListeners.add(new WeakReference<OFullCheckpointListener>(listener));
+    }
+  }
+
+  /**
+   * Removes the giving listener from the list of the full checkpoint listeners of this storage.
+   *
+   * @param listener the listener to remove.
+   */
+  public void removeFullCheckpointListener(OFullCheckpointListener listener) {
+    synchronized (fullCheckpointListeners) {
+      for (Iterator<WeakReference<OFullCheckpointListener>> i = fullCheckpointListeners.iterator(); i.hasNext();) {
+        final OFullCheckpointListener storedListener = i.next().get();
+        if (storedListener == null || storedListener.equals(listener))
+          i.remove();
+      }
+    }
+  }
+
+  private void notifyFullCheckpointListeners() {
+    synchronized (fullCheckpointListeners) {
+      for (Iterator<WeakReference<OFullCheckpointListener>> i = fullCheckpointListeners.iterator(); i.hasNext();) {
+        final OFullCheckpointListener listener = i.next().get();
+
+        if (listener == null) {
+          i.remove();
+          continue;
+        }
+
+        try {
+          listener.fullCheckpointMade(this);
+        } catch (Throwable t) {
+          OLogManager.instance()
+              .error(this, "Error while invoking full checkpoint listener of class %s.", t, listener.getClass().getSimpleName());
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OFullCheckpointListener.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OFullCheckpointListener.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  *  Copyright 2016 OrientDB LTD (info(at)orientdb.com)
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  * For more information: http://www.orientdb.com
+ */
+
+package com.orientechnologies.orient.core.storage.impl.local;
+
+/**
+ * Defines the contract for the full checkpoint listeners.
+ *
+ * @see OAbstractPaginatedStorage#addFullCheckpointListener(OFullCheckpointListener)
+ * @see OAbstractPaginatedStorage#removeFullCheckpointListener(OFullCheckpointListener)
+ *
+ * @author Sergey Sitnikov
+ */
+public interface OFullCheckpointListener {
+
+  /**
+   * Invoked when the full checkpoint made by the storage of interest.
+   *
+   * @param storage the storage that made the full checkpoint.
+   */
+  void fullCheckpointMade(OAbstractPaginatedStorage storage);
+
+}


### PR DESCRIPTION
Listeners should implement `com.orientechnologies.orient.core.storage.impl.local.OFullCheckpointListener`. Use `com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage#addFullCheckpointListener` and `com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage#removeFullCheckpointListener` to add or remove a listener.