### PR TITLE
Replace snapshot junit with release version for 2.1.x

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
My configuration prohibits building releases that use snapshot versions, which is a good thing because it leads to inherent instability. I've reverted junit 4.13-SNAPSHOT to 4.12 (the latest released). This change makes it possible to use a build system configured to only permit released, non-snapshot dependencies.

I needed to build 2.1.x with this change, and it doesn't apply to develop branch. I did think about submitting a PR versus master but the guidelines forbid it, so I figured this maintenance branch is the most appropriate way to contribute. Either way, a small change that has no side-effects (indeed, develop branch now uses 4.12 anyway).