### PR TITLE
A star path finding function and test added to graph sql functions

### DIFF
--- a/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/HeuristicFormula.java
+++ b/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/HeuristicFormula.java
@@ -1,0 +1,46 @@
+/*
+  *
+  *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+  *  *
+  *  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  *  you may not use this file except in compliance with the License.
+  *  *  You may obtain a copy of the License at
+  *  *
+  *  *       http://www.apache.org/licenses/LICENSE-2.0
+  *  *
+  *  *  Unless required by applicable law or agreed to in writing, software
+  *  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  *  See the License for the specific language governing permissions and
+  *  *  limitations under the License.
+  *  *
+  *  * For more information: http://www.orientechnologies.com
+  *
+  */
+package com.orientechnologies.orient.graph.sql.functions;
+
+import com.orientechnologies.orient.core.command.OCommandContext;
+import com.orientechnologies.orient.core.command.OCommandExecutorAbstract;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientVertex;
+
+import java.util.*;
+
+
+/**
+ *  Heuristic formula enum.
+ *
+ * @author Saeed Tabrizi (saeed a_t  nowcando.com)
+ */
+public enum HeuristicFormula {
+    MANHATAN,
+    MAXAXIS,
+    DIAGONAL,
+    EUCLIDEAN,
+    EUCLIDEANNOSQR,
+    CUSTOM
+}

