### PR TITLE
refactor for improve handling of multiple server sessions

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OServerAdmin.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OServerAdmin.java
@@ -91,6 +91,7 @@ public class OServerAdmin {
     networkAdminOperation(new OStorageRemoteOperation<Void>() {
       @Override
       public Void execute(OChannelBinaryAsynchClient network) throws IOException {
+        OStorageRemoteNodeSession nodeSession = storage.getCurrentSession().getOrCreate(network.getServerURL());
         try {
           storage.beginRequest(network, OChannelBinaryProtocol.REQUEST_CONNECT);
 
@@ -114,13 +115,13 @@ public class OServerAdmin {
         }
 
         try {
-          network.beginResponse(session.sessionId, false);
-          session.sessionId = network.readInt();
+          network.beginResponse(nodeSession.getSessionId(), false);
+          int sessionId = network.readInt();
           byte[] sessionToken = network.readBytes();
           if (sessionToken.length == 0) {
             sessionToken = null;
           }
-          session.tokens.put(network.getServerURL(), sessionToken);
+          nodeSession.setSession(sessionId, sessionToken);
         } finally {
           storage.endResponse(network);
         }
@@ -190,7 +191,7 @@ public class OServerAdmin {
   }
 
   public int getSessionId() {
-    return session.sessionId;
+    return session.getSessionId();
   }
 
   /**

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -151,10 +151,8 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
       try {
         // In case i do not have a token or i'm switching between server i've to execute a open operation.
         OStorageRemoteSession session = getCurrentSession();
-        if (!network.getServerURL().equals(session.serverURL)
-            || session.tokens.get(session.serverURL) == null && session.sessionId > 0) {
-          // TODO: Remove this workaround in favor of a proper per server authentication.
-          setSessionId(network.getServerURL(), session.uniqueClientSessionId, null);
+        OStorageRemoteNodeSession nodeSession = session.get(network.getServerURL());
+        if (nodeSession == null) {
           openRemoteDatabase(network);
           if (!network.tryLock())
             continue;
@@ -175,46 +173,14 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     return false;
   }
 
-  public Set<OChannelBinary> getSessionConnections() {
-    OStorageRemoteSession session = getCurrentSession();
-    return session != null ? session.connections : null;
-  }
-
   public int getSessionId() {
     OStorageRemoteSession session = getCurrentSession();
-    return session != null ? session.sessionId : -1;
+    return session != null ? session.getSessionId() : -1;
   }
 
   public String getServerURL() {
     OStorageRemoteSession session = getCurrentSession();
-    return session != null ? session.serverURL : null;
-  }
-
-  public byte[] getSessionToken() {
-    OStorageRemoteSession session = getCurrentSession();
-    if (session != null)
-      return session.tokens.get(session.serverURL);
-    return null;
-  }
-
-  public void setSessionId(final String iServerURL, final int iSessionId, byte[] token) {
-    final OStorageRemoteSession session = getCurrentSession();
-    if (session != null) {
-      session.serverURL = iServerURL;
-      session.sessionId = iSessionId;
-      session.tokens.put(iServerURL, token);
-      session.clear();
-    }
-  }
-
-  public void pushSessionId(final String iServerURL, final int iSessionId, byte[] token, Set<OChannelBinary> connections) {
-    final OStorageRemoteSession session = getCurrentSession();
-    if (session != null) {
-      session.serverURL = iServerURL;
-      session.sessionId = iSessionId;
-      session.connections = connections;
-      session.tokens.put(iServerURL, token);
-    }
+    return session != null ? session.getServerUrl() : null;
   }
 
   public void open(final String iUserName, final String iUserPassword, final Map<String, Object> iOptions) {
@@ -223,8 +189,8 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     addUser();
     try {
       OStorageRemoteSession session = getCurrentSession();
-      if (status == STATUS.CLOSED || !iUserName.equals(session.connectionUserName)
-          || !iUserPassword.equals(session.connectionUserPassword) || session.tokens.isEmpty()) {
+      if (status == STATUS.CLOSED || !iUserName.equals(session.connectionUserName) || !iUserPassword.equals(session.connectionUserPassword)
+          || session.sessions.isEmpty()) {
 
         OCredentialInterceptor ci = OSecurityManager.instance().newCredentialInterceptor();
 
@@ -329,14 +295,25 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     try {
       if (status == STATUS.CLOSED)
         return;
-      if (getSessionToken() != null && getSessionId() != -1) {
-        network = beginRequest(OChannelBinaryProtocol.REQUEST_DB_CLOSE);
-        try {
-          getCurrentSession().close();
-        } finally {
-          endRequest(network);
-          engine.getConnectionManager().release(network);
+
+      OStorageRemoteSession session = getCurrentSession();
+      Collection<OStorageRemoteNodeSession> nodes = session.getAll();
+      if (!nodes.isEmpty()) {
+        for (OStorageRemoteNodeSession nodeSession : nodes) {
+          try {
+            network = getAvailableNetwork(nodeSession.getServerURL());
+            network.beginRequest(OChannelBinaryProtocol.REQUEST_DB_CLOSE, session);
+            endRequest(network);
+            engine.getConnectionManager().release(network);
+          } catch (OIOException ex) {
+            //IGNORING IF THE SERVER IS DOWN OR NOT REACHABLE THE SESSION IS AUTOMATICALLY CLOSED.
+            OLogManager.instance().debug(this, "Impossible to comunicate to the server for close: %s", ex);
+          } catch (IOException ex) {
+            //IGNORING IF THE SERVER IS DOWN OR NOT REACHABLE THE SESSION IS AUTOMATICALLY CLOSED.
+            OLogManager.instance().debug(this, "Impossible to comunicate to the server for close: %s", ex);
+          }
         }
+        session.close();
         if (!checkForClose(iForce))
           return;
       } else {
@@ -1741,10 +1718,9 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
               "Retrying to connect to remote server #" + (retry + 1) + "/" + currentMaxRetry + "...");
 
         // FORCE RESET OF THREAD DATA (SERVER URL + SESSION ID)
-        setSessionId(null, -1, null);
         if (tokenException) {
           OStorageRemoteSession session = getCurrentSession();
-          session.tokens.remove(iNetwork.getServerURL());
+          session.remove(iNetwork.getServerURL());
         }
         // REACQUIRE DB SESSION ID
         final String currentURL = reopenRemoteDatabase();
@@ -1773,15 +1749,15 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
         final OChannelBinaryAsynchClient network = getAvailableNetwork(currentURL);
         try {
           OStorageRemoteSession session = getCurrentSession();
-          final byte[] curToken = session.tokens.get(network.getServerURL());
-          if (curToken == null || curToken.length == 0) {
+          OStorageRemoteNodeSession nodeSession = session.getOrCreate(network.getServerURL());
+          if (nodeSession == null ) {
             openRemoteDatabase(network);
             return network.getServerURL();
           } else {
             try {
               network.writeByte(OChannelBinaryProtocol.REQUEST_DB_REOPEN);
-              network.writeInt(getSessionId());
-              network.writeBytes(curToken);
+              network.writeInt(nodeSession.getSessionId());
+              network.writeBytes(nodeSession.getToken());
             } finally {
               endRequest(network);
             }
@@ -1789,12 +1765,12 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
             final int sessionId;
 
             try {
-              byte[] newToken = network.beginResponse(getSessionId(), true);
+              byte[] newToken = network.beginResponse(nodeSession.getSessionId(), true);
               sessionId = network.readInt();
               if (newToken != null && newToken.length > 0) {
-                setSessionId(currentURL, sessionId, newToken);
+                nodeSession.setSession(sessionId,newToken);
               } else {
-                setSessionId(currentURL, sessionId, curToken);
+                nodeSession.setSession(sessionId,nodeSession.getToken());
               }
               OLogManager.instance().debug(this, "Client connected to %s with session id=%d", network.getServerURL(), sessionId);
               return currentURL;
@@ -1819,7 +1795,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
         } catch (OSecurityException ex) {
           OLogManager.instance().debug(this, "Invalidate token for url=%s", ex, currentURL);
           OStorageRemoteSession session = getCurrentSession();
-          session.tokens.remove(currentURL);
+          session.remove(currentURL);
 
           if (network != null) {
             // REMOVE THE NETWORK CONNECTION IF ANY
@@ -1868,14 +1844,15 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
   public void openRemoteDatabase(OChannelBinaryAsynchClient network) throws IOException {
     stateLock.acquireWriteLock();
     try {
-
+      OStorageRemoteSession session = getCurrentSession();
+      OStorageRemoteNodeSession nodeSession = session.getOrCreate(network.getServerURL());
       try {
         network.writeByte(OChannelBinaryProtocol.REQUEST_DB_OPEN);
-        network.writeInt(getSessionId());
+        network.writeInt(nodeSession.getSessionId());
 
         // @SINCE 1.0rc8
         sendClientInfo(network, DRIVER_NAME, true, true);
-        OStorageRemoteSession session = getCurrentSession();
+
         network.writeString(name);
         network.writeString(session.connectionUserName);
         network.writeString(session.connectionUserPassword);
@@ -1887,13 +1864,14 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
       final int sessionId;
 
       try {
-        network.beginResponse(getSessionId(), false);
+        network.beginResponse(nodeSession.getSessionId(), false);
         sessionId = network.readInt();
         byte[] token = network.readBytes();
         if (token.length == 0) {
           token = null;
         }
-        setSessionId(network.getServerURL(), sessionId, token);
+
+        nodeSession.setSession(sessionId, token);
 
         OLogManager.instance().debug(this, "Client connected to %s with session id=%d", network.getServerURL(), sessionId);
 
@@ -2104,6 +2082,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     return DEFAULT_SSL_PORT;
   }
 
+
   /**
    * Acquire a network channel from the pool. Don't lock the write stream since the connection usage is exclusive.
    *
@@ -2112,13 +2091,9 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
    * @return connection to server
    * @throws IOException
    */
-  protected OChannelBinaryAsynchClient beginRequest(final byte iCommand) throws IOException {
-    return beginRequest(getAvailableNetwork(getNextAvailableServerURL(false)), iCommand);
-  }
-
   public OChannelBinaryAsynchClient beginRequest(final OChannelBinaryAsynchClient network, final byte iCommand) throws IOException {
     OStorageRemoteSession session = getCurrentSession();
-    network.beginRequest(iCommand, session, session.tokens.get(network.getServerURL()));
+    network.beginRequest(iCommand, session);
     return network;
   }
 
@@ -2235,9 +2210,10 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
   }
 
   private void beginResponse(OChannelBinaryAsynchClient iNetwork, OStorageRemoteSession session) throws IOException {
-    byte[] newToken = iNetwork.beginResponse(session.sessionId, true);
+    OStorageRemoteNodeSession nodeSession = session.get(iNetwork.getServerURL());
+    byte[] newToken = iNetwork.beginResponse(nodeSession.getSessionId(), true);
     if (newToken != null && newToken.length > 0) {
-      session.tokens.put(iNetwork.getServerURL(), newToken);
+      nodeSession.setSession(nodeSession.getSessionId(),newToken);
     }
   }
 
@@ -2448,7 +2424,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     OStorageRemoteSession session = getCurrentSession();
     if (session == null)
       return false;
-    return session.sessionId < 0;
+    return session.getAll().isEmpty();
   }
 
   @Override
@@ -2459,7 +2435,6 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     if (session != null) {
       // TODO:may run a session reopen
       OStorageRemoteSession newSession = new OStorageRemoteSession(sessionSerialId.decrementAndGet());
-      newSession.tokens.putAll(session.tokens);
       newSession.connectionUserName = session.connectionUserName;
       newSession.connectionUserPassword = session.connectionUserPassword;
       ODatabaseDocumentTxInternal.setSessionMetadata(dest, newSession);

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemoteNodeSession.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemoteNodeSession.java
@@ -1,0 +1,32 @@
+package com.orientechnologies.orient.client.remote;
+
+/**
+ * Created by tglman on 12/04/16.
+ */
+public class OStorageRemoteNodeSession {
+  private final String serverURL;
+  private Integer sessionId = -1;
+  private byte[]  token     = null;
+
+  public OStorageRemoteNodeSession(String serverURL, Integer uniqueClientSessionId) {
+    this.serverURL = serverURL;
+    this.sessionId = uniqueClientSessionId;
+  }
+
+  public String getServerURL() {
+    return serverURL;
+  }
+
+  public Integer getSessionId() {
+    return sessionId;
+  }
+
+  public byte[] getToken() {
+    return token;
+  }
+
+  public void setSession(Integer sessionId, byte[] token) {
+    this.sessionId = sessionId;
+    this.token = token;
+  }
+}

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemoteSession.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemoteSession.java
@@ -3,33 +3,40 @@ package com.orientechnologies.orient.client.remote;
 import com.orientechnologies.orient.core.db.ODatabaseSessionMetadata;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinary;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Created by tglman on 31/03/16.
  */
 public class OStorageRemoteSession implements ODatabaseSessionMetadata {
-  public boolean             commandExecuting       = false;
-  public Integer             sessionId              = -1;
-  public String              serverURL              = null;
-  public int                 serverURLIndex         = -1;
-  public Map<String, byte[]> tokens                 = new HashMap<String, byte[]>();
-  public Set<OChannelBinary> connections            = new HashSet<OChannelBinary>();
-  public String              connectionUserName     = null;
-  public String              connectionUserPassword = null;
+  public boolean                                commandExecuting       = false;
+  public int                                    serverURLIndex         = -1;
+  public Set<OChannelBinary>                    connections            = new HashSet<OChannelBinary>();
+  public String                                 connectionUserName     = null;
+  public String                                 connectionUserPassword = null;
+  public Map<String, OStorageRemoteNodeSession> sessions               = new HashMap<String, OStorageRemoteNodeSession>();
 
   public final Integer uniqueClientSessionId;
 
   public OStorageRemoteSession(int sessionId) {
-    this.sessionId = sessionId;
     this.uniqueClientSessionId = sessionId;
   }
 
   public boolean has(final OChannelBinary connection) {
     return connections.contains(connection);
+  }
+
+  public OStorageRemoteNodeSession get(String serverURL) {
+    return sessions.get(serverURL);
+  }
+
+  public OStorageRemoteNodeSession getOrCreate(String serverURL) {
+    OStorageRemoteNodeSession session = sessions.get(serverURL);
+    if (session == null) {
+      session = new OStorageRemoteNodeSession(serverURL, uniqueClientSessionId);
+      sessions.put(serverURL, session);
+    }
+    return session;
   }
 
   public void add(final OChannelBinary connection) {
@@ -42,10 +49,30 @@ public class OStorageRemoteSession implements ODatabaseSessionMetadata {
 
   public void close() {
     commandExecuting = false;
-    sessionId = uniqueClientSessionId;
-    serverURL = null;
     serverURLIndex = -1;
-    tokens = new HashMap<String, byte[]>();
     connections = new HashSet<OChannelBinary>();
+    sessions = new HashMap<String, OStorageRemoteNodeSession>();
+  }
+
+  public Integer getSessionId() {
+    if (sessions.isEmpty())
+      return -1;
+    OStorageRemoteNodeSession curSession = sessions.values().iterator().next();
+    return curSession.getSessionId();
+  }
+
+  public String getServerUrl() {
+    if (sessions.isEmpty())
+      return null;
+    OStorageRemoteNodeSession curSession = sessions.values().iterator().next();
+    return curSession.getServerURL();
+  }
+
+  public void remove(String serverURL) {
+    sessions.remove(serverURL);
+  }
+
+  public Collection<OStorageRemoteNodeSession> getAll() {
+    return sessions.values();
   }
 }

--- a/client/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryAsynchClient.java
+++ b/client/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryAsynchClient.java
@@ -26,6 +26,7 @@ import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.exception.OSystemException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.util.OPair;
+import com.orientechnologies.orient.client.remote.OStorageRemoteNodeSession;
 import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
 import com.orientechnologies.orient.core.config.OContextConfiguration;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
@@ -451,13 +452,14 @@ public class OChannelBinaryAsynchClient extends OChannelBinary {
               + (throwable != null ? throwable.getClass().getName() : "null"));
   }
 
-  public void beginRequest(byte iCommand, OStorageRemoteSession session, byte[] token)
+  public void beginRequest(byte iCommand, OStorageRemoteSession session)
       throws IOException {
+    OStorageRemoteNodeSession nodeSession = session.get(getServerURL());
     writeByte(iCommand);
-    writeInt(session.sessionId);
-    if (token != null) {
+    writeInt(nodeSession.getSessionId());
+    if (nodeSession.getToken() != null) {
       if (!session.has(this)) {
-        writeBytes(token);
+        writeBytes(nodeSession.getToken());
         session.add(this);
       } else
         writeBytes(new byte[] {});

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/OSBTreeCollectionManagerRemoteTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/OSBTreeCollectionManagerRemoteTest.java
@@ -51,7 +51,7 @@ public class OSBTreeCollectionManagerRemoteTest {
 
     when(dbMock.getStorage()).thenReturn(storageMock);
     when(storageMock.getUnderlying()).thenReturn(storageMock);
-    when(storageMock.beginRequest(eq(OChannelBinaryProtocol.REQUEST_CREATE_SBTREE_BONSAI))).thenReturn(clientMock);
+    when(storageMock.beginRequest(Mockito.any(OChannelBinaryAsynchClient.class), eq(OChannelBinaryProtocol.REQUEST_CREATE_SBTREE_BONSAI))).thenReturn(clientMock);
     when(networkSerializerMock.readCollectionPointer(Mockito.<OChannelBinaryAsynchClient> any())).thenReturn(
         new OBonsaiCollectionPointer(EXPECTED_FILE_ID, EXPECTED_ROOT_POINTER));
 
@@ -65,7 +65,7 @@ public class OSBTreeCollectionManagerRemoteTest {
     verifyNoMoreInteractions(dbMock);
 
     verify(storageMock).getUnderlying();
-    verify(storageMock).beginRequest(eq(OChannelBinaryProtocol.REQUEST_CREATE_SBTREE_BONSAI));
+    verify(storageMock).beginRequest(Mockito.any(OChannelBinaryAsynchClient.class),eq(OChannelBinaryProtocol.REQUEST_CREATE_SBTREE_BONSAI));
     verify(clientMock).writeInt(eq(EXPECTED_CLUSTER_ID));
     verify(storageMock).endRequest(Matchers.same(clientMock));
     verify(storageMock).beginResponse(Matchers.same(clientMock));

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkProtocolBinary.java
@@ -170,10 +170,12 @@ public class ONetworkProtocolBinary extends ONetworkProtocol {
       try {
         connection = onBeforeRequest();
       } catch (Exception e) {
-        sendError(connection, clientTxId, e);
-        handleConnectionError(connection, e);
-        onAfterRequest(connection);
-        sendShutdown();
+        if(requestType != OChannelBinaryProtocol.REQUEST_DB_CLOSE) {
+          sendError(connection, clientTxId, e);
+          handleConnectionError(connection, e);
+          onAfterRequest(connection);
+          sendShutdown();
+        }
         return;
       }
 


### PR DESCRIPTION
Make able the client to keep all session open with all servers, and close them properly at the close.

It avoid as well no needed reopen in case of switching between servers