### PR TITLE
Refactor index tx

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -39,15 +39,11 @@ import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ridbag.sbtree.OIndexRIDContainer;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
 import com.orientechnologies.orient.core.exception.OConfigurationException;
-import com.orientechnologies.orient.core.exception.OTransactionException;
 import com.orientechnologies.orient.core.intent.OIntentMassiveInsert;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
-import com.orientechnologies.orient.core.serialization.serializer.OStringSerializerHelper;
-import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerSchemaAware2CSV;
-import com.orientechnologies.orient.core.serialization.serializer.stream.OStreamSerializerAnyStreamable;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.cache.OReadCache;
 import com.orientechnologies.orient.core.storage.cache.OWriteCache;
@@ -55,7 +51,6 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
 import com.orientechnologies.orient.core.storage.impl.local.OIndexEngineCallback;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperation;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
-import com.orientechnologies.orient.core.tx.OTransactionIndexChanges.OPERATION;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
 
 import java.io.IOException;
@@ -722,31 +717,6 @@ public abstract class OIndexAbstract<T> implements OIndexInternal<T>, OOrientSta
     return configuration.getDocument();
   }
 
-  @SuppressWarnings("unchecked")
-  public void addTxOperation(final ODocument operationDocument) {
-    if (operationDocument == null)
-      return;
-
-    acquireSharedLock();
-    try {
-      final IndexTxSnapshot indexTxSnapshot = txSnapshot.get();
-
-      final Boolean clearAll = operationDocument.field("clear");
-      if (clearAll != null && clearAll)
-        clearSnapshot(indexTxSnapshot);
-
-      final Collection<ODocument> entries = operationDocument.field("entries");
-      final Map<Object, Object> snapshot = indexTxSnapshot.indexSnapshot;
-      for (final ODocument entry : entries)
-        applyIndexTxEntry(snapshot, entry);
-
-      final ODocument nullIndexEntry = operationDocument.field("nullEntries");
-      applyIndexTxEntry(snapshot, nullIndexEntry);
-    } finally {
-      releaseSharedLock();
-    }
-  }
-
   public void addTxOperation(final OTransactionIndexChanges changes) {
     acquireSharedLock();
     try {
@@ -1050,60 +1020,6 @@ public abstract class OIndexAbstract<T> implements OIndexInternal<T>, OOrientSta
         }
       }
 