--- a/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionAstar.java
+++ b/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionAstar.java
@@ -1,0 +1,356 @@
+/*
+ *
+ *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  * For more information: http://www.orientechnologies.com
+ *
+ */
+package com.orientechnologies.orient.graph.sql.functions;
+
+import java.awt.*;
+import java.lang.reflect.Array;
+import java.util.*;
+import java.util.List;
+
+import com.orientechnologies.common.collection.OMultiValue;
+import com.orientechnologies.common.concur.resource.OPartitionedObjectPool;
+import com.orientechnologies.common.io.OIOUtils;
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.command.OCommandContext;
+import com.orientechnologies.orient.core.command.traverse.OTraverse;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.record.ORecord;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.OSQLHelper;
+import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
+import com.orientechnologies.orient.graph.sql.OGraphCommandExecutorSQLFactory;
+import com.sun.javafx.scene.layout.region.Margins;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientVertex;
+
+/**
+ * A*'s algorithm describes how to find the cheapest path from one node to another node in a directed weighted graph with husrestic function.
+ * <p>
+ * The first parameter is source record. The second parameter is destination record. The third parameter is a name of property that
+ * represents 'weight' and fourth represnts the map of options.
+ * <p>
+ * If property is not defined in edge or is null, distance between vertexes are 0 .
+ * @author Saeed Tabrizi (saeed a_t  nowcando.com)
+ */
+public class OSQLFunctionAstar extends OSQLFunctionHeuristicPathFinderAbstract {
+    public static final String NAME = "astar";
+
+    private String paramWeightFieldName = "weight";
+    private long currentDepth = 0;
+    protected Set<OrientVertex> closedSet = new HashSet<OrientVertex>();
+    protected Map<OrientVertex, OrientVertex> cameFrom = new HashMap<OrientVertex, OrientVertex>();
+
+    protected Map<OrientVertex, Double> gScore = new HashMap<OrientVertex, Double>();
+    protected Map<OrientVertex, Double> fScore = new HashMap<OrientVertex, Double>();
+    protected PriorityQueue<OrientVertex> open = new PriorityQueue<OrientVertex>(1, new Comparator<OrientVertex>() {
+
+        public int compare(OrientVertex nodeA, OrientVertex nodeB) {
+            return Double.compare(fScore.get(nodeA), fScore.get(nodeB));
+        }
+    });
+
+    public OSQLFunctionAstar() {
+        super(NAME, 3, 4);
+    }
+
+    public LinkedList<OrientVertex> execute(final Object iThis, final OIdentifiable iCurrentRecord, final Object iCurrentResult,
+                                            final Object[] iParams, final OCommandContext iContext) {
+        context = iContext;
+        final OSQLFunctionAstar context = this;
+        return OGraphCommandExecutorSQLFactory
+                .runWithAnyGraph(new OGraphCommandExecutorSQLFactory.GraphCallBack<LinkedList<OrientVertex>>() {
+                    @Override
+                    public LinkedList<OrientVertex> call(final OrientBaseGraph graph) {
+
+                        final ORecord record = iCurrentRecord != null ? iCurrentRecord.getRecord() : null;
+
+                        Object source = iParams[0];
+                        if (OMultiValue.isMultiValue(source)) {
+                            if (OMultiValue.getSize(source) > 1)
+                                throw new IllegalArgumentException("Only one sourceVertex is allowed");
+                            source = OMultiValue.getFirstValue(source);
+                        }
+                        paramSourceVertex = graph.getVertex(OSQLHelper.getValue(source, record, iContext));
+
+                        Object dest = iParams[1];
+                        if (OMultiValue.isMultiValue(dest)) {
+                            if (OMultiValue.getSize(dest) > 1)
+                                throw new IllegalArgumentException("Only one destinationVertex is allowed");
+                            dest = OMultiValue.getFirstValue(dest);
+                        }
+                        paramDestinationVertex = graph.getVertex(OSQLHelper.getValue(dest, record, iContext));
+
+                        paramWeightFieldName = OIOUtils.getStringContent(iParams[2]);
+
+
+                        if (iParams.length > 3) {
+                            bindAdditionalParams(iParams[3], context);
+                        }
+                        iContext.setVariable("getNeighbors", 0);
+                        return internalExecute(iContext);
+                    }
+                });
+    }
+
+    private LinkedList<OrientVertex> internalExecute(final OCommandContext iContext) {
+
+        OrientVertex start = paramSourceVertex;
+        OrientVertex goal = paramDestinationVertex;
+
+        open.add(start);
+
+        // The cost of going from start to start is zero.
+        gScore.put(start, 0.0);
+        // For the first node, that value is completely heuristic.
+        fScore.put(start, getHeuristicCost(start, null, goal));
+
+        while (!open.isEmpty()) {
+            OrientVertex current = open.poll();
+
+            // we discussed about this feature in https://github.com/orientechnologies/orientdb/pull/6002#issuecomment-212492687
+            if (paramEmptyIfMaxDepth==true && currentDepth >= paramMaxDepth ){
+                route.clear(); // to ensure our result is empty
+                return getPath();
+            }
+            // if start and goal vertex is equal so return current path from  cameFrom hash map
+            if (current.getIdentity().equals(goal.getIdentity()) || currentDepth >= paramMaxDepth) {
+
+                while (current != null) {
+                    route.add(0, current);
+                    current = cameFrom.get(current);
+                }
+                return getPath();
+            }
+
+            closedSet.add(current);
+            for (OrientVertex neighbor : getNeighbors(current)) {
+
+                // Ignore the neighbor which is already evaluated.
+                if (closedSet.contains(neighbor)) {
+                    continue;
+                }
+                // The distance from start to a neighbor
+                double tentative_gScore = gScore.get(current) + getDistance(current, current, neighbor);
+                boolean contains = open.contains(neighbor);
+
+                if (!contains || tentative_gScore < gScore.get(neighbor)) {
+                    gScore.put(neighbor, tentative_gScore);
+                    fScore.put(neighbor, tentative_gScore + getHeuristicCost(neighbor, current, goal));
+
+                    if (contains) {
+                        open.remove(neighbor);
+                    }
+                    open.offer(neighbor);
+                    cameFrom.put(neighbor, current);
+                }
+            }
+
+            // Increment Depth Level
+            currentDepth++;
+
+        }
+
+        return getPath();
+    }
+
+    private void bindAdditionalParams(Object additionalParams, OSQLFunctionAstar ctx) {
+        if (additionalParams == null) {
+            return;
+        }
+        Map<String, Object> mapParams = null;
+        if (additionalParams instanceof Map) {
+            mapParams = (Map) additionalParams;
+        } else if (additionalParams instanceof OIdentifiable) {
+            mapParams = ((ODocument) ((OIdentifiable) additionalParams).getRecord()).toMap();
+        }
+        if (mapParams != null) {
+            ctx.paramEdgeTypeNames = stringArray(mapParams.get(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES));
+            ctx.paramVertexAxisNames = stringArray(mapParams.get(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES));
+            if(mapParams.get(OSQLFunctionAstar.PARAM_DIRECTION) != null){
+                if (mapParams.get(OSQLFunctionAstar.PARAM_DIRECTION) instanceof  String){
+                    ctx.paramDirection = Direction.valueOf(stringOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_DIRECTION), "OUT").toUpperCase());
+                }
+                else{
+                    ctx.paramDirection = (Direction) mapParams.get(OSQLFunctionAstar.PARAM_DIRECTION);
+                }
+            }
+
+
+            ctx.paramParallel = booleanOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_PARALLEL), false);
+            ctx.paramMaxDepth = longOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_MAX_DEPTH), ctx.paramMaxDepth);
+            ctx.paramEmptyIfMaxDepth = booleanOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_EMPTY_IF_MAX_DEPTH), ctx.paramEmptyIfMaxDepth);
+            ctx.paramTieBreaker = booleanOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_TIE_BREAKER), ctx.paramTieBreaker);
+            ctx.paramDFactor = doubleOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_D_FACTOR), ctx.paramDFactor);
+            if(mapParams.get(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA) !=null){
+                if (mapParams.get(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA) instanceof  String){
+                    ctx.paramHeuristicFormula = HeuristicFormula.valueOf(stringOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA), "MANHATAN").toUpperCase());
+                }
+                else{
+                    ctx.paramHeuristicFormula = (HeuristicFormula)mapParams.get(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA);
+                }
+            }
+
+
+            ctx.paramCustomHeuristicFormula = stringOrDefault(mapParams.get(OSQLFunctionAstar.PARAM_CUSTOM_HEURISTIC_FORMULA), "");
+        }
+    }
+
+
+    public String getSyntax() {
+        return "astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) \n // options  : {direction:\"OUT\",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , tieBreaker:true,maxDepth:99999,dFactor:1.0,customHeuristicFormula:'custom_Function_Name_here'  }";
+    }
+
+    @Override
+    public Object getResult() {
+        return getPath();
+    }
+
+    @Override
+    protected double getDistance(final OrientVertex node, final OrientVertex parent, final OrientVertex target) {
+        final Iterator<Edge> edges = node.getEdges(target, paramDirection).iterator();
+        if (edges.hasNext()) {
+            final Edge e = edges.next();
+            if (e != null) {
+                final Object fieldValue = e.getProperty(paramWeightFieldName);
+                if (fieldValue != null)
+                    if (fieldValue instanceof Float)
+                        return (Float) fieldValue;
+                    else if (fieldValue instanceof Number)
+                        return ((Number) fieldValue).doubleValue();
+            }
+        }
+        return MIN;
+    }
+
+    @Override
+    public boolean aggregateResults() {
+        return false;
+    }
+
+    @Override
+    protected double getHeuristicCost(final OrientVertex node, OrientVertex parent, final OrientVertex target) {
+        double hresult = 0.0;
+
+        if (paramVertexAxisNames.length == 0) {
+            return hresult;
+        } else if (paramVertexAxisNames.length == 1) {
+            double n = doubleOrDefault(node.getProperty(paramVertexAxisNames[0]),0.0) ;
+            double g = doubleOrDefault(target.getProperty(paramVertexAxisNames[0]),0.0);
+            hresult = getSimpleHeuristicCost(n, g, paramDFactor);
+        } else if (paramVertexAxisNames.length == 2) {
+            if (parent == null) parent = node;
+            double sx = doubleOrDefault(paramSourceVertex.getProperty(paramVertexAxisNames[0]),0);
+            double sy = doubleOrDefault(paramSourceVertex.getProperty(paramVertexAxisNames[1]),0);
+            double nx = doubleOrDefault(node.getProperty(paramVertexAxisNames[0]),0);
+            double ny = doubleOrDefault(node.getProperty(paramVertexAxisNames[1]),0);
+            double px = doubleOrDefault(parent.getProperty(paramVertexAxisNames[0]),0);
+            double py = doubleOrDefault(parent.getProperty(paramVertexAxisNames[1]),0);
+            double gx = doubleOrDefault(target.getProperty(paramVertexAxisNames[0]),0);
+            double gy = doubleOrDefault(target.getProperty(paramVertexAxisNames[1]),0);
+
+            switch (paramHeuristicFormula) {
+                case MANHATAN:
+                    hresult = getManhatanHeuristicCost(nx, ny, gx, gy, paramDFactor);
+                    break;
+                case MAXAXIS:
+                    hresult = getMaxAxisHeuristicCost(nx, ny, gx, gy, paramDFactor);
+                    break;
+                case DIAGONAL:
+                    hresult = getDiagonalHeuristicCost(nx, ny, gx, gy, paramDFactor);
+                    break;
+                case EUCLIDEAN:
+                    hresult = getEuclideanHeuristicCost(nx, ny, gx, gy, paramDFactor);
+                    break;
+                case EUCLIDEANNOSQR:
+                    hresult = getEuclideanNoSQRHeuristicCost(nx, ny, gx, gy, paramDFactor);
+                    break;
+                case CUSTOM:
+                    hresult = getCustomHeuristicCost(paramCustomHeuristicFormula,paramVertexAxisNames,paramSourceVertex,paramDestinationVertex, node, parent,currentDepth, paramDFactor);
+                    break;
+            }
+            if (paramTieBreaker) {
+                hresult = getTieBreakingHeuristicCost(px, py, sx, sy, gx, gy, hresult);
+            }
+
+        } else {
+            Map<String,Double> sList = new HashMap<String,Double>();
+            Map<String,Double> cList = new HashMap<String,Double>();
+            Map<String,Double> pList = new HashMap<String,Double>();
+            Map<String,Double> gList = new HashMap<String,Double>();
+            parent = parent == null ? node : parent;
+            for (int i = 0; i < paramVertexAxisNames.length; i++) {
+                Double s = doubleOrDefault(paramSourceVertex.getProperty(paramVertexAxisNames[i]),0);
+                Double c = doubleOrDefault(node.getProperty(paramVertexAxisNames[i]),0);
+                Double g = doubleOrDefault(target.getProperty(paramVertexAxisNames[i]),0);
+                Double p = doubleOrDefault(parent.getProperty(paramVertexAxisNames[i]),0);
+                if (s != null)
+                    sList.put(paramVertexAxisNames[i],s);
+                if (c != null)
+                    cList.put(paramVertexAxisNames[i],s);
+                if (g != null)
+                    gList.put(paramVertexAxisNames[i],g);
+                if (p != null)
+                    pList.put(paramVertexAxisNames[i],p);
+            }
+            switch (paramHeuristicFormula) {
+                case MANHATAN:
+                    hresult = getManhatanHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth,paramDFactor);
+                    break;
+                case MAXAXIS:
+                    hresult = getMaxAxisHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth,paramDFactor);
+                    break;
+                case DIAGONAL:
+                    hresult = getDiagonalHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth,paramDFactor);
+                    break;
+                case EUCLIDEAN:
+                    hresult = getEuclideanHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth,paramDFactor);
+                    break;
+                case EUCLIDEANNOSQR:
+                    hresult = getEuclideanNoSQRHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth,paramDFactor);
+                    break;
+                case CUSTOM:
+                    hresult = getCustomHeuristicCost(paramCustomHeuristicFormula,paramVertexAxisNames,paramSourceVertex,paramDestinationVertex, node, parent,currentDepth, paramDFactor);
+                    break;
+            }
+            if (paramTieBreaker) {
+                hresult = getTieBreakingHeuristicCost(paramVertexAxisNames,sList,cList,pList,gList,currentDepth, hresult);
+            }
+
+
+
+        }
+
+
+        return hresult;
+
+    }
+
+
+    @Override
+    protected boolean isVariableEdgeWeight() {
+        return true;
+    }
+
+
+}

