### PR TITLE
Fixes handling of multiple WWW-Authenticate HTTP Headers

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/security/ODefaultServerSecurity.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/security/ODefaultServerSecurity.java
@@ -204,7 +204,7 @@ public class ODefaultServerSecurity implements OSecurityFactory, OServerLifecycl
             if (sah != null && sah.trim().length() > 0) {
               // If we're not the first authenticator, then append "\n".
               if (sb.length() > 0) {
-                sb.append("\n");
+                sb.append("\r\n");
               }
               sb.append(sah);
             }


### PR DESCRIPTION
The REST API should return valid HTTP Headers.  This is not the case and is causing issues with several http clients.  The issue is specifically with the WWW-Authenticate header.

RFC 2617  defines that multiple WWW-Authenticate can be returned.  The ODefaultServerSecurity class seems to allow for this in the "getAuthenticationHeader()" method.  However the method improperly uses a "\n" to append multiple headers.  HTTP 1.1states the header lines are separated by CRLF ("\r\n").  If only a "\n" is used many parsing will not interpret this as a correct field ending, it will be assumed that the "\n" and the next line are all part of the same field value.  Currently responses can look like this:

```
WWW-Authenticate: Basic realm="OrientDB db-convergence"\n
WWW-Authenticate: Basic realm="OrientDB db-convergence"\n
WWW-Authenticate: Basic realm="OrientDB db-convergence"\r\n
```

This is treated as one field.  RFC 7230 Section 3.2.4 terms headers with a "\n" in them as attempting "line folding".  RFC 7230 specifically deprecates line folding and states that "A sender MUST NOT generate a message that includes line folding".  Therefore many clients will see the "\n" and reject the HTTP response.

I can not speak as to why OrientDB is generating these multiple headers in the first place (as it seems redundant), but this PR updates the line separation of the multiple headers to use "\r\n" to bring it into HTTP 1.1 compliance and should be applied regardless.  This is a very simple change, but is currently a blocker.