### PR TITLE
Fix ODatabaseDocumentTx ignoring iPolymorphic parameter on countClass()

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -2548,15 +2548,27 @@ public class ODatabaseDocumentTx extends OListenerManger<ODatabaseListener>imple
         if (op.type == ORecordOperation.DELETED) {
           final ORecord rec = op.getRecord();
           if (rec != null && rec instanceof ODocument) {
-            if (((ODocument) rec).getSchemaClass().isSubClassOf(iClassName))
-              deletedInTx++;
+            OClass schemaClass = ((ODocument)rec).getSchemaClass();
+            if (iPolymorphic) {
+              if (schemaClass.isSubClassOf(iClassName))
+                deletedInTx++;
+            } else {
+              if (iClassName.equals(schemaClass.getName()) || iClassName.equals(schemaClass.getShortName()))
+                deletedInTx++;
+            }
           }
         }
         if (op.type == ORecordOperation.CREATED) {
           final ORecord rec = op.getRecord();
           if (rec != null && rec instanceof ODocument) {
-            if (((ODocument) rec).getSchemaClass().isSubClassOf(iClassName))
-              addedInTx++;
+            OClass schemaClass = ((ODocument)rec).getSchemaClass();
+            if (iPolymorphic) {
+              if (schemaClass.isSubClassOf(iClassName))
+                addedInTx++;
+            } else {
+              if (iClassName.equals(schemaClass.getName()) || iClassName.equals(schemaClass.getShortName()))
+                addedInTx++;
+            }
           }
         }
       }

--- a/core/src/test/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTxTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTxTest.java
@@ -1,6 +1,7 @@
 package com.orientechnologies.orient.core.db.document;
 
 import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import org.testng.Assert;
@@ -42,6 +43,51 @@ public class ODatabaseDocumentTxTest {
 
       for (ORecord rec : result2) {
         Assert.assertTrue(rec instanceof ODocument);
+      }
+
+    } finally {
+      db.close();
+    }
+  }
+
+  @Test
+  public void testCountClass() throws Exception
+  {
+    String url = "memory:" + ODatabaseDocumentTxTest.class.getSimpleName() + "-testCountClass";
+    ODatabaseDocumentTx db = new ODatabaseDocumentTx(url).create();
+    try {
+
+      OClass testSuperclass = db.getMetadata().getSchema().createClass("TestSuperclass");
+      db.getMetadata().getSchema().createClass("TestSubclass", testSuperclass);
+
+      ODocument toDelete = new ODocument("TestSubclass").field("id", 1).save();
+
+      // 1 SUB, 0 SUPER
+      Assert.assertEquals(db.countClass("TestSubclass", false), 1);
+      Assert.assertEquals(db.countClass("TestSubclass", true), 1);
+      Assert.assertEquals(db.countClass("TestSuperclass", false), 0);
+      Assert.assertEquals(db.countClass("TestSuperclass", true), 1);
+
+      db.begin();
+      try {
+        new ODocument("TestSuperclass").field("id", 1).save();
+        new ODocument("TestSubclass").field("id", 1).save();
+        // 2 SUB, 1 SUPER
+
+        Assert.assertEquals(db.countClass("TestSuperclass", false), 1);
+        Assert.assertEquals(db.countClass("TestSuperclass", true), 3);
+        Assert.assertEquals(db.countClass("TestSubclass", false), 2);
+        Assert.assertEquals(db.countClass("TestSubclass", true), 2);
+
+        toDelete.delete().save();
+        // 1 SUB, 1 SUPER
+
+        Assert.assertEquals(db.countClass("TestSuperclass", false), 1);
+        Assert.assertEquals(db.countClass("TestSuperclass", true), 2);
+        Assert.assertEquals(db.countClass("TestSubclass", false), 1);
+        Assert.assertEquals(db.countClass("TestSubclass", true), 1);
+      } finally {
+        db.commit();
       }
 
     } finally {


### PR DESCRIPTION
... when counting deletes/inserts inside transaction.

Add unit test to test countClass both inside and outside transaction.

Can this please also be backported to the 2.1.* versions as that's what we are using at present, thanks.