--- a/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionHeuristicPathFinderAbstract.java
+++ b/graphdb/src/main/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionHeuristicPathFinderAbstract.java
@@ -1,0 +1,353 @@
+/*
+  *
+  *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+  *  *
+  *  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  *  you may not use this file except in compliance with the License.
+  *  *  You may obtain a copy of the License at
+  *  *
+  *  *       http://www.apache.org/licenses/LICENSE-2.0
+  *  *
+  *  *  Unless required by applicable law or agreed to in writing, software
+  *  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  *  See the License for the specific language governing permissions and
+  *  *  limitations under the License.
+  *  *
+  *  * For more information: http://www.orientechnologies.com
+  *
+  */
+package com.orientechnologies.orient.graph.sql.functions;
+
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.command.OCommandContext;
+import com.orientechnologies.orient.core.command.OCommandExecutorAbstract;
+import com.orientechnologies.orient.core.command.traverse.OTraverse;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.metadata.function.OFunction;
+import com.orientechnologies.orient.core.metadata.function.OFunctionLibrary;
+import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientVertex;
+
+import java.util.*;
+
+
+/**
+ * Abstract class to find paths between nodes using heuristic .
+ * @author Saeed Tabrizi (saeed a_t  nowcando.com)
+ */
+public abstract class OSQLFunctionHeuristicPathFinderAbstract extends OSQLFunctionMathAbstract {
+    public static final String PARAM_DIRECTION = "direction";
+    public static final String PARAM_EDGE_TYPE_NAMES = "edgeTypeNames";
+    public static final String PARAM_VERTEX_AXIS_NAMES = "vertexAxisNames";
+    public static final String PARAM_PARALLEL = "parallel";
+    public static final String PARAM_MAX_DEPTH = "maxDepth";
+    public static final String PARAM_HEURISTIC_FORMULA = "heuristicFormula";
+    public static final String PARAM_CUSTOM_HEURISTIC_FORMULA = "customHeuristicFormula";
+    public static final String PARAM_D_FACTOR = "dFactor";
+    public static final String PARAM_TIE_BREAKER = "tieBreaker";
+    public static final String PARAM_EMPTY_IF_MAX_DEPTH = "emptyIfMaxDepth";
+    protected OrientBaseGraph db;
+    protected static Random rnd = new Random();
+
+    protected Boolean paramParallel = false;
+    protected Boolean paramTieBreaker = true;
+    protected Boolean paramEmptyIfMaxDepth = false;
+    protected String[] paramEdgeTypeNames = new String[]{};
+    protected String[] paramVertexAxisNames = new String[]{};
+    protected OrientVertex paramSourceVertex;
+    protected OrientVertex paramDestinationVertex;
+    protected HeuristicFormula paramHeuristicFormula = HeuristicFormula.MANHATAN;
+    protected Direction paramDirection = Direction.OUT;
+    protected long paramMaxDepth = Long.MAX_VALUE;
+    protected double paramDFactor = 1.0;
+    protected String paramCustomHeuristicFormula = "";
+
+    protected OCommandContext context;
+    protected List<OrientVertex> route = new LinkedList<OrientVertex>();
+    protected static final float MIN = 0f;
+
+    public OSQLFunctionHeuristicPathFinderAbstract(final String iName, final int iMinParams, final int iMaxParams) {
+        super(iName, iMinParams, iMaxParams);
+    }
+
+    // Approx Great-circle distance.  Args in degrees, result in kilometers
+    // obtains from https://github.com/enderceylan/CS-314--Data-Structures/blob/master/HW10-Graph.java
+    public double gcdist(double lata, double longa, double latb, double longb) {
+        double midlat, psi, dist;
+        midlat = 0.5 * (lata + latb);
+        psi = 0.0174532925
+                * Math.sqrt(Math.pow(lata - latb, 2)
+                + Math.pow((longa - longb)
+                * Math.cos(0.0174532925 * midlat), 2));
+        dist = 6372.640112 * psi;
+        return dist;
+    }
+
+    protected boolean isVariableEdgeWeight() {
+        return false;
+    }
+
+    protected abstract double getDistance(final OrientVertex node, final OrientVertex parent, final OrientVertex target);
+
+    protected abstract double getHeuristicCost(final OrientVertex node, final OrientVertex parent, final OrientVertex target);
+
+    protected LinkedList<OrientVertex> getPath() {
+        final LinkedList<OrientVertex> path = new LinkedList<OrientVertex>(route);
+        return path;
+    }
+
+    protected Set<OrientVertex> getNeighbors(final OrientVertex node) {
+        context.incrementVariable("getNeighbors");
+
+        final Set<OrientVertex> neighbors = new HashSet<OrientVertex>();
+        if (node != null) {
+            for (Vertex v : node.getVertices(paramDirection, paramEdgeTypeNames)) {
+                final OrientVertex ov = (OrientVertex) v;
+                if (ov != null)
+                    neighbors.add(ov);
+            }
+        }
+        return neighbors;
+    }
+
+
+    // obtains from http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+    protected double getSimpleHeuristicCost(double x, double g, double dFactor) {
+        double dx = Math.abs(x - g);
+        return dFactor * (dx);
+    }
+
+    // obtains from http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+    protected double getManhatanHeuristicCost(double x, double y, double gx, double gy, double dFactor) {
+        double dx = Math.abs(x - gx);
+        double dy = Math.abs(y - gy);
+        return dFactor * (dx + dy);
+    }
+
+    protected double getMaxAxisHeuristicCost(double x, double y, double gx, double gy, double dFactor) {
+        double dx = Math.abs(x - gx);
+        double dy = Math.abs(y - gy);
+        return dFactor * Math.max(dx, dy);
+    }
+
+    // obtains from http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+    protected double getDiagonalHeuristicCost(double x, double y, double gx, double gy, double dFactor) {
+        double dx = Math.abs(x - gx);
+        double dy = Math.abs(y - gy);
+        double h_diagonal = Math.min(dx, dy);
+        double h_straight = dx + dy;
+        return (dFactor * 2) * h_diagonal + dFactor * (h_straight - 2 * h_diagonal);
+    }
+
+    // obtains from http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+    protected double getEuclideanHeuristicCost(double x, double y, double gx, double gy, double dFactor) {
+        double dx = Math.abs(x - gx);
+        double dy = Math.abs(y - gy);
+
+        return (dFactor * Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2)));
+    }
+
+    protected double getEuclideanNoSQRHeuristicCost(double x, double y, double gx, double gy, double dFactor) {
+        double dx = Math.abs(x - gx);
+        double dy = Math.abs(y - gy);
+
+        return (dFactor * (Math.pow(dx, 2) + Math.pow(dy, 2)));
+    }
+
+    protected double getCustomHeuristicCost(final String functionName, final String[] vertextAxisNames, final OrientVertex start, final OrientVertex goal, final OrientVertex current, final OrientVertex parent, final long depth, double dFactor) {
+
+        double heuristic = 0.0;
+        OrientGraph ff;
+
+        OFunction func = OrientGraph.getActiveGraph().getRawGraph().getMetadata().getFunctionLibrary().getFunction(functionName);
+        Object fValue = func.executeInContext(context, vertextAxisNames, start, goal, current, parent, depth, dFactor);
+        if (fValue != null && fValue instanceof Number) {
+            heuristic = doubleOrDefault(fValue, heuristic);
+        }
+        return heuristic;
+    }
+
+    // obtains from http://theory.stanford.edu/~amitp/GameProgramming/Heuristics.html
+    protected double getTieBreakingHeuristicCost(double x, double y, double sx, double sy, double gx, double gy, double heuristic) {
+        double dx1 = x - gx;
+        double dy1 = y - gy;
+        double dx2 = sx - gx;
+        double dy2 = sy - gy;
+        double cross = Math.abs(dx1 * dy2 - dx2 * dy1);
+        heuristic += (cross * 0.0001);
+        return heuristic;
+    }
+
+    protected double getTieBreakingRandomHeuristicCost(double x, double y, double sx, double sy, double gx, double gy, double heuristic) {
+        double dx1 = x - gx;
+        double dy1 = y - gy;
+        double dx2 = sx - gx;
+        double dy2 = sy - gy;
+        double cross = Math.abs(dx1 * dy2 - dx2 * dy1) + rnd.nextFloat();
+        heuristic += (cross * heuristic);
+        return heuristic;
+    }
+
+    protected double getManhatanHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                              final Map<String, Double> plist, final Map<String, Double> glist, long depth, double dFactor) {
+        Double heuristic = 0.0;
+        double res = 0.0;
+        for (String str : axisNames) {
+            res += Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0));
+        }
+        heuristic = dFactor * res;
+        return heuristic;
+    }
+
+    protected double getMaxAxisHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                             final Map<String, Double> plist, final Map<String, Double> glist, long depth, double dFactor) {
+        Double heuristic = 0.0;
+        double res = 0.0;
+        for (String str : axisNames) {
+            res = Math.max(Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0)), res);
+        }
+        heuristic = dFactor * res;
+        return heuristic;
+    }
+
+    protected double getDiagonalHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                              final Map<String, Double> plist, final Map<String, Double> glist, long depth, double dFactor) {
+
+        Double heuristic = 0.0;
+        double h_diagonal = 0.0;
+        double h_straight = 0.0;
+        for (String str : axisNames) {
+            h_diagonal = Math.min(Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0)), h_diagonal);
+            h_straight += Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0));
+        }
+        heuristic = (dFactor * 2) * h_diagonal + dFactor * (h_straight - 2 * h_diagonal);
+        return heuristic;
+    }
+
+    protected double getEuclideanHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                               final Map<String, Double> plist, final Map<String, Double> glist, long depth, double dFactor) {
+        Double heuristic = 0.0;
+        double res = 0.0;
+        for (String str : axisNames) {
+            res += Math.pow(Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0)), 2);
+        }
+        heuristic = Math.sqrt(res);
+        return heuristic;
+    }
+
+    protected double getEuclideanNoSQRHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                                    final Map<String, Double> plist, final Map<String, Double> glist, long depth, double dFactor) {
+        Double heuristic = 0.0;
+        double res = 0.0;
+        for (String str : axisNames) {
+            res += Math.pow(Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0)), 2);
+        }
+        heuristic = dFactor * res;
+        return heuristic;
+    }
+
+    protected double getTieBreakingHeuristicCost(final String[] axisNames, final Map<String, Double> slist, final Map<String, Double> clist,
+                                                 final Map<String, Double> plist, final Map<String, Double> glist, long depth, double heuristic) {
+
+        double res = 0.0;
+        for (String str : axisNames) {
+            res += Math.abs((clist.get(str) != null ? clist.get(str) : 0.0) - (glist.get(str) != null ? glist.get(str) : 0.0));
+        }
+        double cross = res;
+        heuristic += (cross * 0.0001);
+        return heuristic;
+    }
+
+    protected String[] stringArray(Object fromObject) {
+        if (fromObject == null) {
+            return new String[]{};
+        }
+        if (fromObject instanceof String) {
+            String[] arr = fromObject.toString().replace("},{", " ,").split(",");
+            return (arr);
+        }
+        if (fromObject instanceof Object) {
+            return ((String[]) fromObject);
+        }
+
+        return new String[]{};
+    }
+
+    protected Boolean booleanOrDefault(Object fromObject, boolean defaultValue) {
+        if (fromObject == null) {
+            return defaultValue;
+        }
+        if (fromObject instanceof Boolean) {
+            return (Boolean) fromObject;
+        }
+        if (fromObject instanceof String) {
+            try {
+                return Boolean.parseBoolean((String) fromObject);
+            } catch (Exception e) {
+            }
+        }
+        return defaultValue;
+    }
+
+    protected String stringOrDefault(Object fromObject, String defaultValue) {
+        if (fromObject == null) {
+            return defaultValue;
+        }
+        return (String) fromObject;
+    }
+
+    protected Integer integerOrDefault(Object fromObject, int defaultValue) {
+        if (fromObject == null) {
+            return defaultValue;
+        }
+        if (fromObject instanceof Number) {
+            return ((Number) fromObject).intValue();
+        }
+        if (fromObject instanceof String) {
+            try {
+                return Integer.parseInt((String) fromObject);
+            } catch (Exception e) {
+            }
+        }
+        return defaultValue;
+    }
+
+    protected Long longOrDefault(Object fromObject, long defaultValue) {
+        if (fromObject == null) {
+            return defaultValue;
+        }
+        if (fromObject instanceof Number) {
+            return ((Number) fromObject).longValue();
+        }
+        if (fromObject instanceof String) {
+            try {
+                return Long.parseLong((String) fromObject);
+            } catch (Exception e) {
+            }
+        }
+        return defaultValue;
+    }
+
+    protected Double doubleOrDefault(Object fromObject, double defaultValue) {
+        if (fromObject == null) {
+            return defaultValue;
+        }
+        if (fromObject instanceof Number) {
+            return ((Number) fromObject).doubleValue();
+        }
+        if (fromObject instanceof String) {
+            try {
+                return Double.parseDouble((String) fromObject);
+            } catch (Exception e) {
+            }
+        }
+        return defaultValue;
+    }
+
+
+}