-    }
-  }
-
-  private void applyIndexTxEntry(Map<Object, Object> snapshot, ODocument entry) {
-    final Object key;
-    if (entry.field("k") != null) {
-      Object serKey = entry.field("k");
-      try {
-        ODocument keyContainer = null;
-        // Check for PROTOCOL_VERSION_24 that remove CSV serialization.
-        if (serKey instanceof String) {
-          final String serializedKey = OStringSerializerHelper.decode((String) serKey);
-          keyContainer = new ODocument();
-          keyContainer.setLazyLoad(false);
-          keyContainer.setTrackingChanges(false);
-
-          ORecordSerializerSchemaAware2CSV.INSTANCE.fromString(serializedKey, keyContainer, null);
-        } else if (serKey instanceof ODocument) {
-          keyContainer = (ODocument) serKey;
-        }
-
-        if (keyContainer == null)
-          throw new OTransactionException("Key was not provided during key-value pair insertion");
-
-        final Object storedKey = keyContainer.field("key");
-        if (storedKey instanceof List)
-          key = new OCompositeKey((List<? extends Comparable<?>>) storedKey);
-        else if (Boolean.TRUE.equals(keyContainer.field("binary"))) {
-          key = OStreamSerializerAnyStreamable.INSTANCE.fromStream((byte[]) storedKey);
-        } else
-          key = storedKey;
-      } catch (IOException ioe) {
-        throw OException.wrapException(new OTransactionException("Error during index changes deserialization. "), ioe);
-      }
-    } else
-      key = null;
-
-    final List<ODocument> operations = entry.field("ops");
-    if (operations != null) {
-      for (final ODocument op : operations) {
-        op.setLazyLoad(false);
-        final int operation = (Integer) op.rawField("o");
-        final OIdentifiable value = op.field("v");
-
-        if (operation == OPERATION.PUT.ordinal())
-          putInSnapshot(key, value, snapshot);
-        else if (operation == OPERATION.REMOVE.ordinal()) {
-          if (value == null)
-            removeFromSnapshot(key, snapshot);
-          else {
-            removeFromSnapshot(key, value, snapshot);
-          }
-        }
-      }
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.core.index;
 
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 
 import java.util.Collection;
 
@@ -181,6 +182,7 @@ public interface OIndexInternal<T> extends OIndex<T> {
   void preCommit();
 
   void addTxOperation(ODocument operationDocument);
+  void addTxOperation(final OTransactionIndexChanges changes);
 
   void commit();
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
@@ -181,7 +181,6 @@ public interface OIndexInternal<T> extends OIndex<T> {
 
   void preCommit();
 
-  void addTxOperation(ODocument operationDocument);
   void addTxOperation(final OTransactionIndexChanges changes);
 
   void commit();

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexRecorder.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexRecorder.java
@@ -24,6 +24,7 @@ import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
@@ -382,6 +383,11 @@ public class OIndexRecorder implements OIndex<OIdentifiable>, OIndexInternal<OId
 
   @Override
   public void addTxOperation(ODocument operationDocument) {
+    throw new UnsupportedOperationException("Not allowed operation");
+  }
+
+  @Override
+  public void addTxOperation(OTransactionIndexChanges changes) {
     throw new UnsupportedOperationException("Not allowed operation");
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexRecorder.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexRecorder.java
@@ -382,11 +382,6 @@ public class OIndexRecorder implements OIndex<OIdentifiable>, OIndexInternal<OId
   }
 
   @Override
-  public void addTxOperation(ODocument operationDocument) {
-    throw new UnsupportedOperationException("Not allowed operation");
-  }
-
-  @Override
   public void addTxOperation(OTransactionIndexChanges changes) {
     throw new UnsupportedOperationException("Not allowed operation");
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -77,10 +77,7 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODura
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.*;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OPerformanceStatisticManager;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OSessionStoragePerformanceStatistic;
-import com.orientechnologies.orient.core.tx.OTransaction;
-import com.orientechnologies.orient.core.tx.OTransactionAbstract;
-import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
-import com.orientechnologies.orient.core.tx.OTxListener;
+import com.orientechnologies.orient.core.tx.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.*;
@@ -1270,11 +1267,10 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     checkLowDiskSpaceAndFullCheckpointRequests();
 
     final ODatabaseDocumentInternal databaseRecord = (ODatabaseDocumentInternal) clientTx.getDatabase();
+    final Map<String, OIndexInternal<?>> indexesToCommit = getChangedIndexes(clientTx, databaseRecord.getMetadata().getIndexManager());
+
     ((OMetadataInternal) databaseRecord.getMetadata()).makeThreadLocalSchemaSnapshot();
 
-    final Map<String, OIndex<?>> indexes = new HashMap<String, OIndex<?>>();
-    for (OIndex<?> index : databaseRecord.getMetadata().getIndexManager().getIndexes())
-      indexes.put(index.getName(), index);
     final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getAllRecordEntries();
 
     for (ORecordOperation txEntry : entries) {
@@ -1336,7 +1332,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             result.add(txEntry);
           }
 
-          commitIndexes(clientTx, indexes);
+          commitIndexes(clientTx, indexesToCommit);
 
           endStorageTx();
 
@@ -1360,22 +1356,13 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return result;
   }
 
-  private void commitIndexes(OTransaction clientTx, Map<String, OIndex<?>> indexes) {
-    Map<String, OTransactionIndexChanges> indexChanges = clientTx.getIndexEntries();
-    assert indexChanges != null;
-    final Map<String, OIndexInternal<?>> indexesToCommit = new HashMap<String, OIndexInternal<?>>();
-
-    for (Map.Entry<String, OTransactionIndexChanges> indexChange : indexChanges.entrySet()) {
-      final OIndex<?> idx = indexes.get(indexChange.getKey());
-      if (idx == null)
-        throw new OTransactionException("Cannot find index '" + indexChange.getKey() + "' while committing transaction");
-
-      final OIndexInternal<?> index = idx.getInternal();
-      indexesToCommit.put(index.getName(), index.getInternal());
-    }
+  private void commitIndexes(OTransaction clientTx, final Map<String, OIndexInternal<?>> indexesToCommit) {
+    assert clientTx instanceof OTransactionOptimistic;
 
     for (OIndexInternal<?> indexInternal : indexesToCommit.values())
       indexInternal.preCommit();
+
+    Map<String, OTransactionIndexChanges> indexChanges = ((OTransactionOptimistic) clientTx).getIndexEntries();
 
     for (Map.Entry<String, OTransactionIndexChanges> indexEntry : indexChanges.entrySet()) {
       final OIndexInternal<?> index = indexesToCommit.get(indexEntry.getKey()).getInternal();
@@ -1396,19 +1383,34 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     }
   }
 
+  private Map<String, OIndexInternal<?>> getChangedIndexes(OTransaction clientTx, OIndexManager manager) {
+    assert clientTx instanceof OTransactionOptimistic;
+
+    Map<String, OTransactionIndexChanges> indexChanges = ((OTransactionOptimistic) clientTx).getIndexEntries();
+
+    final Map<String, OIndexInternal<?>> indexesToCommit = new HashMap<String, OIndexInternal<?>>();
+
+    for (Map.Entry<String, OTransactionIndexChanges> indexChange : indexChanges.entrySet()) {
+      final OIndex<?> idx = manager.getIndex(indexChange.getKey());
+      if (idx == null)
+        throw new OTransactionException("Cannot find index '" + indexChange.getKey() + "' while committing transaction");
+
+      final OIndexInternal<?> index = idx.getInternal();
+      indexesToCommit.put(index.getName(), index.getInternal());
+    }
+    return indexesToCommit;
+  }
+
   @Override
   public OUncompletedCommit<List<ORecordOperation>> initiateCommit(OTransaction clientTx, Runnable callback) {
     boolean success = false;
     checkOpeness();
     checkLowDiskSpaceAndFullCheckpointRequests();
-
     final ODatabaseDocumentInternal databaseRecord = (ODatabaseDocumentInternal) clientTx.getDatabase();
+
+    final Map<String, OIndexInternal<?>> indexesToCommit = getChangedIndexes(clientTx, databaseRecord.getMetadata().getIndexManager());
+
     ((OMetadataInternal) databaseRecord.getMetadata()).makeThreadLocalSchemaSnapshot();
-
-    final Map<String, OIndex<?>> indexes = new HashMap<String, OIndex<?>>();
-    for (OIndex<?> index : databaseRecord.getMetadata().getIndexManager().getIndexes())
-      indexes.put(index.getName(), index);
-
     final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getAllRecordEntries();
 
     for (ORecordOperation txEntry : entries) {
@@ -1469,7 +1471,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             result.add(txEntry);
           }
 
-          commitIndexes(clientTx, indexes);
+          commitIndexes(clientTx, indexesToCommit);
 
           final OUncompletedCommit<List<ORecordOperation>> uncompletedCommit = new UncompletedCommit(clientTx, entries, result,
               atomicOperationsManager.initiateCommit());

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
@@ -126,8 +126,6 @@ public interface OTransaction {
 
   ODocument getIndexChanges();
 
-  Map<String, OTransactionIndexChanges> getIndexEntries() ;
-
   void addIndexEntry(OIndex<?> delegate, final String iIndexName, final OTransactionIndexChanges.OPERATION iStatus,
       final Object iKey, final OIdentifiable iValue);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
@@ -35,6 +35,7 @@ import com.orientechnologies.orient.core.storage.OStorage;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public interface OTransaction {
   enum TXTYPE {
@@ -124,6 +125,8 @@ public interface OTransaction {
   List<String> getInvolvedIndexes();
 
   ODocument getIndexChanges();
+
+  Map<String, OTransactionIndexChanges> getIndexEntries() ;
 
   void addIndexEntry(OIndex<?> delegate, final String iIndexName, final OTransactionIndexChanges.OPERATION iStatus,
       final Object iKey, final OIdentifiable iValue);

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChanges.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChanges.java
@@ -64,6 +64,7 @@ public class OTransactionIndexChanges {
     cleared = true;
   }
 
+
   public Object getFirstKey() {
     return changesPerKey.firstKey();
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
@@ -338,16 +338,6 @@ public class OTransactionNoTx extends OTransactionAbstract {
     return null;
   }
 
-  @Override
-  public Map<String, OTransactionIndexChanges> getIndexEntries() {
-    return null;
-  }
-
-
-  public OTransactionIndexChangesPerKey getIndexEntry(final String iIndexName, final Object iKey) {
-    return null;
-  }
-
   public void addIndexEntry(final OIndex<?> delegate, final String indexName, final OPERATION status, final Object key,
       final OIdentifiable value) {
     switch (status) {

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
@@ -39,10 +39,7 @@ import com.orientechnologies.orient.core.storage.ORecordCallback;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges.OPERATION;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * No operation transaction.
@@ -340,6 +337,12 @@ public class OTransactionNoTx extends OTransactionAbstract {
   public ODocument getIndexChanges() {
     return null;
   }
+
+  @Override
+  public Map<String, OTransactionIndexChanges> getIndexEntries() {
+    return null;
+  }
+
 
   public OTransactionIndexChangesPerKey getIndexEntry(final String iIndexName, final Object iKey) {
     return null;

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -289,6 +289,10 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract {
     return result;
   }
 
+  public Map<String, OTransactionIndexChanges> getIndexEntries() {
+    return indexEntries;
+  }
+
   /**
    * Bufferizes index changes to be flushed at commit time.
    * 


### PR DESCRIPTION
This is a refactor for remove some not needed conversion to odocument and backward of index changes, during the transaction commit.

There three commits:
this: https://github.com/orientechnologies/orientdb/commit/0692dfe67b77ff829c6f75cae0db408ccb663abc add the logic for apply in index transaction changes using transaction structures

this: https://github.com/orientechnologies/orientdb/commit/82ff7a061a33daa284b0e8b9f459e8f2b5a17be7 remove all the old code that handle the transaction changes with the odocument

this: https://github.com/orientechnologies/orientdb/commit/0b4f44fa350bf0296bad81637bd282ed0426cc3d optimize the lookup for index for only the one interested by the transaction, plus other minor cleanup.


