### PR TITLE
Add: Switch NETWORK_BINARY_DNS_FALLBACK_SERVERS_ENABLED

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1685,11 +1685,13 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
             if (listeners == null)
               throw new ODatabaseException("Received bad distributed configuration: missing 'listeners' array field");
 
-            for (Map<String, Object> listener : listeners) {
-              if (((String) listener.get("protocol")).equals("ONetworkProtocolBinary")) {
-                String url = (String) listener.get("listen");
-                if (!serverURLs.contains(url))
-                  addHost(url);
+            if (OGlobalConfiguration.NETWORK_BINARY_DNS_FALLBACK_SERVERS_ENABLED.getValueAsBoolean()) {
+              for (Map<String, Object> listener : listeners) {
+                if (((String) listener.get("protocol")).equals("ONetworkProtocolBinary")) {
+                  String url = (String) listener.get("listen");
+                  if (!serverURLs.contains(url))
+                    addHost(url);
+                }
               }
             }
           }

--- a/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
@@ -378,6 +378,9 @@ public enum OGlobalConfiguration {
   NETWORK_BINARY_DNS_LOADBALANCING_TIMEOUT("network.binary.loadBalancing.timeout",
       "Maximum time (in ms) to wait for the answer from DNS about the TXT record for load balancing", Integer.class, 2000, true),
 
+  NETWORK_BINARY_DNS_FALLBACK_SERVERS_ENABLED("network.binary.fallbackServers.enabled",
+      "In case the connected server becomes unreachable, the client automatically connects to the next available one", Boolean.class, Boolean.TRUE, true),
+
   NETWORK_BINARY_MAX_CONTENT_LENGTH("network.binary.maxLength", "TCP/IP max content length in bytes of BINARY requests",
       Integer.class, 32736, true),
 

--- a/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
+++ b/enterprise/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
@@ -378,7 +378,7 @@ public abstract class OChannelBinary extends OChannel {
   @Override
   public void flush() throws IOException {
     if (debug)
-      OLogManager.instance().info(this, "%s - Flush",  socket != null ? " null probably already closed" :socket.getRemoteSocketAddress());
+      OLogManager.instance().info(this, "%s - Flush",  socket == null ? " null probably already closed" :socket.getRemoteSocketAddress());
 
     updateMetricFlushes();
 
@@ -391,7 +391,7 @@ public abstract class OChannelBinary extends OChannel {
   public void close() {
     if (debug)
       OLogManager.instance()
-          .info(this, "%s - Closing socket...", socket != null ? " null probably already closed" : socket.getRemoteSocketAddress());
+          .info(this, "%s - Closing socket...", socket == null ? " null probably already closed" : socket.getRemoteSocketAddress());
 
     try {
       if (in != null) {


### PR DESCRIPTION
Some users don’t have their OrientDb cluster reachable from the client
server. They may rely on external load balancers, health probes, etc.
If hostnames are not configured to be reachable, then user can turn off
“retry on fallback hosts” feature.

This pull req is a workaround for #6058 