--- a/graphdb/src/test/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionAstarTest.java
+++ b/graphdb/src/test/java/com/orientechnologies/orient/graph/sql/functions/OSQLFunctionAstarTest.java
@@ -1,0 +1,402 @@
+/*
+  *
+  *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+  *  *
+  *  *  Licensed under the Apache License, Version 2.0 (the "License");
+  *  *  you may not use this file except in compliance with the License.
+  *  *  You may obtain a copy of the License at
+  *  *
+  *  *       http://www.apache.org/licenses/LICENSE-2.0
+  *  *
+  *  *  Unless required by applicable law or agreed to in writing, software
+  *  *  distributed under the License is distributed on an "AS IS" BASIS,
+  *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *  *  See the License for the specific language governing permissions and
+  *  *  limitations under the License.
+  *  *
+  *  * For more information: http://www.orientechnologies.com
+  *
+  */
+package com.orientechnologies.orient.graph.sql.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.orientechnologies.orient.core.metadata.function.OFunction;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.server.distributed.ODistributedServerLog;
+import com.tinkerpop.blueprints.Direction;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.orientechnologies.orient.core.command.OBasicCommandContext;
+import com.tinkerpop.blueprints.Edge;
+
+import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.impls.orient.OrientGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientVertex;
+/*
+* @author Saeed Tabrizi (saeed a_t  nowcando.com)
+ */
+public class OSQLFunctionAstarTest {
+    private static int dbCounter =0;
+    private OrientGraph          graph;
+    private Vertex               v0;
+    private Vertex               v1;
+    private Vertex               v2;
+    private Vertex               v3;
+    private Vertex               v4;
+    private Vertex               v5;
+    private Vertex               v6;
+    private OSQLFunctionAstar functionAstar;
+
+    @Before
+    public void setUp() throws Exception {
+
+        setUpDatabase();
+
+        functionAstar = new OSQLFunctionAstar();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        graph.shutdown();
+    }
+
+    private void setUpDatabase() {
+        dbCounter++;
+        graph = new OrientGraph("memory:OSQLFunctionAstarTest" + dbCounter);
+        graph.createEdgeType("has_path");
+        OFunction cf = graph.getRawGraph().getMetadata().getFunctionLibrary().createFunction("myCustomHeuristic");
+        cf.setCode("return 1;");
+
+        v0 = graph.addVertex(null);
+        v1 = graph.addVertex(null);
+        v2 = graph.addVertex(null);
+        v3 = graph.addVertex(null);
+        v4 = graph.addVertex(null);
+        v5 = graph.addVertex(null);
+        v6 = graph.addVertex(null);
+
+        v0.setProperty("node_id", "Z"); // Tabriz
+        v0.setProperty("name", "Tabriz");
+        v0.setProperty("lat", 31.746512f);
+        v0.setProperty("lon", 51.427002f);
+        v0.setProperty("alt", 2200);
+
+        v1.setProperty("node_id", "A"); // Tehran
+        v1.setProperty("name", "Tehran");
+        v1.setProperty("lat", 35.746512f);
+        v1.setProperty("lon", 51.427002f);
+        v1.setProperty("alt", 1800);
+
+        v2.setProperty("node_id", "B"); // Mecca
+        v2.setProperty("name", "Mecca");
+        v2.setProperty("lat", 21.371244f);
+        v2.setProperty("lon", 39.847412f);
+        v2.setProperty("alt", 1500);
+
+
+        v3.setProperty("node_id", "C"); // Bejin
+        v3.setProperty("name", "Bejin");
+        v3.setProperty("lat", 39.904041f);
+        v3.setProperty("lon", 116.408011f);
+        v3.setProperty("alt", 1200);
+
+        v4.setProperty("node_id", "D"); // London
+        v4.setProperty("name", "London");
+        v4.setProperty("lat", 51.495065f);
+        v4.setProperty("lon", -0.120850f);
+        v4.setProperty("alt", 900);
+
+        v5.setProperty("node_id", "E"); // NewYork
+        v5.setProperty("name", "NewYork");
+        v5.setProperty("lat", 42.779275f);
+        v5.setProperty("lon", -74.641113f);
+        v5.setProperty("alt", 1700);
+
+        v6.setProperty("node_id", "F"); // Los Angles
+        v6.setProperty("name", "Los Angles");
+        v6.setProperty("lat", 34.052234f);
+        v6.setProperty("lon", -118.243685f);
+        v6.setProperty("alt", 400);
+
+        Edge e1 = graph.addEdge(null, v1, v2, "has_path");
+        e1.setProperty("weight", 250.0f);
+        e1.setProperty("ptype", "road");
+        Edge e2 = graph.addEdge(null, v2, v3, "has_path");
+        e2.setProperty("weight", 250.0f);
+        e2.setProperty("ptype", "road");
+        Edge e3 = graph.addEdge(null, v1, v3, "has_path");
+        e3.setProperty("weight", 1000.0f);
+        e3.setProperty("ptype", "road");
+        Edge e4 = graph.addEdge(null, v3, v4, "has_path");
+        e4.setProperty("weight", 250.0f);
+        e4.setProperty("ptype", "road");
+        Edge e5 = graph.addEdge(null, v2, v4, "has_path");
+        e5.setProperty("weight", 600.0f);
+        e5.setProperty("ptype", "road");
+        Edge e6 = graph.addEdge(null, v4, v5, "has_path");
+        e6.setProperty("weight", 400.0f);
+        e6.setProperty("ptype", "road");
+        Edge e7 = graph.addEdge(null, v5, v6, "has_path");
+        e7.setProperty("weight", 300.0f);
+        e7.setProperty("ptype", "road");
+        Edge e8 = graph.addEdge(null, v3, v6, "has_path");
+        e8.setProperty("weight", 200.0f);
+        e8.setProperty("ptype", "road");
+        Edge e9 = graph.addEdge(null, v4, v6, "has_path");
+        e9.setProperty("weight", 900.0f);
+        e9.setProperty("ptype", "road");
+        Edge e10 = graph.addEdge(null, v2, v6, "has_path");
+        e10.setProperty("weight", 2500.0f);
+        e10.setProperty("ptype", "road");
+        Edge e11 = graph.addEdge(null, v1, v5, "has_path");
+        e11.setProperty("weight", 100.0f);
+        e11.setProperty("ptype", "road");
+        Edge e12 = graph.addEdge(null, v4, v1, "has_path");
+        e12.setProperty("weight", 200.0f);
+        e12.setProperty("ptype", "road");
+        Edge e13 = graph.addEdge(null, v5, v3, "has_path");
+        e13.setProperty("weight", 800.0f);
+        e13.setProperty("ptype", "road");
+        Edge e14 = graph.addEdge(null, v5, v2, "has_path");
+        e14.setProperty("weight", 500.0f);
+        e14.setProperty("ptype", "road");
+        Edge e15 = graph.addEdge(null, v6, v5, "has_path");
+        e15.setProperty("weight", 250.0f);
+        e15.setProperty("ptype", "road");
+        Edge e16 = graph.addEdge(null, v3, v1, "has_path");
+        e16.setProperty("weight", 550.0f);
+        e16.setProperty("ptype", "road");
+        graph.commit();
+    }
+
+    @Test
+    public void test1Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v4,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(4, result.size());
+        assertEquals(v1, result.get(0));
+        assertEquals(v2, result.get(1));
+        assertEquals(v3, result.get(2));
+        assertEquals(v4, result.get(3));
+    }
+
+    @Test
+    public void test2Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(3, result.size());
+        assertEquals(v1, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v6, result.get(2));
+
+    }
+    @Test
+    public void test3Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(3, result.size());
+        assertEquals(v1, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v6, result.get(2));
+
+    }
+
+    @Test
+    public void test4Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon","alt"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(3, result.size());
+        assertEquals(v1, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v6, result.get(2));
+
+    }
+
+    @Test
+    public void test5Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v3, v5,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(3, result.size());
+        assertEquals(v3, result.get(0));
+        assertEquals(v6, result.get(1));
+        assertEquals(v5, result.get(2));
+
+    }
+
+    @Test
+    public void test6Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(6, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v2, result.get(2));
+        assertEquals(v3, result.get(3));
+        assertEquals(v4, result.get(4));
+        assertEquals(v1, result.get(5));
+    }
+
+    @Test
+    public void test7Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, "out");
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, "EucliDEAN");
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(6, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v2, result.get(2));
+        assertEquals(v3, result.get(3));
+        assertEquals(v4, result.get(4));
+        assertEquals(v1, result.get(5));
+    }
+
+    @Test
+    public void test8Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, Direction.OUT);
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_TIE_BREAKER, false);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, HeuristicFormula.EUCLIDEANNOSQR);
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(5, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v2, result.get(2));
+        assertEquals(v4, result.get(3));
+        assertEquals(v1, result.get(4));
+    }
+
+    @Test
+    public void test9Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, Direction.BOTH);
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_TIE_BREAKER, false);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, HeuristicFormula.MAXAXIS);
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(3, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v1, result.get(2));
+    }
+
+    @Test
+    public void test10Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, Direction.OUT);
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_TIE_BREAKER, false);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, HeuristicFormula.CUSTOM);
+        options.put(OSQLFunctionAstar.PARAM_CUSTOM_HEURISTIC_FORMULA, "myCustomHeuristic");
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(6, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v2, result.get(2));
+        assertEquals(v3, result.get(3));
+        assertEquals(v4, result.get(4));
+        assertEquals(v1, result.get(5));
+    }
+
+    @Test
+    public void test11Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, Direction.OUT);
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_TIE_BREAKER, false);
+        options.put(OSQLFunctionAstar.PARAM_EMPTY_IF_MAX_DEPTH, true);
+        options.put(OSQLFunctionAstar.PARAM_MAX_DEPTH, 3);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, HeuristicFormula.CUSTOM);
+        options.put(OSQLFunctionAstar.PARAM_CUSTOM_HEURISTIC_FORMULA, "myCustomHeuristic");
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(0, result.size());
+
+    }
+
+    @Test
+    public void test12Execute() throws Exception {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put(OSQLFunctionAstar.PARAM_DIRECTION, Direction.OUT);
+        options.put(OSQLFunctionAstar.PARAM_PARALLEL, true);
+        options.put(OSQLFunctionAstar.PARAM_TIE_BREAKER, false);
+        options.put(OSQLFunctionAstar.PARAM_EMPTY_IF_MAX_DEPTH, false);
+        options.put(OSQLFunctionAstar.PARAM_MAX_DEPTH, 3);
+        options.put(OSQLFunctionAstar.PARAM_EDGE_TYPE_NAMES, new String[]{"has_path"});
+        options.put(OSQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES, new String[]{"lat","lon"});
+        options.put(OSQLFunctionAstar.PARAM_HEURISTIC_FORMULA, HeuristicFormula.CUSTOM);
+        options.put(OSQLFunctionAstar.PARAM_CUSTOM_HEURISTIC_FORMULA, "myCustomHeuristic");
+        final List<OrientVertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1,"'weight'",options },
+                new OBasicCommandContext());
+        assertEquals(16, graph.countEdges("has_path"));
+        assertEquals(4, result.size());
+        assertEquals(v6, result.get(0));
+        assertEquals(v5, result.get(1));
+        assertEquals(v2, result.get(2));
+        assertEquals(v3, result.get(3));
+
+    }
+
+}


