### PR TITLE
Fix status command not working on small terminals

### DIFF
--- a/server/script/orientdb.sh
+++ b/server/script/orientdb.sh
@@ -41,7 +41,7 @@ stop() {
 }
 
 status() {
-	PID=` ps auxw | grep 'orientdb.www.path' | grep java | grep -v grep | awk '{print $2}'`
+	PID=` ps auxww | grep 'orientdb.www.path' | grep java | grep -v grep | awk '{print $2}'`
 	if [ "x$PID" = "x" ]
 	then
 		PID=0

--- a/server/script/shutdown.sh
+++ b/server/script/shutdown.sh
@@ -70,7 +70,7 @@ else
 
     if [ "x$wait" = "xyes" ] ; then
       while true ; do
-        ps auxw | grep java | grep $ORIENTDB_HOME/lib/orientdb-server > /dev/null || break
+        ps auxww | grep java | grep $ORIENTDB_HOME/lib/orientdb-server > /dev/null || break
         sleep 1;
       done
     fi


### PR DESCRIPTION
The 'w' flag for 'ps' needs to be passed twice in order to enable
unlimited wide output.

Per man page for ps:

```
w               Wide output. Use this option twice for unlimited width.

```

Tested on SuSE Linux Enterprise Server 11.
