### PR TITLE
Set correct status when unmarshalling embedded/link collections to avoid marking records as dirty

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV0.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV0.java
@@ -33,6 +33,7 @@ import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.db.record.ORecordLazyList;
 import com.orientechnologies.orient.core.db.record.ORecordLazyMap;
 import com.orientechnologies.orient.core.db.record.ORecordLazyMultiValue;
@@ -403,54 +404,69 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
 
   private Map<Object, OIdentifiable> readLinkMap(final BytesContainer bytes, final ODocument document) {
     int size = OVarIntSerializer.readAsInteger(bytes);
-    Map<Object, OIdentifiable> result = new ORecordLazyMap(document);
-    while ((size--) > 0) {
-      OType keyType = readOType(bytes);
-      Object key = readSingleValue(bytes, keyType, document);
-      ORecordId value = readOptimizedLink(bytes);
-      if (value.equals(NULL_RECORD_ID))
-        result.put(key, null);
-      else
-        result.put(key, value);
+    ORecordLazyMap result = new ORecordLazyMap(document);
+    result.setInternalStatus(ORecordElement.STATUS.UNMARSHALLING);
+    try {
+      while ((size--) > 0) {
+        OType keyType = readOType(bytes);
+        Object key = readSingleValue(bytes, keyType, document);
+        ORecordId value = readOptimizedLink(bytes);
+        if (value.equals(NULL_RECORD_ID))
+          result.put(key, null);
+        else
+          result.put(key, value);
+      }
+      return result;
+    } finally {
+      result.setInternalStatus(ORecordElement.STATUS.LOADED);
     }
-    return result;
   }
 
   private Object readEmbeddedMap(final BytesContainer bytes, final ODocument document) {
     int size = OVarIntSerializer.readAsInteger(bytes);
-    final Map<Object, Object> result = new OTrackedMap<Object>(document);
-    int last = 0;
-    while ((size--) > 0) {
-      OType keyType = readOType(bytes);
-      Object key = readSingleValue(bytes, keyType, document);
-      final int valuePos = readInteger(bytes);
-      final OType type = readOType(bytes);
-      if (valuePos != 0) {
-        int headerCursor = bytes.offset;
-        bytes.offset = valuePos;
-        Object value = readSingleValue(bytes, type, document);
-        if (bytes.offset > last)
-          last = bytes.offset;
-        bytes.offset = headerCursor;
-        result.put(key, value);
-      } else
-        result.put(key, null);
+    final OTrackedMap<Object> result = new OTrackedMap<Object>(document);
+    result.setInternalStatus(ORecordElement.STATUS.UNMARSHALLING);
+    try {
+      int last = 0;
+      while ((size--) > 0) {
+        OType keyType = readOType(bytes);
+        Object key = readSingleValue(bytes, keyType, document);
+        final int valuePos = readInteger(bytes);
+        final OType type = readOType(bytes);
+        if (valuePos != 0) {
+          int headerCursor = bytes.offset;
+          bytes.offset = valuePos;
+          Object value = readSingleValue(bytes, type, document);
+          if (bytes.offset > last)
+            last = bytes.offset;
+          bytes.offset = headerCursor;
+          result.put(key, value);
+        } else
+          result.put(key, null);
+      }
+      if (last > bytes.offset)
+        bytes.offset = last;
+      return result;
+    } finally {
+      result.setInternalStatus(ORecordElement.STATUS.LOADED);
     }
-    if (last > bytes.offset)
-      bytes.offset = last;
-    return result;
   }
 
   private Collection<OIdentifiable> readLinkCollection(BytesContainer bytes, Collection<OIdentifiable> found) {
-    final int items = OVarIntSerializer.readAsInteger(bytes);
-    for (int i = 0; i < items; i++) {
-      ORecordId id = readOptimizedLink(bytes);
-      if (id.equals(NULL_RECORD_ID))
-        found.add(null);
-      else
-        found.add(id);
+    ((ORecordElement)found).setInternalStatus(ORecordElement.STATUS.UNMARSHALLING);
+    try {
+      final int items = OVarIntSerializer.readAsInteger(bytes);
+      for (int i = 0; i < items; i++) {
+        ORecordId id = readOptimizedLink(bytes);
+        if (id.equals(NULL_RECORD_ID))
+          found.add(null);
+        else
+          found.add(id);
+      }
+      return found;
+    } finally {
+      ((ORecordElement)found).setInternalStatus(ORecordElement.STATUS.LOADED);
     }
-    return found;
   }
 
   private ORecordId readOptimizedLink(final BytesContainer bytes) {
@@ -462,14 +478,19 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     OType type = readOType(bytes);
 
     if (type == OType.ANY) {
-      for (int i = 0; i < items; i++) {
-        OType itemType = readOType(bytes);
-        if (itemType == OType.ANY)
-          found.add(null);
-        else
-          found.add(readSingleValue(bytes, itemType, document));
+      ((ORecordElement)found).setInternalStatus(ORecordElement.STATUS.UNMARSHALLING);
+      try {
+        for (int i = 0; i < items; i++) {
+          OType itemType = readOType(bytes);
+          if (itemType == OType.ANY)
+            found.add(null);
+          else
+            found.add(readSingleValue(bytes, itemType, document));
+        }
+        return found;
+      } finally {
+        ((ORecordElement)found).setInternalStatus(ORecordElement.STATUS.LOADED);
       }
-      return found;
     }
     // TODO: manage case where type is known
     return null;


### PR DESCRIPTION
Backported unmarshalling improvements made to ORecordSerializerBinaryV0 under issue #5113 to 2.1.x

Diff is simpler with ignore whitespace: https://github.com/orientechnologies/orientdb/pull/6122/files?w=1 :)