### PR TITLE
Allow ORecordHook define default hook position by itself

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -44,6 +44,7 @@ import com.orientechnologies.orient.core.dictionary.ODictionary;
 import com.orientechnologies.orient.core.exception.*;
 import com.orientechnologies.orient.core.fetch.OFetchHelper;
 import com.orientechnologies.orient.core.hook.ORecordHook;
+import com.orientechnologies.orient.core.hook.ORecordHook.HOOK_POSITION;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.index.ClassIndexManagerRemote;
@@ -962,10 +963,10 @@ public class ODatabaseDocumentTx extends OListenerManger<ODatabaseListener> impl
   /**
    * {@inheritDoc}
    */
-  public <DB extends ODatabase<?>> DB registerHook(final ORecordHook iHookImpl, final ORecordHook.HOOK_POSITION iPosition) {
+  public <DB extends ODatabase<?>> DB registerHook(final ORecordHook iHookImpl, ORecordHook.HOOK_POSITION iPosition) {
     checkOpeness();
     checkIfActive();
-
+    if(iPosition==null) iPosition = HOOK_POSITION.REGULAR;
     final Map<ORecordHook, ORecordHook.HOOK_POSITION> tmp = new LinkedHashMap<ORecordHook, ORecordHook.HOOK_POSITION>(hooks);
     tmp.put(iHookImpl, iPosition);
     hooks.clear();
@@ -982,7 +983,7 @@ public class ODatabaseDocumentTx extends OListenerManger<ODatabaseListener> impl
    * {@inheritDoc}
    */
   public <DB extends ODatabase<?>> DB registerHook(final ORecordHook iHookImpl) {
-    return (DB) registerHook(iHookImpl, ORecordHook.HOOK_POSITION.REGULAR);
+    return (DB) registerHook(iHookImpl, iHookImpl.getDefaultHookPosition());
   }
 
   /**

--- a/core/src/main/java/com/orientechnologies/orient/core/hook/ODocumentHookAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/hook/ODocumentHookAbstract.java
@@ -345,4 +345,10 @@ public abstract class ODocumentHookAbstract implements ORecordHook {
 
     return true;
   }
+
+  @Override
+  public HOOK_POSITION getDefaultHookPosition() {
+	return HOOK_POSITION.REGULAR;
+  }
+  
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/hook/ORecordHook.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/hook/ORecordHook.java
@@ -54,4 +54,6 @@ public interface ORecordHook {
   RESULT onTrigger(TYPE iType, ORecord iRecord);
 
   DISTRIBUTED_EXECUTION_MODE getDistributedExecutionMode();
+  
+  HOOK_POSITION getDefaultHookPosition();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/hook/ORecordHookAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/hook/ORecordHookAbstract.java
@@ -248,4 +248,10 @@ public abstract class ORecordHookAbstract implements ORecordHook {
     }
     return RESULT.RECORD_NOT_CHANGED;
   }
+
+  @Override
+  public HOOK_POSITION getDefaultHookPosition() {
+	return HOOK_POSITION.REGULAR;
+  }
+  
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/db/hook/HookRegisterRemoveTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/hook/HookRegisterRemoveTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.hook.ORecordHook;
+import com.orientechnologies.orient.core.hook.ORecordHook.HOOK_POSITION;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerSchemaAware2CSV;
@@ -37,6 +38,11 @@ public class HookRegisterRemoveTest {
       @Override
       public DISTRIBUTED_EXECUTION_MODE getDistributedExecutionMode() {
         return null;
+      }
+      
+      @Override
+      public HOOK_POSITION getDefaultHookPosition() {
+    	return HOOK_POSITION.REGULAR;
       }
     };
     db.registerHook(iHookImpl);

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/asynch/UpdateHook.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/asynch/UpdateHook.java
@@ -1,6 +1,7 @@
 package com.orientechnologies.orient.server.distributed.asynch;
 
 import com.orientechnologies.orient.core.hook.ORecordHook;
+import com.orientechnologies.orient.core.hook.ORecordHook.HOOK_POSITION;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
@@ -37,6 +38,11 @@ public class UpdateHook implements ORecordHook {
   @Override
   public DISTRIBUTED_EXECUTION_MODE getDistributedExecutionMode() {
     return DISTRIBUTED_EXECUTION_MODE.SOURCE_NODE;
+  }
+
+  @Override
+  public HOOK_POSITION getDefaultHookPosition() {
+	return HOOK_POSITION.REGULAR;
   }
 
 }

--- a/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/OrientGraphHookCall.java
+++ b/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/OrientGraphHookCall.java
@@ -1,6 +1,7 @@
 package com.tinkerpop.blueprints.impls.orient;
 
 import com.orientechnologies.orient.core.hook.ORecordHook;
+import com.orientechnologies.orient.core.hook.ORecordHook.HOOK_POSITION;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.tinkerpop.blueprints.Vertex;
@@ -53,6 +54,11 @@ public class OrientGraphHookCall {
       @Override
       public DISTRIBUTED_EXECUTION_MODE getDistributedExecutionMode() {
         return null;
+      }
+      
+      @Override
+      public HOOK_POSITION getDefaultHookPosition() {
+    	return HOOK_POSITION.REGULAR;
       }
     });
     try {


### PR DESCRIPTION
Fix for #6067  
Please consider to merge to 2.2.1: it is not changing API and existing behaviour