### PR DESCRIPTION
A star path finding function and some test case added to graph sql functions ,
The latest syntax is :
```
astar(<sourceVertex>, <destinationVertex>, <weightEdgeFieldName>, [<options>]) 
 // options  : {direction:"OUT",edgeTypeNames:[] , vertexAxisNames:[] , parallel : false , emptyIfMaxDepth:false,heuristicFormula:'manhatan',tieBreaker:true,maxDepth:99999,dFactor:1.0,customHeuristicFormula:'custom_Function_Name_here'  }
```
**direction** : "out|in|both" , default is out .
**edgeTypeNames** : an array of string to filter edge type name in path finding , default empty array to get all edges .
**vertexAxisNames** : an array of string that contains the  axis fields that computes in heuristic cost . for example ['x','y'] ,default is empty array
**tieBreaker** : true|false , this option may be useful for breaking the ties for improve the path finding result , default is true.
**parallel** : true | false , if set the true this function working on parallel mode to improve the time of process , default is false (not implemented yet) .
**maxDepth** : long value to limit the depth of traversing graph in path finding . default is 99999
**dFactor** : a double , factor that mostly times to heuristic cost value to gain the improve result.
**customHeuristicFormula** : a function name to return a double value for computing the heuristic cost value .
**heuristicFormula** : a heuristic formula name that be , 'manhatan'|'maxaxis'|'diagonal'|'euclid'|'euclidnosqr','custom' , default is manhatan
**emptyIfMaxDepth** : true|false , if set true and reach to maxDepth limit route result sets to empty else the result contains routing to reach limitation .  default is false .

welcome to the idea and comments . :)

Thanks
Saeed 


