### PR TITLE
 Refactor get changes

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ODirectoryFirstPage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ODirectoryFirstPage.java
@@ -23,7 +23,6 @@ package com.orientechnologies.orient.core.index.hashindex.local;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -40,8 +39,8 @@ public class ODirectoryFirstPage extends ODirectoryPage {
   public static final int  NODES_PER_PAGE   = (OGlobalConfiguration.DISK_CACHE_PAGE_SIZE.getValueAsInteger() * 1024 - ITEMS_OFFSET)
                                                 / OHashTableDirectory.BINARY_LEVEL_SIZE;
 
-  public ODirectoryFirstPage(OCacheEntry cacheEntry, OWALChanges changes, OCacheEntry entry) {
-    super(cacheEntry, changes, entry);
+  public ODirectoryFirstPage(OCacheEntry cacheEntry, OCacheEntry entry) {
+    super(cacheEntry, entry);
   }
 
   public void setTreeSize(int treeSize) throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ODirectoryPage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ODirectoryPage.java
@@ -24,7 +24,6 @@ import com.orientechnologies.common.serialization.types.OByteSerializer;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -40,8 +39,8 @@ public class ODirectoryPage extends ODurablePage {
 
   private final OCacheEntry entry;
 
-  public ODirectoryPage(OCacheEntry cacheEntry, OWALChanges changes, OCacheEntry entry) {
-    super(cacheEntry, changes);
+  public ODirectoryPage(OCacheEntry cacheEntry, OCacheEntry entry) {
+    super(cacheEntry);
     this.entry = entry;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexBucket.java
@@ -28,11 +28,9 @@ import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -59,8 +57,8 @@ public class OHashIndexBucket<K, V> extends ODurablePage implements Iterable<OHa
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public OHashIndexBucket(int depth, OCacheEntry cacheEntry, OBinarySerializer<K> keySerializer,
-      OBinarySerializer<V> valueSerializer, OType[] keyTypes, OWALChanges changes) throws IOException {
-    super(cacheEntry, changes);
+      OBinarySerializer<V> valueSerializer, OType[] keyTypes) throws IOException {
+    super(cacheEntry);
 
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;
@@ -71,8 +69,8 @@ public class OHashIndexBucket<K, V> extends ODurablePage implements Iterable<OHa
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public OHashIndexBucket(OCacheEntry cacheEntry, OBinarySerializer<K> keySerializer, OBinarySerializer<V> valueSerializer,
-      OType[] keyTypes, OWALChanges changes) {
-    super(cacheEntry, changes);
+      OType[] keyTypes) {
+    super(cacheEntry);
 
     this.keySerializer = keySerializer;
     this.valueSerializer = valueSerializer;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexFileLevelMetadataPage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexFileLevelMetadataPage.java
@@ -24,7 +24,6 @@ import com.orientechnologies.common.serialization.types.OByteSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -41,8 +40,8 @@ public class OHashIndexFileLevelMetadataPage extends ODurablePage {
 
   private final static int ITEM_SIZE                  = OByteSerializer.BYTE_SIZE + 3 * OLongSerializer.LONG_SIZE;
 
-  public OHashIndexFileLevelMetadataPage(OCacheEntry cacheEntry, OWALChanges changes, boolean isNewPage) throws IOException {
-    super(cacheEntry, changes);
+  public OHashIndexFileLevelMetadataPage(OCacheEntry cacheEntry, boolean isNewPage) throws IOException {
+    super(cacheEntry);
 
     if (isNewPage) {
       for (int i = 0; i < OLocalHashTable.HASH_CODE_SIZE; i++)

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTableDirectory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTableDirectory.java
@@ -94,7 +94,7 @@ public class OHashTableDirectory extends ODurableComponent {
 
       firstEntry.acquireExclusiveLock();
       try {
-        ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, getChanges(atomicOperation, firstEntry), firstEntry);
+        ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, firstEntry);
 
         firstPage.setTreeSize(0);
         firstPage.setTombstone(-1);
@@ -212,7 +212,7 @@ public class OHashTableDirectory extends ODurableComponent {
         OCacheEntry firstEntry = loadPage(atomicOperation, fileId, firstEntryIndex, true);
         firstEntry.acquireExclusiveLock();
         try {
-          ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, getChanges(atomicOperation, firstEntry), firstEntry);
+          ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, firstEntry);
 
           final int tombstone = firstPage.getTombstone();
 
@@ -250,7 +250,7 @@ public class OHashTableDirectory extends ODurableComponent {
 
             cacheEntry.acquireExclusiveLock();
             try {
-              ODirectoryPage page = new ODirectoryPage(cacheEntry, getChanges(atomicOperation, cacheEntry), cacheEntry);
+              ODirectoryPage page = new ODirectoryPage(cacheEntry, cacheEntry);
 
               page.setMaxLeftChildDepth(localLevel, maxLeftChildDepth);
               page.setMaxRightChildDepth(localLevel, maxRightChildDepth);
@@ -300,7 +300,7 @@ public class OHashTableDirectory extends ODurableComponent {
         OCacheEntry firstEntry = loadPage(atomicOperation, fileId, firstEntryIndex, true);
         firstEntry.acquireExclusiveLock();
         try {
-          ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, getChanges(atomicOperation, firstEntry), firstEntry);
+          ODirectoryFirstPage firstPage = new ODirectoryFirstPage(firstEntry, firstEntry);
           if (nodeIndex < ODirectoryFirstPage.NODES_PER_PAGE) {
             firstPage.setPointer(nodeIndex, 0, firstPage.getTombstone());
             firstPage.setTombstone(nodeIndex);
@@ -311,7 +311,7 @@ public class OHashTableDirectory extends ODurableComponent {
             final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, true);
             cacheEntry.acquireExclusiveLock();
             try {
-              ODirectoryPage page = new ODirectoryPage(cacheEntry, getChanges(atomicOperation, cacheEntry), cacheEntry);
+              ODirectoryPage page = new ODirectoryPage(cacheEntry, cacheEntry);
 
               page.setPointer(localNodeIndex, 0, firstPage.getTombstone());
               firstPage.setTombstone(nodeIndex);
@@ -672,7 +672,7 @@ public class OHashTableDirectory extends ODurableComponent {
       else
         cacheEntry.acquireSharedLock();
 
-      return new ODirectoryFirstPage(cacheEntry, getChanges(atomicOperation, cacheEntry), cacheEntry);
+      return new ODirectoryFirstPage(cacheEntry, cacheEntry);
     }
 
     final int pageIndex = nodeIndex / ODirectoryPage.NODES_PER_PAGE;
@@ -683,7 +683,7 @@ public class OHashTableDirectory extends ODurableComponent {
     else
       cacheEntry.acquireSharedLock();
 
-    return new ODirectoryPage(cacheEntry, getChanges(atomicOperation, cacheEntry), cacheEntry);
+    return new ODirectoryPage(cacheEntry, cacheEntry);
   }
 
   private void releasePage(ODirectoryPage page, boolean exclusiveLock, OAtomicOperation atomicOperation) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
@@ -161,8 +161,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
           hashStateEntry.acquireExclusiveLock();
           try {
-            OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-                getChanges(atomicOperation, hashStateEntry), true);
+            OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, true);
 
             hashStateEntryIndex = hashStateEntry.getPageIndex();
           } finally {
@@ -226,8 +225,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
         OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
         hashStateEntry.acquireExclusiveLock();
         try {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
           metadataPage.setKeySerializerId(keySerializer.getId());
         } finally {
@@ -287,8 +285,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
         final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
         hashStateEntry.acquireExclusiveLock();
         try {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
           metadataPage.setValueSerializerId(valueSerializer.getId());
         } finally {
@@ -332,7 +329,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
             OCacheEntry cacheEntry = loadPage(atomicOperation, nullBucketFileId, 0, false);
             cacheEntry.acquireSharedLock();
             try {
-              ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry), valueSerializer,
+              ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer,
                   false);
               result = nullBucket.getValue();
             } finally {
@@ -358,8 +355,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
             OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
             cacheEntry.acquireSharedLock();
             try {
-              final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
               OHashIndexBucket.Entry<K, V> entry = bucket.find(key, hashCode);
               if (entry == null)
@@ -459,8 +455,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireExclusiveLock();
           try {
-            final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             final int positionIndex = bucket.getIndex(hashCode, key);
             if (positionIndex < 0) {
               endAtomicOperation(false, null);
@@ -501,8 +496,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
           cacheEntry.acquireExclusiveLock();
           try {
-            final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry),
-                valueSerializer, false);
+            final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer, false);
 
             removed = nullBucket.getValue();
             if (removed != null) {
@@ -540,8 +534,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
       OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
         page.setRecordsCount(page.getRecordsCount() + sizeDiff);
       } finally {
@@ -610,8 +603,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             while (bucket.size() == 0 || comparator.compare(bucket.getKey(bucket.size() - 1), key) <= 0) {
               bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
@@ -628,8 +620,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             }
 
             final int index = bucket.getIndex(hashCode, key);
@@ -689,8 +680,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
         pinPage(atomicOperation, hashStateEntry);
         hashStateEntry.acquireSharedLock();
         try {
-          OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
           OBinarySerializerFactory serializerFactory = OBinarySerializerFactory
               .create(storage.getConfiguration().binaryFormatVersion);
@@ -901,8 +891,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             while (bucket.size() == 0) {
               bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
               if (bucketPath == null)
@@ -917,8 +906,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             }
 
             final int index = bucket.getIndex(hashCode, key);
@@ -964,8 +952,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             while (bucket.size() == 0) {
               bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
@@ -981,8 +968,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             }
 
             return bucket.getEntry(0);
@@ -1021,8 +1007,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             while (bucket.size() == 0) {
               final OHashTable.BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
@@ -1039,8 +1024,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
 
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
               bucketPath = prevBucketPath;
             }
@@ -1085,8 +1069,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             while (bucket.size() == 0 || comparator.compare(bucket.getKey(0), key) >= 0) {
               final OHashTable.BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
               if (prevBucketPath == null)
@@ -1102,8 +1085,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
               bucketPath = prevBucketPath;
             }
@@ -1156,8 +1138,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
             while (bucket.size() == 0) {
               final OHashTable.BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
               if (prevBucketPath == null)
@@ -1174,8 +1155,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
 
-              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                  getChanges(atomicOperation, cacheEntry));
+              bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
               bucketPath = prevBucketPath;
             }
@@ -1313,8 +1293,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
           hashStateEntry.acquireSharedLock();
           try {
-            OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-                getChanges(atomicOperation, hashStateEntry), false);
+            OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
             return metadataPage.getRecordsCount();
           } finally {
             hashStateEntry.releaseSharedLock();
@@ -1456,7 +1435,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
       cacheEntry.acquireExclusiveLock();
       try {
-        ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry), valueSerializer, isNew);
+        ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer, isNew);
         if (nullBucket.getValue() != null)
           sizeDiff--;
 
@@ -1481,8 +1460,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
       final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
       cacheEntry.acquireExclusiveLock();
       try {
-        final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-            getChanges(atomicOperation, cacheEntry));
+        final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
         final int index = bucket.getIndex(hashCode, key);
 
         if (index > -1) {
@@ -1887,7 +1865,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
     newBucketCacheEntry.acquireExclusiveLock();
     try {
       final OHashIndexBucket<K, V> newBucket = new OHashIndexBucket<K, V>(newBucketDepth, newBucketCacheEntry, keySerializer,
-          valueSerializer, keyTypes, getChanges(atomicOperation, newBucketCacheEntry));
+          valueSerializer, keyTypes);
 
       splitBucketContent(bucket, newBucket, newBucketDepth);
 
@@ -1945,7 +1923,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
       cacheEntry.acquireExclusiveLock();
       try {
         final OHashIndexBucket<K, V> emptyBucket = new OHashIndexBucket<K, V>(MAX_LEVEL_DEPTH, cacheEntry, keySerializer,
-            valueSerializer, keyTypes, getChanges(atomicOperation, cacheEntry));
+            valueSerializer, keyTypes);
       } finally {
         cacheEntry.releaseExclusiveLock();
         releasePage(atomicOperation, cacheEntry);
@@ -1962,8 +1940,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
     OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
     hashStateEntry.acquireExclusiveLock();
     try {
-      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-          getChanges(atomicOperation, hashStateEntry), false);
+      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
       metadataPage.setRecordsCount(0);
     } finally {
       hashStateEntry.releaseExclusiveLock();

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable20.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable20.java
@@ -175,8 +175,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         hashStateEntry.acquireExclusiveLock();
         try {
-          OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), true);
+          OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, true);
 
           createFileMetadata(0, page, atomicOperation);
           hashStateEntryIndex = hashStateEntry.getPageIndex();
@@ -233,8 +232,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
         metadataPage.setKeySerializerId(keySerializer.getId());
       } finally {
@@ -289,8 +287,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
         metadataPage.setValueSerializerId(valueSerializer.getId());
       } finally {
@@ -334,7 +331,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
           V result = null;
           OCacheEntry cacheEntry = loadPage(atomicOperation, nullBucketFileId, 0, false);
           try {
-            ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry), valueSerializer,
+            ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer,
                 false);
             result = nullBucket.getValue();
           } finally {
@@ -358,8 +355,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
           OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
           try {
-            final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             OHashIndexBucket.Entry<K, V> entry = bucket.find(key, hashCode);
             if (entry == null)
@@ -439,8 +435,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         final OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         cacheEntry.acquireExclusiveLock();
         try {
-          final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           final int positionIndex = bucket.getIndex(hashCode, key);
           if (positionIndex < 0) {
             endAtomicOperation(false, null);
@@ -483,7 +478,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         cacheEntry.acquireExclusiveLock();
         try {
-          final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry), valueSerializer,
+          final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer,
               false);
 
           removed = nullBucket.getValue();
@@ -517,8 +512,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
         page.setRecordsCount(page.getRecordsCount() + sizeDiff);
       } finally {
@@ -542,8 +536,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
         for (int i = 0; i < HASH_CODE_SIZE; i++) {
           if (!page.isRemoved(i)) {
@@ -598,8 +591,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
           while (bucket.size() == 0 || comparator.compare(bucket.getKey(bucket.size() - 1), key) <= 0) {
             bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
@@ -615,8 +607,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
             pageIndex = getPageIndex(nextPointer);
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           }
 
           final int index = bucket.getIndex(hashCode, key);
@@ -669,8 +660,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
       pinPage(atomicOperation, hashStateEntry);
       try {
-        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage page = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
         keySerializer = (OBinarySerializer<K>) storage.getComponentsFactory().binarySerializerFactory
             .getObjectSerializer(page.getKeySerializerId());
         valueSerializer = (OBinarySerializer<V>) storage.getComponentsFactory().binarySerializerFactory
@@ -708,8 +698,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, 0, true);
 
         try {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
           for (int i = 0; i < HASH_CODE_SIZE; i++) {
             if (!metadataPage.isRemoved(i)) {
               final long fileId = metadataPage.getFileId(i);
@@ -879,8 +868,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           while (bucket.size() == 0) {
             bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
             if (bucketPath == null)
@@ -894,8 +882,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
             pageIndex = getPageIndex(nextPointer);
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           }
 
           final int index = bucket.getIndex(hashCode, key);
@@ -935,8 +922,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
           while (bucket.size() == 0) {
             bucketPath = nextBucketToFind(bucketPath, bucket.getDepth());
@@ -951,8 +937,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
             pageIndex = getPageIndex(nextPointer);
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           }
 
           return bucket.getEntry(0);
@@ -985,8 +970,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
           while (bucket.size() == 0) {
             final BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
@@ -1001,8 +985,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
             pageIndex = getPageIndex(prevPointer);
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             bucketPath = prevBucketPath;
           }
@@ -1041,8 +1024,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           while (bucket.size() == 0 || comparator.compare(bucket.getKey(0), key) >= 0) {
             final BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
             if (prevBucketPath == null)
@@ -1057,8 +1039,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
             pageIndex = getPageIndex(prevPointer);
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             bucketPath = prevBucketPath;
           }
@@ -1105,8 +1086,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
         OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
         try {
-          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-              getChanges(atomicOperation, cacheEntry));
+          OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
           while (bucket.size() == 0) {
             final BucketPath prevBucketPath = prevBucketToFind(bucketPath, bucket.getDepth());
             if (prevBucketPath == null)
@@ -1122,8 +1102,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
             cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
 
-            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-                getChanges(atomicOperation, cacheEntry));
+            bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
 
             bucketPath = prevBucketPath;
           }
@@ -1252,8 +1231,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         final OAtomicOperation atomicOperation = atomicOperationsManager.getCurrentOperation();
         final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
         try {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
           return metadataPage.getRecordsCount();
         } finally {
           releasePage(atomicOperation, hashStateEntry);
@@ -1280,8 +1258,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       try {
         for (int i = 0; i < HASH_CODE_SIZE; i++) {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
           if (!metadataPage.isRemoved(i)) {
             readCache.closeFile(metadataPage.getFileId(i), true, writeCache);
           }
@@ -1312,8 +1289,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       try {
         for (int i = 0; i < HASH_CODE_SIZE; i++) {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
           if (!metadataPage.isRemoved(i)) {
             deleteFile(atomicOperation, metadataPage.getFileId(i));
           }
@@ -1437,8 +1413,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       hashStateEntry.acquireExclusiveLock();
       try {
-        buddyBucket = new OHashIndexBucket<K, V>(buddyCacheEntry, keySerializer, valueSerializer, keyTypes,
-            getChanges(atomicOperation, buddyCacheEntry));
+        buddyBucket = new OHashIndexBucket<K, V>(buddyCacheEntry, keySerializer, valueSerializer, keyTypes);
 
         if (buddyBucket.getDepth() != bucketDepth)
           return;
@@ -1446,8 +1421,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         if (bucket.mergedSize(buddyBucket) >= OHashIndexBucket.MAX_BUCKET_SIZE_BYTES)
           return;
 
-        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-            getChanges(atomicOperation, hashStateEntry), false);
+        OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
         metadataPage.setBucketsCount(buddyLevel, metadataPage.getBucketsCount(buddyLevel) - 2);
 
         int newBuddyLevel = buddyLevel - 1;
@@ -1459,7 +1433,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         newBuddyCacheEntry.acquireExclusiveLock();
         try {
           final OHashIndexBucket<K, V> newBuddyBucket = new OHashIndexBucket<K, V>(bucketDepth - 1, newBuddyCacheEntry,
-              keySerializer, valueSerializer, keyTypes, getChanges(atomicOperation, newBuddyCacheEntry));
+              keySerializer, valueSerializer, keyTypes);
 
           for (OHashIndexBucket.Entry<K, V> entry : buddyBucket)
             newBuddyBucket.appendEntry(entry.hashCode, entry.key, entry.value);
@@ -1514,8 +1488,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
       try {
         for (int i = 0; i < HASH_CODE_SIZE; i++) {
-          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-              getChanges(atomicOperation, hashStateEntry), false);
+          OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
           if (!metadataPage.isRemoved(i))
             writeCache.flush(metadataPage.getFileId(i));
         }
@@ -1556,7 +1529,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
       cacheEntry.acquireExclusiveLock();
       try {
-        ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry), valueSerializer, isNew);
+        ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer, isNew);
         if (nullBucket.getValue() != null)
           sizeDiff--;
 
@@ -1582,8 +1555,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       final OCacheEntry cacheEntry = loadPageEntry(pageIndex, fileLevel, atomicOperation);
       cacheEntry.acquireExclusiveLock();
       try {
-        final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes,
-            getChanges(atomicOperation, cacheEntry));
+        final OHashIndexBucket<K, V> bucket = new OHashIndexBucket<K, V>(cacheEntry, keySerializer, valueSerializer, keyTypes);
         final int index = bucket.getIndex(hashCode, key);
 
         if (index > -1) {
@@ -1983,8 +1955,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
     hashStateEntry.acquireExclusiveLock();
     try {
-      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-          getChanges(atomicOperation, hashStateEntry), false);
+      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
 
       if (metadataPage.isRemoved(newFileLevel))
         createFileMetadata(newFileLevel, metadataPage, atomicOperation);
@@ -1997,7 +1968,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         final OCacheEntry tombstoneCacheEntry = loadPageEntry(tombstoneIndex, newFileLevel, atomicOperation);
         try {
           final OHashIndexBucket<K, V> tombstone = new OHashIndexBucket<K, V>(tombstoneCacheEntry, keySerializer, valueSerializer,
-              keyTypes, getChanges(atomicOperation, tombstoneCacheEntry));
+              keyTypes);
           metadataPage.setTombstoneIndex(newFileLevel, tombstone.getNextRemovedBucketPair());
 
           updatedBucketIndex = tombstoneIndex;
@@ -2017,9 +1988,9 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
         newBucketCacheEntry.acquireExclusiveLock();
         try {
           final OHashIndexBucket<K, V> updatedBucket = new OHashIndexBucket<K, V>(newBucketDepth, updatedBucketCacheEntry,
-              keySerializer, valueSerializer, keyTypes, getChanges(atomicOperation, updatedBucketCacheEntry));
+              keySerializer, valueSerializer, keyTypes);
           final OHashIndexBucket<K, V> newBucket = new OHashIndexBucket<K, V>(newBucketDepth, newBucketCacheEntry, keySerializer,
-              valueSerializer, keyTypes, getChanges(atomicOperation, newBucketCacheEntry));
+              valueSerializer, keyTypes);
 
           splitBucketContent(bucket, updatedBucket, newBucket, newBucketDepth);
 
@@ -2093,7 +2064,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       cacheEntry.acquireExclusiveLock();
       try {
         final OHashIndexBucket<K, V> emptyBucket = new OHashIndexBucket<K, V>(MAX_LEVEL_DEPTH, cacheEntry, keySerializer,
-            valueSerializer, keyTypes, getChanges(atomicOperation, cacheEntry));
+            valueSerializer, keyTypes);
       } finally {
         cacheEntry.releaseExclusiveLock();
         releasePage(atomicOperation, cacheEntry);
@@ -2110,8 +2081,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
     OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
     hashStateEntry.acquireExclusiveLock();
     try {
-      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-          getChanges(atomicOperation, hashStateEntry), false);
+      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
       metadataPage.setBucketsCount(0, MAX_LEVEL_SIZE);
       metadataPage.setRecordsCount(0);
     } finally {
@@ -2136,8 +2106,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
     final long fileId;
     final OCacheEntry hashStateEntry = loadPage(atomicOperation, fileStateId, hashStateEntryIndex, true);
     try {
-      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry,
-          getChanges(atomicOperation, hashStateEntry), false);
+      OHashIndexFileLevelMetadataPage metadataPage = new OHashIndexFileLevelMetadataPage(hashStateEntry, false);
       fileId = metadataPage.getFileId(fileLevel);
     } finally {
       releasePage(atomicOperation, hashStateEntry);

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ONullBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/ONullBucket.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientechnologies.com)
@@ -34,8 +33,8 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALCh
 public class ONullBucket<V> extends ODurablePage {
   private final OBinarySerializer<V> valueSerializer;
 
-  public ONullBucket(OCacheEntry cacheEntry, OWALChanges changes, OBinarySerializer<V> valueSerializer, boolean isNew) {
-    super(cacheEntry, changes);
+  public ONullBucket(OCacheEntry cacheEntry, OBinarySerializer<V> valueSerializer, boolean isNew) {
+    super(cacheEntry);
     this.valueSerializer = valueSerializer;
 
     if (isNew)

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucket.java
@@ -22,7 +22,6 @@ package com.orientechnologies.orient.core.index.sbtree.local;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -42,8 +41,8 @@ import java.io.IOException;
 public class ONullBucket<V> extends ODurablePage {
   private final OBinarySerializer<V> valueSerializer;
 
-  public ONullBucket(OCacheEntry cacheEntry, OWALChanges changes, OBinarySerializer<V> valueSerializer, boolean isNew) {
-    super(cacheEntry, changes);
+  public ONullBucket(OCacheEntry cacheEntry, OBinarySerializer<V> valueSerializer, boolean isNew) {
+    super(cacheEntry);
     this.valueSerializer = valueSerializer;
 
     if (isNew)

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTree.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTree.java
@@ -138,8 +138,7 @@ public class OSBTree<K, V> extends ODurableComponent {
         rootCacheEntry.acquireExclusiveLock();
         try {
 
-          OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, true, keySerializer, keyTypes, valueSerializer,
-              getChanges(atomicOperation, rootCacheEntry));
+          OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, true, keySerializer, keyTypes, valueSerializer);
           rootBucket.setTreeSize(0);
 
         } finally {
@@ -194,8 +193,7 @@ public class OSBTree<K, V> extends ODurableComponent {
             OCacheEntry keyBucketCacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
             keyBucketCacheEntry.acquireSharedLock();
             try {
-              OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer,
-                  getChanges(atomicOperation, keyBucketCacheEntry));
+              OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer);
 
               OSBTreeBucket.SBTreeEntry<K, V> treeEntry = keyBucket.getEntry(bucketSearchResult.itemIndex);
               return readValue(treeEntry.value, atomicOperation);
@@ -210,8 +208,7 @@ public class OSBTree<K, V> extends ODurableComponent {
             final OCacheEntry nullBucketCacheEntry = loadPage(atomicOperation, nullBucketFileId, 0, false);
             nullBucketCacheEntry.acquireSharedLock();
             try {
-              final ONullBucket<V> nullBucket = new ONullBucket<V>(nullBucketCacheEntry,
-                  getChanges(atomicOperation, nullBucketCacheEntry), valueSerializer, false);
+              final ONullBucket<V> nullBucket = new ONullBucket<V>(nullBucketCacheEntry, valueSerializer, false);
               final OSBTreeValue<V> treeValue = nullBucket.getValue();
               if (treeValue == null)
                 return null;
@@ -276,8 +273,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
           OCacheEntry keyBucketCacheEntry = loadPage(atomicOperation, fileId, bucketSearchResult.getLastPathItem(), false);
           keyBucketCacheEntry.acquireExclusiveLock();
-          OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer,
-              getChanges(atomicOperation, keyBucketCacheEntry));
+          OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer);
 
           int insertionIndex;
           int sizeDiff;
@@ -316,8 +312,7 @@ public class OSBTree<K, V> extends ODurableComponent {
             keyBucketCacheEntry = loadPage(atomicOperation, fileId, bucketSearchResult.getLastPathItem(), false);
             keyBucketCacheEntry.acquireExclusiveLock();
 
-            keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer,
-                getChanges(atomicOperation, keyBucketCacheEntry));
+            keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer);
           }
 
           keyBucketCacheEntry.releaseExclusiveLock();
@@ -349,8 +344,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
           cacheEntry.acquireExclusiveLock();
           try {
-            final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, getChanges(atomicOperation, cacheEntry),
-                valueSerializer, isNew);
+            final ONullBucket<V> nullBucket = new ONullBucket<V>(cacheEntry, valueSerializer, isNew);
 
             if (nullBucket.getValue() != null)
               sizeDiff = -1;
@@ -432,8 +426,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
         cacheEntry.acquireExclusiveLock();
         try {
-          OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(cacheEntry, true, keySerializer, keyTypes, valueSerializer,
-              getChanges(atomicOperation, cacheEntry));
+          OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(cacheEntry, true, keySerializer, keyTypes, valueSerializer);
 
           rootBucket.setTreeSize(0);
 
@@ -571,8 +564,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           OCacheEntry rootCacheEntry = loadPage(atomicOperation, fileId, ROOT_INDEX, false);
           rootCacheEntry.acquireSharedLock();
           try {
-            OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer,
-                getChanges(atomicOperation, rootCacheEntry));
+            OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer);
             return rootBucket.getTreeSize();
           } finally {
             rootCacheEntry.releaseSharedLock();
@@ -620,8 +612,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           OCacheEntry keyBucketCacheEntry = loadPage(atomicOperation, fileId, bucketSearchResult.getLastPathItem(), false);
           keyBucketCacheEntry.acquireExclusiveLock();
           try {
-            OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer,
-                getChanges(atomicOperation, keyBucketCacheEntry));
+            OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(keyBucketCacheEntry, keySerializer, keyTypes, valueSerializer);
 
             final OSBTreeValue<V> removed = keyBucket.getEntry(bucketSearchResult.itemIndex).value;
             final V value = readValue(removed, atomicOperation);
@@ -646,8 +637,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           OCacheEntry nullCacheEntry = loadPage(atomicOperation, nullBucketFileId, 0, false);
           nullCacheEntry.acquireExclusiveLock();
           try {
-            ONullBucket<V> nullBucket = new ONullBucket<V>(nullCacheEntry, getChanges(atomicOperation, nullCacheEntry),
-                valueSerializer, false);
+            ONullBucket<V> nullBucket = new ONullBucket<V>(nullCacheEntry, valueSerializer, false);
             OSBTreeValue<V> treeValue = nullBucket.getValue();
             if (treeValue == null) {
               endAtomicOperation(false, null);
@@ -770,8 +760,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, searchResult.getLastPathItem(), false);
           cacheEntry.acquireSharedLock();
           try {
-            OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-                getChanges(atomicOperation, cacheEntry));
+            OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
             return bucket.getKey(searchResult.itemIndex);
           } finally {
             cacheEntry.releaseSharedLock();
@@ -813,8 +802,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, searchResult.getLastPathItem(), false);
           cacheEntry.acquireSharedLock();
           try {
-            OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-                getChanges(atomicOperation, cacheEntry));
+            OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
             return bucket.getKey(searchResult.itemIndex);
           } finally {
             cacheEntry.releaseSharedLock();
@@ -945,7 +933,7 @@ public class OSBTree<K, V> extends ODurableComponent {
       OCacheEntry valueEntry = loadPage(atomicOperation, fileId, removedLink, false);
       valueEntry.acquireSharedLock();
       try {
-        OSBTreeValuePage valuePage = new OSBTreeValuePage(valueEntry, getChanges(atomicOperation, valueEntry), false);
+        OSBTreeValuePage valuePage = new OSBTreeValuePage(valueEntry, false);
         nextPage = valuePage.getNextPage();
       } finally {
         valueEntry.releaseSharedLock();
@@ -962,8 +950,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     OCacheEntry rootCacheEntry = loadPage(atomicOperation, fileId, ROOT_INDEX, false);
 
     rootCacheEntry.acquireExclusiveLock();
-    OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer,
-        getChanges(atomicOperation, rootCacheEntry));
+    OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer);
     try {
       prevFreeListItem = rootBucket.getValuesFreeListFirstIndex();
       rootBucket.setValuesFreeListFirstIndex(pageIndex);
@@ -975,7 +962,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     OCacheEntry valueEntry = loadPage(atomicOperation, fileId, pageIndex, false);
     valueEntry.acquireExclusiveLock();
     try {
-      OSBTreeValuePage valuePage = new OSBTreeValuePage(valueEntry, getChanges(atomicOperation, valueEntry), false);
+      OSBTreeValuePage valuePage = new OSBTreeValuePage(valueEntry, false);
       valuePage.setNextFreeListPage(prevFreeListItem);
     } finally {
       valueEntry.releaseExclusiveLock();
@@ -1001,8 +988,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     final long valueLink = cacheEntry.getPageIndex();
     cacheEntry.acquireExclusiveLock();
     try {
-      OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, getChanges(atomicOperation, cacheEntry),
-          freeListPageIndex >= 0);
+      OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, freeListPageIndex >= 0);
       position = valuePage.fillBinaryContent(serializeValue, position);
 
       valuePage.setNextFreeListPage(-1);
@@ -1024,8 +1010,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
       cacheEntry.acquireExclusiveLock();
       try {
-        OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, getChanges(atomicOperation, cacheEntry),
-            freeListPageIndex >= 0);
+        OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, freeListPageIndex >= 0);
         position = valuePage.fillBinaryContent(serializeValue, position);
 
         valuePage.setNextFreeListPage(-1);
@@ -1039,8 +1024,7 @@ public class OSBTree<K, V> extends ODurableComponent {
       OCacheEntry prevPageCacheEntry = loadPage(atomicOperation, fileId, prevPage, false);
       prevPageCacheEntry.acquireExclusiveLock();
       try {
-        OSBTreeValuePage valuePage = new OSBTreeValuePage(prevPageCacheEntry, getChanges(atomicOperation, prevPageCacheEntry),
-            freeListPageIndex >= 0);
+        OSBTreeValuePage valuePage = new OSBTreeValuePage(prevPageCacheEntry, freeListPageIndex >= 0);
         valuePage.setNextPage(cacheEntry.getPageIndex());
 
       } finally {
@@ -1062,8 +1046,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     long freeListFirstIndex;
     OSBTreeBucket<K, V> rootBucket;
     try {
-      rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer,
-          getChanges(atomicOperation, rootCacheEntry));
+      rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer);
       freeListFirstIndex = rootBucket.getValuesFreeListFirstIndex();
     } finally {
       rootCacheEntry.releaseSharedLock();
@@ -1074,13 +1057,12 @@ public class OSBTree<K, V> extends ODurableComponent {
       OCacheEntry freePageEntry = loadPage(atomicOperation, fileId, freeListFirstIndex, false);
       freePageEntry.acquireExclusiveLock();
       try {
-        OSBTreeValuePage valuePage = new OSBTreeValuePage(freePageEntry, getChanges(atomicOperation, freePageEntry), false);
+        OSBTreeValuePage valuePage = new OSBTreeValuePage(freePageEntry, false);
         long nextFreeListIndex = valuePage.getNextFreeListPage();
 
         rootCacheEntry = loadPage(atomicOperation, fileId, ROOT_INDEX, false);
         rootCacheEntry.acquireExclusiveLock();
-        rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer,
-            getChanges(atomicOperation, rootCacheEntry));
+        rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer);
         try {
           rootBucket.setValuesFreeListFirstIndex(nextFreeListIndex);
         } finally {
@@ -1112,8 +1094,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     OCacheEntry rootCacheEntry = loadPage(atomicOperation, fileId, ROOT_INDEX, false);
     rootCacheEntry.acquireExclusiveLock();
     try {
-      OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer,
-          getChanges(atomicOperation, rootCacheEntry));
+      OSBTreeBucket<K, V> rootBucket = new OSBTreeBucket<K, V>(rootCacheEntry, keySerializer, keyTypes, valueSerializer);
       rootBucket.setTreeSize(size);
     } finally {
       rootCacheEntry.releaseExclusiveLock();
@@ -1262,8 +1243,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     int itemIndex = 0;
     cacheEntry.acquireSharedLock();
     try {
-      OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-          getChanges(atomicOperation, cacheEntry));
+      OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
 
       while (true) {
         if (!bucket.isLeaf()) {
@@ -1313,8 +1293,7 @@ public class OSBTree<K, V> extends ODurableComponent {
         cacheEntry = loadPage(atomicOperation, fileId, bucketIndex, false);
         cacheEntry.acquireSharedLock();
 
-        bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-            getChanges(atomicOperation, cacheEntry));
+        bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
       }
     } finally {
       cacheEntry.releaseSharedLock();
@@ -1330,8 +1309,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, bucketIndex, false);
     cacheEntry.acquireSharedLock();
 
-    OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-        getChanges(atomicOperation, cacheEntry));
+    OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
 
     int itemIndex = bucket.size() - 1;
     try {
@@ -1384,8 +1362,7 @@ public class OSBTree<K, V> extends ODurableComponent {
         cacheEntry = loadPage(atomicOperation, fileId, bucketIndex, false);
         cacheEntry.acquireSharedLock();
 
-        bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-            getChanges(atomicOperation, cacheEntry));
+        bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
         if (itemIndex == OSBTreeBucket.MAX_PAGE_SIZE_BYTES + 1)
           itemIndex = bucket.size() - 1;
       }
@@ -1491,8 +1468,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
     bucketEntry.acquireExclusiveLock();
     try {
-      OSBTreeBucket<K, V> bucketToSplit = new OSBTreeBucket<K, V>(bucketEntry, keySerializer, keyTypes, valueSerializer,
-          getChanges(atomicOperation, bucketEntry));
+      OSBTreeBucket<K, V> bucketToSplit = new OSBTreeBucket<K, V>(bucketEntry, keySerializer, keyTypes, valueSerializer);
 
       final boolean splitLeaf = bucketToSplit.isLeaf();
       final int bucketSize = bucketToSplit.size();
@@ -1527,7 +1503,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
     try {
       OSBTreeBucket<K, V> newRightBucket = new OSBTreeBucket<K, V>(rightBucketEntry, splitLeaf, keySerializer, keyTypes,
-          valueSerializer, getChanges(atomicOperation, rightBucketEntry));
+          valueSerializer);
       newRightBucket.addAll(rightEntries);
 
       bucketToSplit.shrink(indexToSplit);
@@ -1544,7 +1520,7 @@ public class OSBTree<K, V> extends ODurableComponent {
           final OCacheEntry rightSiblingBucketEntry = loadPage(atomicOperation, fileId, rightSiblingPageIndex, false);
           rightSiblingBucketEntry.acquireExclusiveLock();
           OSBTreeBucket<K, V> rightSiblingBucket = new OSBTreeBucket<K, V>(rightSiblingBucketEntry, keySerializer, keyTypes,
-              valueSerializer, getChanges(atomicOperation, rightSiblingBucketEntry));
+              valueSerializer);
           try {
             rightSiblingBucket.setLeftSibling(rightBucketEntry.getPageIndex());
           } finally {
@@ -1558,8 +1534,7 @@ public class OSBTree<K, V> extends ODurableComponent {
       OCacheEntry parentCacheEntry = loadPage(atomicOperation, fileId, parentIndex, false);
       parentCacheEntry.acquireExclusiveLock();
       try {
-        OSBTreeBucket<K, V> parentBucket = new OSBTreeBucket<K, V>(parentCacheEntry, keySerializer, keyTypes, valueSerializer,
-            getChanges(atomicOperation, parentCacheEntry));
+        OSBTreeBucket<K, V> parentBucket = new OSBTreeBucket<K, V>(parentCacheEntry, keySerializer, keyTypes, valueSerializer);
         OSBTreeBucket.SBTreeEntry<K, V> parentEntry = new OSBTreeBucket.SBTreeEntry<K, V>(pageIndex,
             rightBucketEntry.getPageIndex(), separationKey, null);
 
@@ -1580,8 +1555,7 @@ public class OSBTree<K, V> extends ODurableComponent {
 
           insertionIndex = bucketSearchResult.itemIndex;
 
-          parentBucket = new OSBTreeBucket<K, V>(parentCacheEntry, keySerializer, keyTypes, valueSerializer,
-              getChanges(atomicOperation, parentCacheEntry));
+          parentBucket = new OSBTreeBucket<K, V>(parentCacheEntry, keySerializer, keyTypes, valueSerializer);
         }
 
       } finally {
@@ -1627,7 +1601,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     leftBucketEntry.acquireExclusiveLock();
     try {
       OSBTreeBucket<K, V> newLeftBucket = new OSBTreeBucket<K, V>(leftBucketEntry, splitLeaf, keySerializer, keyTypes,
-          valueSerializer, getChanges(atomicOperation, leftBucketEntry));
+          valueSerializer);
       newLeftBucket.addAll(leftEntries);
 
       if (splitLeaf)
@@ -1641,7 +1615,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     rightBucketEntry.acquireExclusiveLock();
     try {
       OSBTreeBucket<K, V> newRightBucket = new OSBTreeBucket<K, V>(rightBucketEntry, splitLeaf, keySerializer, keyTypes,
-          valueSerializer, getChanges(atomicOperation, rightBucketEntry));
+          valueSerializer);
       newRightBucket.addAll(rightEntries);
 
       if (splitLeaf)
@@ -1651,8 +1625,7 @@ public class OSBTree<K, V> extends ODurableComponent {
       releasePage(atomicOperation, rightBucketEntry);
     }
 
-    bucketToSplit = new OSBTreeBucket<K, V>(bucketEntry, false, keySerializer, keyTypes, valueSerializer,
-        getChanges(atomicOperation, bucketEntry));
+    bucketToSplit = new OSBTreeBucket<K, V>(bucketEntry, false, keySerializer, keyTypes, valueSerializer);
 
     bucketToSplit.setTreeSize(treeSize);
     bucketToSplit.setValuesFreeListFirstIndex(freeListPage);
@@ -1691,8 +1664,7 @@ public class OSBTree<K, V> extends ODurableComponent {
       bucketEntry.acquireSharedLock();
       final OSBTreeBucket.SBTreeEntry<K, V> entry;
       try {
-        final OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(bucketEntry, keySerializer, keyTypes, valueSerializer,
-            getChanges(atomicOperation, bucketEntry));
+        final OSBTreeBucket<K, V> keyBucket = new OSBTreeBucket<K, V>(bucketEntry, keySerializer, keyTypes, valueSerializer);
         final int index = keyBucket.find(key);
 
         if (keyBucket.isLeaf())
@@ -1752,7 +1724,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, sbTreeValue.getLink(), false);
     cacheEntry.acquireSharedLock();
 
-    OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, getChanges(atomicOperation, cacheEntry), false);
+    OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, false);
 
     int totalSize = valuePage.getSize();
     int currentSize = 0;
@@ -1769,7 +1741,7 @@ public class OSBTree<K, V> extends ODurableComponent {
         cacheEntry = loadPage(atomicOperation, fileId, nextPage, false);
         cacheEntry.acquireSharedLock();
 
-        valuePage = new OSBTreeValuePage(cacheEntry, getChanges(atomicOperation, cacheEntry), false);
+        valuePage = new OSBTreeValuePage(cacheEntry, false);
       }
     }
 
@@ -1904,8 +1876,7 @@ public class OSBTree<K, V> extends ODurableComponent {
               final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
               try {
-                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-                    getChanges(atomicOperation, cacheEntry));
+                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
 
                 if (itemIndex >= bucket.size()) {
                   pageIndex = bucket.getRightSibling();
@@ -2007,8 +1978,7 @@ public class OSBTree<K, V> extends ODurableComponent {
               final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
               try {
-                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-                    getChanges(atomicOperation, cacheEntry));
+                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
 
                 if (itemIndex >= bucket.size()) {
                   pageIndex = bucket.getRightSibling();
@@ -2118,8 +2088,7 @@ public class OSBTree<K, V> extends ODurableComponent {
               final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireSharedLock();
               try {
-                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer,
-                    getChanges(atomicOperation, cacheEntry));
+                final OSBTreeBucket<K, V> bucket = new OSBTreeBucket<K, V>(cacheEntry, keySerializer, keyTypes, valueSerializer);
 
                 if (itemIndex >= bucket.size())
                   itemIndex = bucket.size() - 1;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTreeBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTreeBucket.java
@@ -33,7 +33,6 @@ import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -72,8 +71,8 @@ public class OSBTreeBucket<K, V> extends ODurablePage {
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public OSBTreeBucket(OCacheEntry cacheEntry, boolean isLeaf, OBinarySerializer<K> keySerializer, OType[] keyTypes,
-      OBinarySerializer<V> valueSerializer, OWALChanges changes) throws IOException {
-    super(cacheEntry, changes);
+      OBinarySerializer<V> valueSerializer) throws IOException {
+    super(cacheEntry);
 
     this.isLeaf = isLeaf;
     this.keySerializer = keySerializer;
@@ -96,8 +95,8 @@ public class OSBTreeBucket<K, V> extends ODurablePage {
 
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public OSBTreeBucket(OCacheEntry cacheEntry, OBinarySerializer<K> keySerializer, OType[] keyTypes,
-      OBinarySerializer<V> valueSerializer, OWALChanges changes) {
-    super(cacheEntry, changes);
+      OBinarySerializer<V> valueSerializer) {
+    super(cacheEntry);
     this.keyTypes = keyTypes;
 
     this.isLeaf = getByteValue(IS_LEAF_OFFSET) > 0;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTreeValuePage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTreeValuePage.java
@@ -26,7 +26,6 @@ import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 /**
  * This page will contain value if it exceeds value limit for SBTree. Value is stored as list of linked pages. Following format is
@@ -54,8 +53,8 @@ public class OSBTreeValuePage extends ODurablePage {
 
   public static final int  MAX_BINARY_VALUE_SIZE      = MAX_PAGE_SIZE_BYTES - BINARY_CONTENT_OFFSET;
 
-  public OSBTreeValuePage(OCacheEntry cacheEntry, OWALChanges changes, boolean isNew) throws IOException {
-    super(cacheEntry, changes);
+  public OSBTreeValuePage(OCacheEntry cacheEntry, boolean isNew) throws IOException {
+    super(cacheEntry);
 
     if (isNew) {
       setNextFreeListPage(-1);

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OBonsaiBucketAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OBonsaiBucketAbstract.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 /**
  * A base class for bonsai buckets. Bonsai bucket size is usually less than page size and one page could contain multiple bonsai
@@ -39,8 +38,8 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALCh
  * @author Artem Orobets (enisher-at-gmail.com)
  */
 public class OBonsaiBucketAbstract extends ODurablePage {
-  public OBonsaiBucketAbstract(OCacheEntry cacheEntry, OWALChanges changes) {
-    super(cacheEntry, changes);
+  public OBonsaiBucketAbstract(OCacheEntry cacheEntry) {
+    super(cacheEntry);
   }
 
   /**

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiBucket.java
@@ -28,7 +28,6 @@ import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.exception.OSBTreeBonsaiLocalException;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -137,8 +136,8 @@ public class OSBTreeBonsaiBucket<K, V> extends OBonsaiBucketAbstract {
   }
 
   public OSBTreeBonsaiBucket(OCacheEntry cacheEntry, int pageOffset, boolean isLeaf, OBinarySerializer<K> keySerializer,
-      OBinarySerializer<V> valueSerializer, OWALChanges changes, OSBTreeBonsaiLocal<K, V> tree) throws IOException {
-    super(cacheEntry, changes);
+      OBinarySerializer<V> valueSerializer, OSBTreeBonsaiLocal<K, V> tree) throws IOException {
+    super(cacheEntry);
 
     this.offset = pageOffset;
     this.isLeaf = isLeaf;
@@ -160,8 +159,8 @@ public class OSBTreeBonsaiBucket<K, V> extends OBonsaiBucketAbstract {
   }
 
   public OSBTreeBonsaiBucket(OCacheEntry cacheEntry, int pageOffset, OBinarySerializer<K> keySerializer,
-      OBinarySerializer<V> valueSerializer, OWALChanges changes, OSBTreeBonsaiLocal<K, V> tree) {
-    super(cacheEntry, changes);
+      OBinarySerializer<V> valueSerializer, OSBTreeBonsaiLocal<K, V> tree) {
+    super(cacheEntry);
 
     this.offset = pageOffset;
     this.isLeaf = getByteValue(offset + IS_LEAF_OFFSET) > 0;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
@@ -124,7 +124,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     rootCacheEntry.acquireExclusiveLock();
     try {
       OSBTreeBonsaiBucket<K, V> rootBucket = new OSBTreeBonsaiBucket<K, V>(rootCacheEntry, this.rootBucketPointer.getPageOffset(),
-          true, keySerializer, valueSerializer, getChanges(atomicOperation, rootCacheEntry), this);
+          true, keySerializer, valueSerializer, this);
       rootBucket.setTreeSize(0);
     } finally {
       rootCacheEntry.releaseExclusiveLock();
@@ -190,7 +190,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
           keyBucketCacheEntry.acquireSharedLock();
           try {
             OSBTreeBonsaiBucket<K, V> keyBucket = new OSBTreeBonsaiBucket<K, V>(keyBucketCacheEntry, bucketPointer.getPageOffset(),
-                keySerializer, valueSerializer, getChanges(atomicOperation, keyBucketCacheEntry), this);
+                keySerializer, valueSerializer, this);
             return keyBucket.getEntry(bucketSearchResult.itemIndex).value;
           } finally {
             keyBucketCacheEntry.releaseSharedLock();
@@ -234,7 +234,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         OCacheEntry keyBucketCacheEntry = loadPage(atomicOperation, fileId, bucketPointer.getPageIndex(), false);
         keyBucketCacheEntry.acquireExclusiveLock();
         OSBTreeBonsaiBucket<K, V> keyBucket = new OSBTreeBonsaiBucket<K, V>(keyBucketCacheEntry, bucketPointer.getPageOffset(),
-            keySerializer, valueSerializer, getChanges(atomicOperation, keyBucketCacheEntry), this);
+            keySerializer, valueSerializer, this);
 
         final boolean itemFound = bucketSearchResult.itemIndex >= 0;
         boolean result = true;
@@ -260,7 +260,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
             keyBucketCacheEntry.acquireExclusiveLock();
 
             keyBucket = new OSBTreeBonsaiBucket<K, V>(keyBucketCacheEntry, bucketPointer.getPageOffset(), keySerializer,
-                valueSerializer, getChanges(atomicOperation, keyBucketCacheEntry), this);
+                valueSerializer, this);
           }
         }
 
@@ -337,13 +337,13 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         cacheEntry.acquireExclusiveLock();
         try {
           OSBTreeBonsaiBucket<K, V> rootBucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, rootBucketPointer.getPageOffset(),
-              keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+              keySerializer, valueSerializer, this);
 
           addChildrenToQueue(subTreesToDelete, rootBucket);
 
           rootBucket.shrink(0);
           rootBucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, rootBucketPointer.getPageOffset(), true, keySerializer,
-              valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+              valueSerializer, this);
 
           rootBucket.setTreeSize(0);
         } finally {
@@ -395,7 +395,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
       cacheEntry.acquireExclusiveLock();
       try {
         final OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(),
-            keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+            keySerializer, valueSerializer, this);
 
         addChildrenToQueue(subTreesToDelete, bucket);
 
@@ -412,7 +412,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
       final OCacheEntry sysCacheEntry = loadPage(atomicOperation, fileId, SYS_BUCKET.getPageIndex(), false);
       sysCacheEntry.acquireExclusiveLock();
       try {
-        final OSysBucket sysBucket = new OSysBucket(sysCacheEntry, getChanges(atomicOperation, sysCacheEntry));
+        final OSysBucket sysBucket = new OSysBucket(sysCacheEntry);
 
         attachFreeListHead(tail, sysBucket.getFreeListHead(), atomicOperation);
         sysBucket.setFreeListHead(head);
@@ -431,7 +431,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     cacheEntry.acquireExclusiveLock();
     try {
       final OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(),
-          keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+          keySerializer, valueSerializer, this);
 
       bucket.setFreeListPointer(freeListHead);
     } finally {
@@ -493,8 +493,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         rootCacheEntry.acquireSharedLock();
         try {
           OSBTreeBonsaiBucket<K, V> rootBucket = new OSBTreeBonsaiBucket<K, V>(rootCacheEntry,
-              this.rootBucketPointer.getPageOffset(), keySerializer, valueSerializer, getChanges(atomicOperation, rootCacheEntry),
-              this);
+              this.rootBucketPointer.getPageOffset(), keySerializer, valueSerializer, this);
           keySerializer = (OBinarySerializer<K>) storage.getComponentsFactory().binarySerializerFactory
               .getObjectSerializer(rootBucket.getKeySerializerId());
           valueSerializer = (OBinarySerializer<V>) storage.getComponentsFactory().binarySerializerFactory
@@ -522,7 +521,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     rootCacheEntry.acquireExclusiveLock();
     try {
       OSBTreeBonsaiBucket<K, V> rootBucket = new OSBTreeBonsaiBucket<K, V>(rootCacheEntry, rootBucketPointer.getPageOffset(),
-          keySerializer, valueSerializer, getChanges(atomicOperation, rootCacheEntry), this);
+          keySerializer, valueSerializer, this);
       rootBucket.setTreeSize(size);
     } finally {
       rootCacheEntry.releaseExclusiveLock();
@@ -543,7 +542,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
           rootCacheEntry.acquireSharedLock();
           try {
             OSBTreeBonsaiBucket rootBucket = new OSBTreeBonsaiBucket<K, V>(rootCacheEntry, rootBucketPointer.getPageOffset(),
-                keySerializer, valueSerializer, getChanges(atomicOperation, rootCacheEntry), this);
+                keySerializer, valueSerializer, this);
             return rootBucket.getTreeSize();
           } finally {
             rootCacheEntry.releaseSharedLock();
@@ -593,7 +592,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         keyBucketCacheEntry.acquireExclusiveLock();
         try {
           OSBTreeBonsaiBucket<K, V> keyBucket = new OSBTreeBonsaiBucket<K, V>(keyBucketCacheEntry, bucketPointer.getPageOffset(),
-              keySerializer, valueSerializer, getChanges(atomicOperation, keyBucketCacheEntry), this);
+              keySerializer, valueSerializer, this);
 
           removed = keyBucket.getEntry(bucketSearchResult.itemIndex).value;
 
@@ -679,7 +678,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
             cacheEntry.acquireSharedLock();
             try {
               OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(),
-                  keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+                  keySerializer, valueSerializer, this);
               if (!firstBucket)
                 index = bucket.size() - 1;
 
@@ -781,7 +780,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
             cacheEntry.acquireSharedLock();
             try {
               OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(),
-                  keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+                  keySerializer, valueSerializer, this);
               int bucketSize = bucket.size();
               for (int i = index; i < bucketSize; i++) {
                 if (!listener.addResult(bucket.getEntry(i))) {
@@ -861,7 +860,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
           cacheEntry.acquireSharedLock();
           try {
             OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer,
-                valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+                valueSerializer, this);
 
             while (true) {
               if (bucket.isLeaf()) {
@@ -908,8 +907,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
               cacheEntry = loadPage(atomicOperation, fileId, bucketPointer.getPageIndex(), false);
               cacheEntry.acquireSharedLock();
 
-              bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer, valueSerializer,
-                  getChanges(atomicOperation, cacheEntry), this);
+              bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer, valueSerializer, this);
             }
           } finally {
             cacheEntry.releaseSharedLock();
@@ -951,7 +949,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, bucketPointer.getPageIndex(), false);
           cacheEntry.acquireSharedLock();
           OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer,
-              valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+              valueSerializer, this);
 
           int itemIndex = bucket.size() - 1;
           try {
@@ -999,8 +997,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
               cacheEntry = loadPage(atomicOperation, fileId, bucketPointer.getPageIndex(), false);
               cacheEntry.acquireSharedLock();
 
-              bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer, valueSerializer,
-                  getChanges(atomicOperation, cacheEntry), this);
+              bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(), keySerializer, valueSerializer, this);
               if (itemIndex == OSBTreeBonsaiBucket.MAX_BUCKET_SIZE_BYTES + 1)
                 itemIndex = bucket.size() - 1;
             }
@@ -1072,7 +1069,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
             cacheEntry.acquireSharedLock();
             try {
               OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, bucketPointer.getPageOffset(),
-                  keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+                  keySerializer, valueSerializer, this);
               if (!bucketPointer.equals(bucketPointerTo))
                 endIndex = bucket.size() - 1;
               else
@@ -1144,7 +1141,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     bucketEntry.acquireExclusiveLock();
     try {
       OSBTreeBonsaiBucket<K, V> bucketToSplit = new OSBTreeBonsaiBucket<K, V>(bucketEntry, bucketPointer.getPageOffset(),
-          keySerializer, valueSerializer, getChanges(atomicOperation, bucketEntry), this);
+          keySerializer, valueSerializer, this);
 
       final boolean splitLeaf = bucketToSplit.isLeaf();
       final int bucketSize = bucketToSplit.size();
@@ -1167,8 +1164,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
 
         try {
           OSBTreeBonsaiBucket<K, V> newRightBucket = new OSBTreeBonsaiBucket<K, V>(rightBucketEntry,
-              rightBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer,
-              getChanges(atomicOperation, rightBucketEntry), this);
+              rightBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer, this);
           newRightBucket.addAll(rightEntries);
 
           bucketToSplit.shrink(indexToSplit);
@@ -1187,8 +1183,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
 
               rightSiblingBucketEntry.acquireExclusiveLock();
               OSBTreeBonsaiBucket<K, V> rightSiblingBucket = new OSBTreeBonsaiBucket<K, V>(rightSiblingBucketEntry,
-                  rightSiblingBucketPointer.getPageOffset(), keySerializer, valueSerializer,
-                  getChanges(atomicOperation, rightSiblingBucketEntry), this);
+                  rightSiblingBucketPointer.getPageOffset(), keySerializer, valueSerializer, this);
               try {
                 rightSiblingBucket.setLeftSibling(rightBucketPointer);
               } finally {
@@ -1204,8 +1199,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
           parentCacheEntry.acquireExclusiveLock();
           try {
             OSBTreeBonsaiBucket<K, V> parentBucket = new OSBTreeBonsaiBucket<K, V>(parentCacheEntry,
-                parentBucketPointer.getPageOffset(), keySerializer, valueSerializer, getChanges(atomicOperation, parentCacheEntry),
-                this);
+                parentBucketPointer.getPageOffset(), keySerializer, valueSerializer, this);
             OSBTreeBonsaiBucket.SBTreeEntry<K, V> parentEntry = new OSBTreeBonsaiBucket.SBTreeEntry<K, V>(bucketPointer,
                 rightBucketPointer, separationKey, null);
 
@@ -1228,7 +1222,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
               insertionIndex = bucketSearchResult.itemIndex;
 
               parentBucket = new OSBTreeBonsaiBucket<K, V>(parentCacheEntry, parentBucketPointer.getPageOffset(), keySerializer,
-                  valueSerializer, getChanges(atomicOperation, parentCacheEntry), this);
+                  valueSerializer, this);
             }
 
           } finally {
@@ -1274,8 +1268,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         leftBucketEntry.acquireExclusiveLock();
         try {
           OSBTreeBonsaiBucket<K, V> newLeftBucket = new OSBTreeBonsaiBucket<K, V>(leftBucketEntry,
-              leftBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer,
-              getChanges(atomicOperation, leftBucketEntry), this);
+              leftBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer, this);
           newLeftBucket.addAll(leftEntries);
 
           if (splitLeaf)
@@ -1288,8 +1281,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         rightBucketEntry.acquireExclusiveLock();
         try {
           OSBTreeBonsaiBucket<K, V> newRightBucket = new OSBTreeBonsaiBucket<K, V>(rightBucketEntry,
-              rightBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer,
-              getChanges(atomicOperation, rightBucketEntry), this);
+              rightBucketPointer.getPageOffset(), splitLeaf, keySerializer, valueSerializer, this);
           newRightBucket.addAll(rightEntries);
 
           if (splitLeaf)
@@ -1300,7 +1292,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         }
 
         bucketToSplit = new OSBTreeBonsaiBucket<K, V>(bucketEntry, bucketPointer.getPageOffset(), false, keySerializer,
-            valueSerializer, getChanges(atomicOperation, bucketEntry), this);
+            valueSerializer, this);
         bucketToSplit.setTreeSize(treeSize);
 
         bucketToSplit
@@ -1340,7 +1332,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
       final OSBTreeBonsaiBucket.SBTreeEntry<K, V> entry;
       try {
         final OSBTreeBonsaiBucket<K, V> keyBucket = new OSBTreeBonsaiBucket<K, V>(bucketEntry, bucketPointer.getPageOffset(),
-            keySerializer, valueSerializer, getChanges(atomicOperation, bucketEntry), this);
+            keySerializer, valueSerializer, this);
         final int index = keyBucket.find(key);
 
         if (keyBucket.isLeaf())
@@ -1377,7 +1369,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
 
     sysCacheEntry.acquireExclusiveLock();
     try {
-      OSysBucket sysBucket = new OSysBucket(sysCacheEntry, getChanges(atomicOperation, sysCacheEntry));
+      OSysBucket sysBucket = new OSysBucket(sysCacheEntry);
       if (sysBucket.isInitialized()) {
         sysCacheEntry.releaseExclusiveLock();
         releasePage(atomicOperation, sysCacheEntry);
@@ -1385,7 +1377,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
         sysCacheEntry = loadPage(atomicOperation, fileId, SYS_BUCKET.getPageIndex(), false);
         sysCacheEntry.acquireExclusiveLock();
 
-        sysBucket = new OSysBucket(sysCacheEntry, getChanges(atomicOperation, sysCacheEntry));
+        sysBucket = new OSysBucket(sysCacheEntry);
         sysBucket.init();
       }
     } finally {
@@ -1403,7 +1395,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
 
     sysCacheEntry.acquireExclusiveLock();
     try {
-      final OSysBucket sysBucket = new OSysBucket(sysCacheEntry, getChanges(atomicOperation, sysCacheEntry));
+      final OSysBucket sysBucket = new OSysBucket(sysCacheEntry);
       if ((1.0 * sysBucket.freeListLength()) / ((1.0 * getFilledUpTo(atomicOperation, fileId)) * PAGE_SIZE
           / OSBTreeBonsaiBucket.MAX_BUCKET_SIZE_BYTES) >= freeSpaceReuseTrigger) {
         final AllocationResult allocationResult = reuseBucketFromFreeList(sysBucket, atomicOperation);
@@ -1438,7 +1430,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     cacheEntry.acquireExclusiveLock();
     try {
       final OSBTreeBonsaiBucket<K, V> bucket = new OSBTreeBonsaiBucket<K, V>(cacheEntry, oldFreeListHead.getPageOffset(),
-          keySerializer, valueSerializer, getChanges(atomicOperation, cacheEntry), this);
+          keySerializer, valueSerializer, this);
 
       sysBucket.setFreeListHead(bucket.getFreeListPointer());
       sysBucket.setFreeListLength(sysBucket.freeListLength() - 1);
@@ -1557,7 +1549,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     OSBTreeBonsaiBucket.SBTreeEntry<K, V> entry;
     try {
       final OSBTreeBonsaiBucket<K, V> keyBucket = new OSBTreeBonsaiBucket<K, V>(bucketEntry, bucketPointer.getPageOffset(),
-          keySerializer, valueSerializer, null, this);
+          keySerializer, valueSerializer, this);
       if (keyBucket.isLeaf()) {
         for (int i = 0; i < path.size(); i++)
           writer.append("\t");

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSysBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSysBucket.java
@@ -23,7 +23,6 @@ package com.orientechnologies.orient.core.index.sbtreebonsai.local;
 import com.orientechnologies.common.serialization.types.OByteSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -53,8 +52,8 @@ public class OSysBucket extends OBonsaiBucketAbstract {
    */
   private static final byte SYS_MAGIC               = (byte) 41;
 
-  public OSysBucket(OCacheEntry cacheEntry, OWALChanges changes) {
-    super(cacheEntry, changes);
+  public OSysBucket(OCacheEntry cacheEntry) {
+    super(cacheEntry);
   }
 
   public void init() throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntry.java
@@ -24,128 +24,43 @@ package com.orientechnologies.orient.core.storage.cache;
  * @author Andrey Lomakin
  * @since 7/23/13
  */
-public class OCacheEntry {
-  OCachePointer dataPointer;
+public interface OCacheEntry {
 
-  final long    fileId;
-  final long    pageIndex;
+  void markDirty();
 
-  boolean       dirty;
-  int           usagesCount;
+  void clearDirty();
 
-  public OCacheEntry(long fileId, long pageIndex, OCachePointer dataPointer, boolean dirty) {
-    this.fileId = fileId;
-    this.pageIndex = pageIndex;
+  boolean isDirty();
 
-    this.dataPointer = dataPointer;
-    this.dirty = dirty;
-  }
+  OCachePointer getCachePointer();
 
-  public void markDirty() {
-    this.dirty = true;
-  }
+  void clearCachePointer();
 
-  public void clearDirty() {
-    this.dirty = false;
-  }
+  void setCachePointer(OCachePointer cachePointer);
 
-  public boolean isDirty() {
-    return dirty;
-  }
+  long getFileId();
 
-  public OCachePointer getCachePointer() {
-    return dataPointer;
-  }
+  long getPageIndex();
 
-  public void clearCachePointer() {
-    dataPointer = null;
-  }
+  void acquireExclusiveLock();
 
-  public void setCachePointer(OCachePointer cachePointer) {
-    this.dataPointer = cachePointer;
-  }
+  void releaseExclusiveLock();
 
-  public long getFileId() {
-    return fileId;
-  }
+  void acquireSharedLock();
 
-  public long getPageIndex() {
-    return pageIndex;
-  }
+  void releaseSharedLock();
 
-  public void acquireExclusiveLock() {
-    dataPointer.acquireExclusiveLock();
-  }
+  int getUsagesCount();
 
-  public void releaseExclusiveLock() {
-    dataPointer.releaseExclusiveLock();
-  }
-
-  public void acquireSharedLock() {
-    dataPointer.acquireSharedLock();
-  }
-
-  public void releaseSharedLock() {
-    dataPointer.releaseSharedLock();
-  }
-
-  public int getUsagesCount() {
-    return usagesCount;
-  }
-
-  public void incrementUsages() {
-    usagesCount++;
-  }
+  void incrementUsages();
 
   /**
    * DEBUG only !!
    *
    * @return Whether lock acquired on current entry
    */
-  public boolean isLockAcquiredByCurrentThread() {
-    return dataPointer.isLockAcquiredByCurrentThread();
-  }
+  boolean isLockAcquiredByCurrentThread();
 
-  public void decrementUsages() {
-    usagesCount--;
-  }
+  void decrementUsages();
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
-
-    OCacheEntry that = (OCacheEntry) o;
-
-    if (fileId != that.fileId)
-      return false;
-    if (dirty != that.dirty)
-      return false;
-    if (pageIndex != that.pageIndex)
-      return false;
-    if (usagesCount != that.usagesCount)
-      return false;
-    if (dataPointer != null ? !dataPointer.equals(that.dataPointer) : that.dataPointer != null)
-      return false;
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = (int) (fileId ^ (fileId >>> 32));
-    result = 31 * result + (int) (pageIndex ^ (pageIndex >>> 32));
-    result = 31 * result + (dataPointer != null ? dataPointer.hashCode() : 0);
-    result = 31 * result + (dirty ? 1 : 0);
-    result = 31 * result + usagesCount;
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "OReadCacheEntry{" + "fileId=" + fileId + ", pageIndex=" + pageIndex + ", dataPointer=" + dataPointer + ", dirty="
-        + dirty + ", usagesCount=" + usagesCount + '}';
-  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntry.java
@@ -20,6 +20,8 @@
 
 package com.orientechnologies.orient.core.storage.cache;
 
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
+
 /**
  * @author Andrey Lomakin
  * @since 7/23/13
@@ -62,5 +64,7 @@ public interface OCacheEntry {
   boolean isLockAcquiredByCurrentThread();
 
   void decrementUsages();
+
+  OWALChanges getChanges();
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntryImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntryImpl.java
@@ -1,0 +1,130 @@
+package com.orientechnologies.orient.core.storage.cache;
+
+/**
+ * Created by tglman on 23/06/16.
+ */
+public class OCacheEntryImpl implements OCacheEntry{
+  OCachePointer dataPointer;
+  final long    fileId;
+  final long    pageIndex;
+
+  boolean       dirty;
+  int           usagesCount;
+
+  public OCacheEntryImpl(long fileId, long pageIndex, OCachePointer dataPointer, boolean dirty) {
+    this.fileId = fileId;
+    this.pageIndex = pageIndex;
+
+    this.dataPointer = dataPointer;
+    this.dirty = dirty;
+  }
+
+  public void markDirty() {
+    this.dirty = true;
+  }
+
+  public void clearDirty() {
+    this.dirty = false;
+  }
+
+  public boolean isDirty() {
+    return dirty;
+  }
+
+  public OCachePointer getCachePointer() {
+    return dataPointer;
+  }
+
+  public void clearCachePointer() {
+    dataPointer = null;
+  }
+
+  public void setCachePointer(OCachePointer cachePointer) {
+    this.dataPointer = cachePointer;
+  }
+
+  public long getFileId() {
+    return fileId;
+  }
+
+  public long getPageIndex() {
+    return pageIndex;
+  }
+
+  public void acquireExclusiveLock() {
+    dataPointer.acquireExclusiveLock();
+  }
+
+  public void releaseExclusiveLock() {
+    dataPointer.releaseExclusiveLock();
+  }
+
+  public void acquireSharedLock() {
+    dataPointer.acquireSharedLock();
+  }
+
+  public void releaseSharedLock() {
+    dataPointer.releaseSharedLock();
+  }
+
+  public int getUsagesCount() {
+    return usagesCount;
+  }
+
+  public void incrementUsages() {
+    usagesCount++;
+  }
+
+  /**
+   * DEBUG only !!
+   *
+   * @return Whether lock acquired on current entry
+   */
+  public boolean isLockAcquiredByCurrentThread() {
+    return dataPointer.isLockAcquiredByCurrentThread();
+  }
+
+  public void decrementUsages() {
+    usagesCount--;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+
+    OCacheEntryImpl that = (OCacheEntryImpl) o;
+
+    if (fileId != that.fileId)
+      return false;
+    if (dirty != that.dirty)
+      return false;
+    if (pageIndex != that.pageIndex)
+      return false;
+    if (usagesCount != that.usagesCount)
+      return false;
+    if (dataPointer != null ? !dataPointer.equals(that.dataPointer) : that.dataPointer != null)
+      return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (fileId ^ (fileId >>> 32));
+    result = 31 * result + (int) (pageIndex ^ (pageIndex >>> 32));
+    result = 31 * result + (dataPointer != null ? dataPointer.hashCode() : 0);
+    result = 31 * result + (dirty ? 1 : 0);
+    result = 31 * result + usagesCount;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "OReadCacheEntry{" + "fileId=" + fileId + ", pageIndex=" + pageIndex + ", dataPointer=" + dataPointer + ", dirty="
+        + dirty + ", usagesCount=" + usagesCount + '}';
+  }
+
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntryImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OCacheEntryImpl.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.storage.cache;
 
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
+
 /**
  * Created by tglman on 23/06/16.
  */
@@ -86,6 +88,11 @@ public class OCacheEntryImpl implements OCacheEntry{
 
   public void decrementUsages() {
     usagesCount--;
+  }
+
+  @Override
+  public OWALChanges getChanges() {
+    return null;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/twoq/O2QCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/twoq/O2QCache.java
@@ -821,7 +821,7 @@ public class O2QCache implements OReadCache {
       final long pageIndex = dataInputStream.readLong();
       try {
         final long fileId = writeCache.externalFileId(internalFileId);
-        final OCacheEntry cacheEntry = new OCacheEntry(fileId, pageIndex, null, false);
+        final OCacheEntry cacheEntry = new OCacheEntryImpl(fileId, pageIndex, null, false);
 
         Set<Long> pages = filePages.get(fileId);
         if (pages == null) {
@@ -871,7 +871,7 @@ public class O2QCache implements OReadCache {
       final long pageIndex = dataInputStream.readLong();
       try {
         final long fileId = writeCache.externalFileId(internalFileId);
-        final OCacheEntry entry = new OCacheEntry(fileId, pageIndex, null, false);
+        final OCacheEntry entry = new OCacheEntryImpl(fileId, pageIndex, null, false);
         filePositionMap.put(new PageKey(fileId, pageIndex), new OPair<Long, OCacheEntry>(position, entry));
         queuePositionMap.put(position, entry);
 
@@ -1152,7 +1152,7 @@ public class O2QCache implements OReadCache {
 
   private UpdateCacheResult entryIsAbsentInQueues(long fileId, long pageIndex, OCachePointer dataPointer) {
     OCacheEntry cacheEntry;
-    cacheEntry = new OCacheEntry(fileId, pageIndex, dataPointer, false);
+    cacheEntry = new OCacheEntryImpl(fileId, pageIndex, dataPointer, false);
     a1in.putToMRU(cacheEntry);
 
     Set<Long> pages = filePages.get(fileId);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -4048,7 +4048,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         final OCachePointer cachePointer = cacheEntry.getCachePointer();
         cachePointer.acquireExclusiveLock();
         try {
-          ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+          ODurablePage durablePage = new ODurablePage(cacheEntry);
           durablePage.restoreChanges(updatePageRecord.getChanges());
           durablePage.setLsn(updatePageRecord.getLsn());
         } finally {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPage.java
@@ -27,7 +27,6 @@ import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.record.ORecordVersionHelper;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,8 +59,8 @@ public class OClusterPage extends ODurablePage {
 
   public static final int MAX_RECORD_SIZE = MAX_ENTRY_SIZE - 3 * OIntegerSerializer.INT_SIZE;
 
-  public OClusterPage(OCacheEntry cacheEntry, boolean newPage, OWALChanges changes) throws IOException {
-    super(cacheEntry, changes);
+  public OClusterPage(OCacheEntry cacheEntry, boolean newPage) throws IOException {
+    super(cacheEntry);
 
     if (newPage) {
       setLongValue(NEXT_PAGE_OFFSET, -1);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
@@ -204,7 +204,7 @@ public class OClusterPositionMap extends ODurableComponent {
         cacheEntry.acquireExclusiveLock();
         try {
 
-          OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+          OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
           if (bucket.isFull()) {
             cacheEntry.releaseExclusiveLock();
             releasePage(atomicOperation, cacheEntry);
@@ -212,7 +212,7 @@ public class OClusterPositionMap extends ODurableComponent {
             cacheEntry = addPage(atomicOperation, fileId);
 
             cacheEntry.acquireExclusiveLock();
-            bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+            bucket = new OClusterPositionMapBucket(cacheEntry);
           }
 
           final long index = bucket.add(pageIndex, recordPosition);
@@ -253,7 +253,7 @@ public class OClusterPositionMap extends ODurableComponent {
         cacheEntry.acquireExclusiveLock();
         try {
 
-          OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+          OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
           if (bucket.isFull()) {
             cacheEntry.releaseExclusiveLock();
             releasePage(atomicOperation, cacheEntry);
@@ -261,7 +261,7 @@ public class OClusterPositionMap extends ODurableComponent {
             cacheEntry = addPage(atomicOperation, fileId);
 
             cacheEntry.acquireExclusiveLock();
-            bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+            bucket = new OClusterPositionMapBucket(cacheEntry);
           }
 
           final long index = bucket.allocate();
@@ -302,8 +302,7 @@ public class OClusterPositionMap extends ODurableComponent {
         final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
         cacheEntry.acquireExclusiveLock();
         try {
-          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry,
-              getChanges(atomicOperation, cacheEntry));
+          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
           bucket.set(index, entry);
         } finally {
           cacheEntry.releaseExclusiveLock();
@@ -344,8 +343,7 @@ public class OClusterPositionMap extends ODurableComponent {
         final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
         cacheEntry.acquireExclusiveLock();
         try {
-          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry,
-              getChanges(atomicOperation, cacheEntry));
+          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
           bucket.resurrect(index, entry);
         } finally {
           cacheEntry.releaseExclusiveLock();
@@ -387,8 +385,7 @@ public class OClusterPositionMap extends ODurableComponent {
           final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, pageCount);
           cacheEntry.acquireSharedLock();
           try {
-            final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry,
-                getChanges(atomicOperation, cacheEntry));
+            final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
             return bucket.get(index);
           } finally {
             cacheEntry.releaseSharedLock();
@@ -418,8 +415,7 @@ public class OClusterPositionMap extends ODurableComponent {
         final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
         cacheEntry.acquireExclusiveLock();
         try {
-          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry,
-              getChanges(atomicOperation, cacheEntry));
+          final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
 
           OClusterPositionMapBucket.PositionEntry positionEntry = bucket.remove(index);
           if (positionEntry == null) {
@@ -492,7 +488,7 @@ public class OClusterPositionMap extends ODurableComponent {
             OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
             cacheEntry.acquireSharedLock();
 
-            OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+            OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
             int resultSize = bucket.getSize() - index;
 
             if (resultSize <= 0) {
@@ -592,7 +588,7 @@ public class OClusterPositionMap extends ODurableComponent {
             OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
             cacheEntry.acquireSharedLock();
 
-            OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+            OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
             if (index == Integer.MIN_VALUE)
               index = bucket.getSize() - 1;
 
@@ -649,7 +645,7 @@ public class OClusterPositionMap extends ODurableComponent {
             OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
             cacheEntry.acquireSharedLock();
             try {
-              OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+              OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
               int bucketSize = bucket.getSize();
 
               for (int index = 0; index < bucketSize; index++) {
@@ -692,8 +688,7 @@ public class OClusterPositionMap extends ODurableComponent {
           final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
           cacheEntry.acquireSharedLock();
           try {
-            final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry,
-                getChanges(atomicOperation, cacheEntry));
+            final OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
 
             return bucket.getStatus(index);
 
@@ -726,7 +721,7 @@ public class OClusterPositionMap extends ODurableComponent {
             OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, 1);
             cacheEntry.acquireSharedLock();
             try {
-              OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry, getChanges(atomicOperation, cacheEntry));
+              OClusterPositionMapBucket bucket = new OClusterPositionMapBucket(cacheEntry);
               final int bucketSize = bucket.getSize();
 
               for (int index = bucketSize - 1; index >= 0; index--) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMapBucket.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMapBucket.java
@@ -26,7 +26,6 @@ import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -49,8 +48,8 @@ public class OClusterPositionMapBucket extends ODurablePage {
 
   public static final int  MAX_ENTRIES      = (MAX_PAGE_SIZE_BYTES - POSITIONS_OFFSET) / ENTRY_SIZE;
 
-  public OClusterPositionMapBucket(OCacheEntry cacheEntry, OWALChanges changes) {
-    super(cacheEntry, changes);
+  public OClusterPositionMapBucket(OCacheEntry cacheEntry) {
+    super(cacheEntry);
   }
 
   public int add(long pageIndex, int recordPosition) throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
@@ -537,8 +537,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
                 final OCacheEntry prevPageCacheEntry = loadPage(atomicOperation, fileId, prevPageIndex, false);
                 prevPageCacheEntry.acquireExclusiveLock();
                 try {
-                  final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false,
-                      getChanges(atomicOperation, prevPageCacheEntry));
+                  final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false);
                   prevPage.setRecordLongValue(prevPageRecordPosition, -OLongSerializer.LONG_SIZE, addedPagePointer);
                 } finally {
                   prevPageCacheEntry.releaseExclusiveLock();
@@ -649,7 +648,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
     final OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, pageCount);
     cacheEntry.acquireSharedLock();
     try {
-      final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+      final OClusterPage localPage = new OClusterPage(cacheEntry, false);
       if (localPage.isDeleted(recordPosition))
         return null;
 
@@ -705,7 +704,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+            final OClusterPage localPage = new OClusterPage(cacheEntry, false);
             if (localPage.isDeleted(recordPosition))
               throw new ORecordNotFoundException(new ORecordId(id, clusterPosition),
                   "Record for cluster with id " + id + " and position " + clusterPosition + " is absent.");
@@ -763,7 +762,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           cacheEntry.acquireExclusiveLock();
           int initialFreePageIndex;
           try {
-            OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+            OClusterPage localPage = new OClusterPage(cacheEntry, false);
             initialFreePageIndex = calculateFreePageIndex(localPage);
 
             if (localPage.isDeleted(recordPosition)) {
@@ -780,7 +779,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
               cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
               cacheEntry.acquireExclusiveLock();
 
-              localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+              localPage = new OClusterPage(cacheEntry, false);
             }
 
             byte[] content = localPage.getRecordBinaryValue(recordPosition, 0, localPage.getRecordSize(recordPosition));
@@ -968,7 +967,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
 
           cacheEntry.acquireExclusiveLock();
           try {
-            final OClusterPage localPage = new OClusterPage(cacheEntry, isNew, getChanges(atomicOperation, cacheEntry));
+            final OClusterPage localPage = new OClusterPage(cacheEntry, isNew);
             final int pageFreeSpace = localPage.getFreeSpace();
 
             if (freePageIndex < 0)
@@ -1036,7 +1035,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
               OCacheEntry prevCacheEntry = loadPage(atomicOperation, fileId, prevPageIndex, false);
               prevCacheEntry.acquireExclusiveLock();
               try {
-                OClusterPage prevPage = new OClusterPage(prevCacheEntry, false, getChanges(atomicOperation, prevCacheEntry));
+                OClusterPage prevPage = new OClusterPage(prevCacheEntry, false);
                 prevPage.setRecordLongValue(prevRecordPosition, -OLongSerializer.LONG_SIZE,
                     createPagePointer(cacheEntry.getPageIndex(), updatedEntryPosition));
               } finally {
@@ -1063,7 +1062,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, nextPageIndex, false);
           cacheEntry.acquireExclusiveLock();
           try {
-            final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+            final OClusterPage localPage = new OClusterPage(cacheEntry, false);
             freeSpace = localPage.getFreeSpace();
             freePagesIndex = calculateFreePageIndex(localPage);
 
@@ -1217,8 +1216,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
                 final OCacheEntry prevPageCacheEntry = loadPage(atomicOperation, fileId, prevPageIndex, false);
                 prevPageCacheEntry.acquireExclusiveLock();
                 try {
-                  final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false,
-                      getChanges(atomicOperation, prevPageCacheEntry));
+                  final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false);
                   prevPage.setRecordLongValue(prevPageRecordPosition, -OLongSerializer.LONG_SIZE, addedPagePointer);
                 } finally {
                   prevPageCacheEntry.releaseExclusiveLock();
@@ -1327,7 +1325,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
           cacheEntry.acquireSharedLock();
           try {
-            final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+            final OClusterPage localPage = new OClusterPage(cacheEntry, false);
             if (localPage.isDeleted(recordPosition))
               return null;
 
@@ -1369,7 +1367,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           final OCacheEntry pinnedStateEntry = loadPage(atomicOperation, fileId, pinnedStateEntryIndex, true);
           pinnedStateEntry.acquireSharedLock();
           try {
-            return new OPaginatedClusterState(pinnedStateEntry, getChanges(atomicOperation, pinnedStateEntry)).getSize();
+            return new OPaginatedClusterState(pinnedStateEntry).getSize();
           } finally {
             pinnedStateEntry.releaseSharedLock();
             releasePage(atomicOperation, pinnedStateEntry);
@@ -1495,7 +1493,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           final OCacheEntry pinnedStateEntry = loadPage(atomicOperation, fileId, pinnedStateEntryIndex, true);
           pinnedStateEntry.acquireSharedLock();
           try {
-            return new OPaginatedClusterState(pinnedStateEntry, getChanges(atomicOperation, pinnedStateEntry)).getRecordsSize();
+            return new OPaginatedClusterState(pinnedStateEntry).getRecordsSize();
           } finally {
             pinnedStateEntry.releaseSharedLock();
             releasePage(atomicOperation, pinnedStateEntry);
@@ -1700,8 +1698,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
     final OCacheEntry pinnedStateEntry = loadPage(atomicOperation, fileId, pinnedStateEntryIndex, true);
     pinnedStateEntry.acquireExclusiveLock();
     try {
-      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry,
-          getChanges(atomicOperation, pinnedStateEntry));
+      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry);
       paginatedClusterState.setSize(paginatedClusterState.getSize() + sizeDiff);
       paginatedClusterState.setRecordsSize(paginatedClusterState.getRecordsSize() + recordsSizeDiff);
     } finally {
@@ -1816,7 +1813,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
       OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false, pageCount);
       cacheEntry.acquireSharedLock();
       try {
-        final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+        final OClusterPage localPage = new OClusterPage(cacheEntry, false);
 
         if (localPage.isDeleted(recordPosition)) {
           if (recordChunks.isEmpty())
@@ -1891,7 +1888,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
     final int finalVersion;
 
     try {
-      final OClusterPage localPage = new OClusterPage(cacheEntry, newRecord, getChanges(atomicOperation, cacheEntry));
+      final OClusterPage localPage = new OClusterPage(cacheEntry, newRecord);
       assert newRecord || freePageIndex == calculateFreePageIndex(localPage);
 
       int initialFreeSpace = localPage.getFreeSpace();
@@ -1923,8 +1920,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         if (freePageIndex < 0)
           freePageIndex = 0;
 
-        OPaginatedClusterState freePageLists = new OPaginatedClusterState(pinnedStateEntry,
-            getChanges(atomicOperation, pinnedStateEntry));
+        OPaginatedClusterState freePageLists = new OPaginatedClusterState(pinnedStateEntry);
         long pageIndex;
         do {
           pageIndex = freePageLists.getFreeListPage(freePageIndex);
@@ -1941,7 +1937,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           cacheEntry.acquireSharedLock();
           int realFreePageIndex;
           try {
-            OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+            OClusterPage localPage = new OClusterPage(cacheEntry, false);
             realFreePageIndex = calculateFreePageIndex(localPage);
           } finally {
             cacheEntry.releaseSharedLock();
@@ -1971,7 +1967,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
 
     cacheEntry.acquireExclusiveLock();
     try {
-      final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+      final OClusterPage localPage = new OClusterPage(cacheEntry, false);
       int newFreePageIndex = calculateFreePageIndex(localPage);
 
       if (prevFreePageIndex == newFreePageIndex)
@@ -1984,8 +1980,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         final OCacheEntry prevPageCacheEntry = loadPage(atomicOperation, fileId, prevPageIndex, false);
         prevPageCacheEntry.acquireExclusiveLock();
         try {
-          final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false,
-              getChanges(atomicOperation, prevPageCacheEntry));
+          final OClusterPage prevPage = new OClusterPage(prevPageCacheEntry, false);
           assert calculateFreePageIndex(prevPage) == prevFreePageIndex;
           prevPage.setNextPage(nextPageIndex);
         } finally {
@@ -1998,8 +1993,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         final OCacheEntry nextPageCacheEntry = loadPage(atomicOperation, fileId, nextPageIndex, false);
         nextPageCacheEntry.acquireExclusiveLock();
         try {
-          final OClusterPage nextPage = new OClusterPage(nextPageCacheEntry, false,
-              getChanges(atomicOperation, nextPageCacheEntry));
+          final OClusterPage nextPage = new OClusterPage(nextPageCacheEntry, false);
           if (calculateFreePageIndex(nextPage) != prevFreePageIndex)
             calculateFreePageIndex(nextPage);
 
@@ -2028,8 +2022,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         OCacheEntry pinnedStateEntry = loadPage(atomicOperation, fileId, pinnedStateEntryIndex, true);
         pinnedStateEntry.acquireSharedLock();
         try {
-          OPaginatedClusterState clusterFreeList = new OPaginatedClusterState(pinnedStateEntry,
-              getChanges(atomicOperation, pinnedStateEntry));
+          OPaginatedClusterState clusterFreeList = new OPaginatedClusterState(pinnedStateEntry);
           oldFreePage = clusterFreeList.getFreeListPage(newFreePageIndex);
         } finally {
           pinnedStateEntry.releaseSharedLock();
@@ -2040,8 +2033,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
           final OCacheEntry oldFreePageCacheEntry = loadPage(atomicOperation, fileId, oldFreePage, false);
           oldFreePageCacheEntry.acquireExclusiveLock();
           try {
-            final OClusterPage oldFreeLocalPage = new OClusterPage(oldFreePageCacheEntry, false,
-                getChanges(atomicOperation, oldFreePageCacheEntry));
+            final OClusterPage oldFreeLocalPage = new OClusterPage(oldFreePageCacheEntry, false);
             assert calculateFreePageIndex(oldFreeLocalPage) == newFreePageIndex;
 
             oldFreeLocalPage.setPrevPage(pageIndex);
@@ -2066,8 +2058,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
     final OCacheEntry pinnedStateEntry = loadPage(atomicOperation, fileId, pinnedStateEntryIndex, true);
     pinnedStateEntry.acquireExclusiveLock();
     try {
-      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry,
-          getChanges(atomicOperation, pinnedStateEntry));
+      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry);
       paginatedClusterState.setFreeListPage(freeListIndex, pageIndex);
     } finally {
       pinnedStateEntry.releaseExclusiveLock();
@@ -2091,8 +2082,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
     OCacheEntry pinnedStateEntry = addPage(atomicOperation, fileId);
     pinnedStateEntry.acquireExclusiveLock();
     try {
-      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry,
-          getChanges(atomicOperation, pinnedStateEntry));
+      OPaginatedClusterState paginatedClusterState = new OPaginatedClusterState(pinnedStateEntry);
 
       pinPage(atomicOperation, pinnedStateEntry);
       paginatedClusterState.setSize(0);
@@ -2161,7 +2151,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         OCacheEntry cacheEntry = loadPage(atomicOperation, fileId, pageIndex, false);
         cacheEntry.acquireSharedLock();
         try {
-          final OClusterPage localPage = new OClusterPage(cacheEntry, false, getChanges(atomicOperation, cacheEntry));
+          final OClusterPage localPage = new OClusterPage(cacheEntry, false);
 
           if (localPage.isDeleted(recordPosition)) {
             if (debug.pages.isEmpty()) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedClusterState.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedClusterState.java
@@ -23,7 +23,6 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 
 import java.io.IOException;
 
@@ -36,8 +35,8 @@ public class OPaginatedClusterState extends ODurablePage {
   private static final int SIZE_OFFSET         = RECORDS_SIZE_OFFSET + OLongSerializer.LONG_SIZE;
   private static final int FREE_LIST_OFFSET    = SIZE_OFFSET + OLongSerializer.LONG_SIZE;
 
-  public OPaginatedClusterState(OCacheEntry cacheEntry, OWALChanges changes) {
-    super(cacheEntry, changes);
+  public OPaginatedClusterState(OCacheEntry cacheEntry) {
+    super(cacheEntry);
   }
 
   public void setSize(long size) throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperation.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperation.java
@@ -206,21 +206,6 @@ public class OAtomicOperation {
     }
   }
 
-  public OWALChanges getChanges(long fileId, long pageIndex) {
-    fileId = checkFileIdCompatibilty(fileId, storageId);
-
-    if (deletedFiles.contains(fileId))
-      throw new OStorageException("File with id " + fileId + " is deleted.");
-
-    final FileChanges changesContainer = fileChanges.get(fileId);
-    assert changesContainer != null;
-
-    final OCacheEntryChanges pageChangesContainer = changesContainer.pageChangesMap.get(pageIndex);
-    assert pageChangesContainer != null;
-
-    return pageChangesContainer.changes;
-  }
-
   public long filledUpTo(long fileId) throws IOException {
     fileId = checkFileIdCompatibilty(fileId, storageId);
 
@@ -436,7 +421,7 @@ public class OAtomicOperation {
 
           cacheEntry.acquireExclusiveLock();
           try {
-            ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+            ODurablePage durablePage = new ODurablePage(cacheEntry);
             durablePage.restoreChanges(filePageChanges.changes);
 
             durablePage.setLsn(filePageChanges.lsn);
@@ -620,7 +605,7 @@ public class OAtomicOperation {
 
             cacheEntry.acquireExclusiveLock();
             try {
-              ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+              ODurablePage durablePage = new ODurablePage(cacheEntry);
               durablePage.restoreChanges(filePageChanges.changes);
 
               durablePage.setLsn(filePageChanges.lsn);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperation.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperation.java
@@ -23,10 +23,7 @@ import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.OUncompletedCommit;
 import com.orientechnologies.orient.core.exception.OStorageException;
-import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
-import com.orientechnologies.orient.core.storage.cache.OCachePointer;
-import com.orientechnologies.orient.core.storage.cache.OReadCache;
-import com.orientechnologies.orient.core.storage.cache.OWriteCache;
+import com.orientechnologies.orient.core.storage.cache.*;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.*;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OPerformanceStatisticManager;
@@ -99,7 +96,7 @@ public class OAtomicOperation {
 
     if (changesContainer.isNew) {
       if (pageIndex <= changesContainer.maxNewPageIndex)
-        return new OCacheEntry(fileId, pageIndex, new OCachePointer(null, null, new OLogSequenceNumber(-1, -1), fileId, pageIndex),
+        return new OCacheEntryImpl(fileId, pageIndex, new OCachePointer(null, null, new OLogSequenceNumber(-1, -1), fileId, pageIndex),
             false);
       else
         return null;
@@ -115,7 +112,7 @@ public class OAtomicOperation {
         }
 
         if (pageChangesContainer.isNew)
-          return new OCacheEntry(fileId, pageIndex,
+          return new OCacheEntryImpl(fileId, pageIndex,
               new OCachePointer(null, null, new OLogSequenceNumber(-1, -1), fileId, pageIndex), false);
         else
           return readCache.load(fileId, pageIndex, checkPinnedPages, writeCache, pageCount);
@@ -184,7 +181,7 @@ public class OAtomicOperation {
     changesContainer.pageChangesMap.put(filledUpTo, pageChangesContainer);
     changesContainer.maxNewPageIndex = filledUpTo;
 
-    return new OCacheEntry(fileId, filledUpTo, new OCachePointer(null, null, new OLogSequenceNumber(-1, -1), fileId, filledUpTo),
+    return new OCacheEntryImpl(fileId, filledUpTo, new OCachePointer(null, null, new OLogSequenceNumber(-1, -1), fileId, filledUpTo),
         false);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
@@ -17,6 +17,9 @@ public class OCacheEntryChanges implements OCacheEntry {
   protected boolean            isNew   = false;
   protected boolean            pinPage = false;
 
+  public OCacheEntryChanges(OCacheEntry entry) {
+    delegate = entry;
+  }
   public OCacheEntryChanges(){
 
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
@@ -1,0 +1,115 @@
+package com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations;
+
+import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCachePointer;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALPageChangesPortion;
+
+/**
+ * Created by tglman on 23/06/16.
+ */
+public class OCacheEntryChanges implements OCacheEntry {
+
+  protected OCacheEntry delegate;
+  protected OWALChanges changes = new OWALPageChangesPortion();
+  protected OLogSequenceNumber lsn     = null;
+  protected boolean            isNew   = false;
+  protected boolean            pinPage = false;
+
+  public OCacheEntryChanges(){
+
+  }
+
+  @Override
+  public void markDirty() {
+    delegate.markDirty();
+  }
+
+  @Override
+  public void clearDirty() {
+    delegate.clearDirty();
+  }
+
+  @Override
+  public boolean isDirty() {
+    return delegate.isDirty();
+  }
+
+  @Override
+  public OCachePointer getCachePointer() {
+    return delegate.getCachePointer();
+  }
+
+  @Override
+  public void clearCachePointer() {
+    delegate.clearCachePointer();
+  }
+
+  @Override
+  public void setCachePointer(OCachePointer cachePointer) {
+    delegate.setCachePointer(cachePointer);
+  }
+
+  @Override
+  public long getFileId() {
+    return delegate.getFileId();
+  }
+
+  @Override
+  public long getPageIndex() {
+    return delegate.getPageIndex();
+  }
+
+  @Override
+  public void acquireExclusiveLock() {
+    delegate.acquireExclusiveLock();
+  }
+
+  @Override
+  public void releaseExclusiveLock() {
+    delegate.releaseExclusiveLock();
+  }
+
+  @Override
+  public void acquireSharedLock() {
+    delegate.acquireSharedLock();
+  }
+
+  @Override
+  public void releaseSharedLock() {
+    delegate.releaseSharedLock();
+  }
+
+  @Override
+  public int getUsagesCount() {
+    return delegate.getUsagesCount();
+  }
+
+  @Override
+  public void incrementUsages() {
+    delegate.incrementUsages();
+  }
+
+  @Override
+  public boolean isLockAcquiredByCurrentThread() {
+    return delegate.isLockAcquiredByCurrentThread();
+  }
+
+  @Override
+  public void decrementUsages() {
+    delegate.decrementUsages();
+  }
+
+  public OWALChanges getChanges() {
+    return changes;
+  }
+
+  public void setDelegate(OCacheEntry delegate) {
+    this.delegate = delegate;
+  }
+
+  public OCacheEntry getDelegate() {
+    return delegate;
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
@@ -123,13 +123,6 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
     return atomicOperationsManager.startAtomicOperation(this, trackNonTxOperations);
   }
 
-  protected OWALChanges getChanges(OAtomicOperation atomicOperation, OCacheEntry entry) {
-    if (atomicOperation == null)
-      return null;
-
-    return entry.getChanges();
-  }
-
   protected long getFilledUpTo(OAtomicOperation atomicOperation, long fileId) throws IOException {
     if (atomicOperation == null)
       return writeCache.getFilledUpTo(fileId);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
@@ -127,7 +127,7 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
     if (atomicOperation == null)
       return null;
 
-    return atomicOperation.getChanges(entry.getFileId(), entry.getPageIndex());
+    return entry.getChanges();
   }
 
   protected long getFilledUpTo(OAtomicOperation atomicOperation, long fileId) throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
@@ -72,7 +72,7 @@ public class ODurablePage {
 
   private final OCachePointer pointer;
 
-  public ODurablePage(OCacheEntry cacheEntry, OWALChanges changes) {
+  public ODurablePage(OCacheEntry cacheEntry) {
     assert cacheEntry != null || changes != null;
 
     this.cacheEntry = cacheEntry;
@@ -82,7 +82,7 @@ public class ODurablePage {
     } else
       this.pointer = null;
 
-    this.changes = changes;
+    this.changes = cacheEntry.getChanges();
   }
 
   public static OLogSequenceNumber getLogSequenceNumberFromPage(ByteBuffer buffer) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
@@ -485,7 +485,7 @@ public class ODirectMemoryOnlyDiskCache extends OAbstractWriteCache implements O
           final OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(-1, -1), id, index);
           cachePointer.incrementReferrer();
 
-          cacheEntry = new OCacheEntry(composeFileId(storageId, id), index, cachePointer, false);
+          cacheEntry = new OCacheEntryImpl(composeFileId(storageId, id), index, cachePointer, false);
 
           OCacheEntry oldCacheEntry = content.putIfAbsent(index, cacheEntry);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableWALTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableWALTest.java
@@ -287,7 +287,7 @@ public class OLocalHashTableWALTest extends OLocalHashTableTest {
 
             cacheEntry.acquireExclusiveLock();
             try {
-              ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+              ODurablePage durablePage = new ODurablePage(cacheEntry);
               durablePage.restoreChanges(updatePageRecord.getChanges());
               durablePage.setLsn(updatePageRecord.getLsn());
             } finally {

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/ConcurrentLRUListConcurrentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/ConcurrentLRUListConcurrentTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.local.twoq.ConcurrentLRUList;
 import com.orientechnologies.orient.core.storage.cache.local.twoq.LRUList;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
@@ -127,7 +128,7 @@ public class ConcurrentLRUListConcurrentTest {
         @Override
         public Integer call() throws Exception {
           for (int i = 0; i < AMOUNT_OF_OPERATIONS; i++) {
-            list.putToMRU(new OCacheEntry(threadNumber, i, null, false));
+            list.putToMRU(new OCacheEntryImpl(threadNumber, i, null, false));
           }
           return AMOUNT_OF_OPERATIONS;
         }
@@ -166,7 +167,7 @@ public class ConcurrentLRUListConcurrentTest {
         public Integer call() throws Exception {
           Random r = new Random();
           for (int i = 0; i < AMOUNT_OF_OPERATIONS; i++) {
-            list.putToMRU(new OCacheEntry(0, r.nextInt(200), null, false));
+            list.putToMRU(new OCacheEntryImpl(0, r.nextInt(200), null, false));
             consumeCPU(r.nextInt(500) + 1000);
           }
           return AMOUNT_OF_OPERATIONS;
@@ -185,7 +186,7 @@ public class ConcurrentLRUListConcurrentTest {
         public Integer call() throws Exception {
           Random r = new Random();
           for (int i = 0; i < AMOUNT_OF_OPERATIONS; i++) {
-            list.putToMRU(new OCacheEntry(0, 0, null, false));
+            list.putToMRU(new OCacheEntryImpl(0, 0, null, false));
             consumeCPU(r.nextInt(500) + 1000);
           }
           return AMOUNT_OF_OPERATIONS;

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUListTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/cache/LRUListTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.local.twoq.LRUList;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
@@ -27,12 +28,12 @@ public abstract class LRUListTest {
     final ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointer, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointer, false));
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     Assert.assertTrue(entryIterator.hasNext());
 
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 10, cachePointer, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 10, cachePointer, false));
   }
 
   @Test
@@ -45,16 +46,16 @@ public abstract class LRUListTest {
     OCachePointer cachePointerOne = new OCachePointer(bufferOne, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     OCachePointer cachePointerTwo = new OCachePointer(bufferTwo, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
 
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointerOne, false));
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerTwo, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointerOne, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerTwo, false));
 
     Assert.assertEquals(lruList.size(), 2);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     Assert.assertTrue(entryIterator.hasNext());
 
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 20, cachePointerTwo, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 10, cachePointerOne, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 10, cachePointerOne, false));
   }
 
   @Test
@@ -69,18 +70,18 @@ public abstract class LRUListTest {
     OCachePointer cachePointerTwo = new OCachePointer(bufferTwo, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     OCachePointer cachePointerThree = new OCachePointer(bufferThree, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
 
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointerOne, false));
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerTwo, false));
-    lruList.putToMRU(new OCacheEntry(3, 30, cachePointerThree, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointerOne, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    lruList.putToMRU(new OCacheEntryImpl(3, 30, cachePointerThree, false));
 
     Assert.assertEquals(lruList.size(), 3);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     Assert.assertTrue(entryIterator.hasNext());
 
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(3, 30, cachePointerThree, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 20, cachePointerTwo, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 10, cachePointerOne, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(3, 30, cachePointerThree, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 10, cachePointerOne, false));
   }
 
   @Test
@@ -95,20 +96,20 @@ public abstract class LRUListTest {
     OCachePointer cachePointerTwo = new OCachePointer(bufferTwo, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     OCachePointer cachePointerThree = new OCachePointer(bufferThree, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
 
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointerOne, false));
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerTwo, false));
-    lruList.putToMRU(new OCacheEntry(3, 30, cachePointerThree, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointerOne, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    lruList.putToMRU(new OCacheEntryImpl(3, 30, cachePointerThree, false));
 
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerTwo, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerTwo, false));
 
     Assert.assertEquals(lruList.size(), 3);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     Assert.assertTrue(entryIterator.hasNext());
 
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 20, cachePointerTwo, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(3, 30, cachePointerThree, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 10, cachePointerOne, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(3, 30, cachePointerThree, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 10, cachePointerOne, false));
   }
 
   @Test
@@ -125,20 +126,20 @@ public abstract class LRUListTest {
     OCachePointer cachePointerThree = new OCachePointer(bufferThree, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     OCachePointer cachePointerFour = new OCachePointer(bufferFour, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
 
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointerOne, false));
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerTwo, false));
-    lruList.putToMRU(new OCacheEntry(3, 30, cachePointerThree, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointerOne, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerTwo, false));
+    lruList.putToMRU(new OCacheEntryImpl(3, 30, cachePointerThree, false));
 
-    lruList.putToMRU(new OCacheEntry(1, 20, cachePointerFour, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 20, cachePointerFour, false));
 
     Assert.assertEquals(lruList.size(), 3);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     Assert.assertTrue(entryIterator.hasNext());
 
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 20, cachePointerFour, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(3, 30, cachePointerThree, false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 10, cachePointerOne, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 20, cachePointerFour, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(3, 30, cachePointerThree, false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 10, cachePointerOne, false));
   }
 
   @Test
@@ -151,24 +152,24 @@ public abstract class LRUListTest {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
 
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
-    lruList.putToMRU(new OCacheEntry(1, 50, cachePointers[5], false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 50, cachePointers[5], false));
 
     Assert.assertEquals(lruList.size(), 11);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
 
     Assert.assertTrue(entryIterator.hasNext());
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 50, cachePointers[5], false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 50, cachePointers[5], false));
 
     for (int i = 10; i >= 0; i--) {
       if (i == 5)
         continue;
 
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -178,7 +179,7 @@ public abstract class LRUListTest {
     ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointerOne = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    lruList.putToMRU(new OCacheEntry(1, 10, cachePointerOne, false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 10, cachePointerOne, false));
     lruList.removeLRU();
 
     Assert.assertEquals(lruList.size(), 0);
@@ -193,7 +194,7 @@ public abstract class LRUListTest {
     ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointerOne = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(1, 10, cachePointerOne, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(1, 10, cachePointerOne, false);
     lruList.putToMRU(cacheEntry);
     cacheEntry.incrementUsages();
 
@@ -212,7 +213,7 @@ public abstract class LRUListTest {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
 
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
     lruList.removeLRU();
@@ -223,7 +224,7 @@ public abstract class LRUListTest {
 
     for (int i = 10; i > 0; i--) {
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -236,10 +237,10 @@ public abstract class LRUListTest {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
 
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
-    Assert.assertEquals(lruList.remove(1, 50), new OCacheEntry(1, 50, cachePointers[5], false));
+    Assert.assertEquals(lruList.remove(1, 50), new OCacheEntryImpl(1, 50, cachePointers[5], false));
     Assert.assertNull(lruList.remove(1, 500));
 
     Assert.assertEquals(lruList.size(), 10);
@@ -250,7 +251,7 @@ public abstract class LRUListTest {
         continue;
 
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -264,11 +265,11 @@ public abstract class LRUListTest {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
 
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
     Assert.assertTrue(lruList.contains(1, 50));
-    Assert.assertEquals(lruList.get(1, 50), new OCacheEntry(1, 50, cachePointers[5], false));
+    Assert.assertEquals(lruList.get(1, 50), new OCacheEntryImpl(1, 50, cachePointers[5], false));
 
     Assert.assertFalse(lruList.contains(2, 50));
 
@@ -277,7 +278,7 @@ public abstract class LRUListTest {
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     for (int i = 10; i >= 0; i--) {
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -289,7 +290,7 @@ public abstract class LRUListTest {
     for (int i = 0; i < 9128; i++) {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
     Assert.assertEquals(lruList.size(), 9128);
@@ -297,7 +298,7 @@ public abstract class LRUListTest {
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     for (int i = 9127; i >= 0; i--) {
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -309,18 +310,18 @@ public abstract class LRUListTest {
     for (int i = 0; i < 9128; i++) {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
     Assert.assertEquals(lruList.size(), 9128);
 
     for (int i = 0; i < 9128; i++)
-      Assert.assertEquals(lruList.get(1, i * 10), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(lruList.get(1, i * 10), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     for (int i = 9127; i >= 0; i--) {
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -332,18 +333,18 @@ public abstract class LRUListTest {
     for (int i = 0; i < 9128; i++) {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
     for (int i = 4564; i < 9128; i++)
-      Assert.assertEquals(lruList.remove(1, i * 10), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(lruList.remove(1, i * 10), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
 
     Assert.assertEquals(lruList.size(), 4564);
 
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
     for (int i = 4563; i >= 0; i--) {
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -356,25 +357,25 @@ public abstract class LRUListTest {
     for (int i = 0; i < 9128; i++) {
       ByteBuffer buffer = bufferPool.acquireDirect(true);
       cachePointers[i] = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-      lruList.putToMRU(new OCacheEntry(1, i * 10, cachePointers[i], false));
+      lruList.putToMRU(new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
 
-    lruList.putToMRU(new OCacheEntry(1, 0, cachePointers[0], false));
-    lruList.putToMRU(new OCacheEntry(1, 4500 * 10, cachePointers[4500], false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 0, cachePointers[0], false));
+    lruList.putToMRU(new OCacheEntryImpl(1, 4500 * 10, cachePointers[4500], false));
 
     Assert.assertEquals(lruList.size(), 9128);
     Iterator<OCacheEntry> entryIterator = lruList.iterator();
 
     Assert.assertTrue(entryIterator.hasNext());
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 4500 * 10, cachePointers[4500], false));
-    Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, 0, cachePointers[0], false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 4500 * 10, cachePointers[4500], false));
+    Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, 0, cachePointers[0], false));
 
     for (int i = 9127; i >= 1; i--) {
       if (i == 4500)
         continue;
 
       Assert.assertTrue(entryIterator.hasNext());
-      Assert.assertEquals(entryIterator.next(), new OCacheEntry(1, i * 10, cachePointers[i], false));
+      Assert.assertEquals(entryIterator.next(), new OCacheEntryImpl(1, i * 10, cachePointers[i], false));
     }
   }
 
@@ -383,7 +384,7 @@ public abstract class LRUListTest {
     final ArrayList<OCacheEntry> entries = new ArrayList<OCacheEntry>();
 
     for (int i = 0; i < 10; i++) {
-      final OCacheEntry cacheEntry = new OCacheEntry(1, i, null, false);
+      final OCacheEntry cacheEntry = new OCacheEntryImpl(1, i, null, false);
 
       entries.add(cacheEntry);
       lruList.putToMRU(cacheEntry);

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucketTest.java
@@ -3,6 +3,7 @@ package com.orientechnologies.orient.core.index.sbtree.local;
 import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.common.serialization.types.OStringSerializer;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import org.testng.Assert;
@@ -24,7 +25,7 @@ public class ONullBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
@@ -41,7 +42,7 @@ public class ONullBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
@@ -61,7 +62,7 @@ public class ONullBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
@@ -83,7 +84,7 @@ public class ONullBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/ONullBucketTest.java
@@ -28,7 +28,7 @@ public class ONullBucketTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
-    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
+    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, OStringSerializer.INSTANCE, true);
     Assert.assertNull(bucket.getValue());
 
     cacheEntry.releaseExclusiveLock();
@@ -45,7 +45,7 @@ public class ONullBucketTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
-    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
+    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, OStringSerializer.INSTANCE, true);
 
     bucket.setValue(new OSBTreeValue<String>(false, -1, "test"));
     OSBTreeValue<String> treeValue = bucket.getValue();
@@ -65,7 +65,7 @@ public class ONullBucketTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
-    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
+    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, OStringSerializer.INSTANCE, true);
 
     bucket.setValue(new OSBTreeValue<String>(false, -1, "test"));
     bucket.removeValue();
@@ -87,7 +87,7 @@ public class ONullBucketTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
-    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, null, OStringSerializer.INSTANCE, true);
+    ONullBucket<String> bucket = new ONullBucket<String>(cacheEntry, OStringSerializer.INSTANCE, true);
 
     bucket.setValue(new OSBTreeValue<String>(false, -1, "test"));
     bucket.removeValue();

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeLeafBucketTest.java
@@ -37,11 +37,11 @@ public class SBTreeLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertTrue(treeBucket.isLeaf());
 
-    treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+    treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertTrue(treeBucket.isLeaf());
     Assert.assertEquals(treeBucket.getLeftSibling(), -1);
@@ -72,7 +72,7 @@ public class SBTreeLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     int index = 0;
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
@@ -116,7 +116,7 @@ public class SBTreeLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
     int index = 0;
@@ -167,7 +167,7 @@ public class SBTreeLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     int index = 0;
     for (Long key : keys) {
@@ -247,7 +247,7 @@ public class SBTreeLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     int index = 0;
     for (Long key : keys) {
@@ -321,7 +321,7 @@ public class SBTreeLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     treeBucket.setLeftSibling(123);
     Assert.assertEquals(treeBucket.getLeftSibling(), 123);
 
@@ -340,7 +340,7 @@ public class SBTreeLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     treeBucket.setRightSibling(123);
     Assert.assertEquals(treeBucket.getRightSibling(), 123);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeLeafBucketTest.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.TreeSet;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,7 +33,7 @@ public class SBTreeLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
@@ -65,7 +66,7 @@ public class SBTreeLeafBucketTest {
     ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     cachePointer.incrementReferrer();
@@ -109,7 +110,7 @@ public class SBTreeLeafBucketTest {
     ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     cachePointer.incrementReferrer();
@@ -162,7 +163,7 @@ public class SBTreeLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
@@ -242,7 +243,7 @@ public class SBTreeLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
@@ -316,7 +317,7 @@ public class SBTreeLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,
@@ -335,7 +336,7 @@ public class SBTreeLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, true,

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeNonLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeNonLeafBucketTest.java
@@ -31,11 +31,11 @@ public class SBTreeNonLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, false,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertFalse(treeBucket.isLeaf());
 
-    treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+    treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertFalse(treeBucket.isLeaf());
     Assert.assertEquals(treeBucket.getLeftSibling(), -1);
@@ -65,7 +65,7 @@ public class SBTreeNonLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, false,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     int index = 0;
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
@@ -131,7 +131,7 @@ public class SBTreeNonLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBucket<Long, OIdentifiable> treeBucket = new OSBTreeBucket<Long, OIdentifiable>(cacheEntry, false,
-        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE, null);
+        OLongSerializer.INSTANCE, null, OLinkSerializer.INSTANCE);
 
     int index = 0;
     for (Long key : keys) {

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeNonLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeNonLeafBucketTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import org.testng.Assert;
@@ -25,7 +26,7 @@ public class SBTreeNonLeafBucketTest {
     final ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
     cachePointer.incrementReferrer();
 
@@ -59,7 +60,7 @@ public class SBTreeNonLeafBucketTest {
     final ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
     cachePointer.incrementReferrer();
 
@@ -124,7 +125,7 @@ public class SBTreeNonLeafBucketTest {
     final ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     cachePointer.incrementReferrer();

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeValuePageTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeValuePageTest.java
@@ -5,6 +5,7 @@ import java.util.Random;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import org.testng.Assert;
@@ -25,7 +26,7 @@ public class SBTreeValuePageTest {
     OCachePointer cachePointerOne = new OCachePointer(bufferOne, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointerOne.incrementReferrer();
 
-    OCacheEntry cacheEntryOne = new OCacheEntry(0, 0, cachePointerOne, false);
+    OCacheEntry cacheEntryOne = new OCacheEntryImpl(0, 0, cachePointerOne, false);
     cacheEntryOne.acquireExclusiveLock();
     OSBTreeValuePage valuePageOne = new OSBTreeValuePage(cacheEntryOne, null, true);
 
@@ -40,7 +41,7 @@ public class SBTreeValuePageTest {
     OCachePointer cachePointerTwo = new OCachePointer(bufferTwo, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointerTwo.incrementReferrer();
 
-    OCacheEntry cacheEntryTwo = new OCacheEntry(0, 0, cachePointerTwo, false);
+    OCacheEntry cacheEntryTwo = new OCacheEntryImpl(0, 0, cachePointerTwo, false);
     cacheEntryTwo.acquireExclusiveLock();
 
     OSBTreeValuePage valuePageTwo = new OSBTreeValuePage(cacheEntryTwo, null, true);
@@ -75,7 +76,7 @@ public class SBTreeValuePageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, null, true);

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeValuePageTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeValuePageTest.java
@@ -28,7 +28,7 @@ public class SBTreeValuePageTest {
 
     OCacheEntry cacheEntryOne = new OCacheEntryImpl(0, 0, cachePointerOne, false);
     cacheEntryOne.acquireExclusiveLock();
-    OSBTreeValuePage valuePageOne = new OSBTreeValuePage(cacheEntryOne, null, true);
+    OSBTreeValuePage valuePageOne = new OSBTreeValuePage(cacheEntryOne, true);
 
     byte[] data = new byte[ODurablePage.MAX_PAGE_SIZE_BYTES + 100];
     Random random = new Random();
@@ -44,7 +44,7 @@ public class SBTreeValuePageTest {
     OCacheEntry cacheEntryTwo = new OCacheEntryImpl(0, 0, cachePointerTwo, false);
     cacheEntryTwo.acquireExclusiveLock();
 
-    OSBTreeValuePage valuePageTwo = new OSBTreeValuePage(cacheEntryTwo, null, true);
+    OSBTreeValuePage valuePageTwo = new OSBTreeValuePage(cacheEntryTwo, true);
     offset = valuePageTwo.fillBinaryContent(data, offset);
 
     Assert.assertEquals(offset, data.length);
@@ -79,7 +79,7 @@ public class SBTreeValuePageTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
-    OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, null, true);
+    OSBTreeValuePage valuePage = new OSBTreeValuePage(cacheEntry, true);
     valuePage.setNextFreeListPage(124);
     Assert.assertEquals(valuePage.getNextFreeListPage(), 124);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeWALTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeWALTest.java
@@ -1,30 +1,20 @@
 package com.orientechnologies.orient.core.index.sbtree.local;
 
-import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
-import com.orientechnologies.orient.core.config.OStorageClusterConfiguration;
-import com.orientechnologies.orient.core.config.OStorageConfiguration;
-import com.orientechnologies.orient.core.config.OStorageSegmentConfiguration;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
-import com.orientechnologies.orient.core.db.record.OCurrentStorageComponentsFactory;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.serialization.serializer.binary.impl.OLinkSerializer;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.cache.OReadCache;
 import com.orientechnologies.orient.core.storage.cache.OWriteCache;
-import com.orientechnologies.orient.core.storage.cache.local.twoq.O2QCache;
-import com.orientechnologies.orient.core.storage.cache.local.OWOWCache;
 import com.orientechnologies.orient.core.storage.fs.OFileClassic;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
-import com.orientechnologies.orient.core.storage.impl.local.OStorageVariableParser;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OClusterPage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OLocalPaginatedStorage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationsManager;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.*;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -39,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Andrey Lomakin
@@ -320,7 +309,7 @@ public class SBTreeWALTest extends SBTreeTest {
 
             cacheEntry.acquireExclusiveLock();
             try {
-              ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+              ODurablePage durablePage = new ODurablePage(cacheEntry);
               durablePage.restoreChanges(updatePageRecord.getChanges());
               durablePage.setLsn(updatePageRecord.getLsn());
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLeafBucketTest.java
@@ -37,12 +37,12 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertTrue(treeBucket.isLeaf());
 
     treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE,
-        null, null);
+        null);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertTrue(treeBucket.isLeaf());
     Assert.assertFalse(treeBucket.getLeftSibling().isValid());
@@ -73,7 +73,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     int index = 0;
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
@@ -118,7 +118,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
     int index = 0;
@@ -171,7 +171,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cachePointer.incrementReferrer();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     int index = 0;
     for (Long key : keys) {
@@ -254,7 +254,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     int index = 0;
     for (Long key : keys) {
@@ -331,7 +331,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
     final OBonsaiBucketPointer p = new OBonsaiBucketPointer(123, 8192 * 2);
     treeBucket.setLeftSibling(p);
     Assert.assertEquals(treeBucket.getLeftSibling(), p);
@@ -351,7 +351,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
     final OBonsaiBucketPointer p = new OBonsaiBucketPointer(123, 8192 * 2);
     treeBucket.setRightSibling(p);
     Assert.assertEquals(treeBucket.getRightSibling(), p);

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLeafBucketTest.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.TreeSet;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,7 +33,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
@@ -68,7 +69,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
@@ -113,7 +114,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
@@ -164,7 +165,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     ByteBuffer buffer = bufferPool.acquireDirect(true);
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     cachePointer.incrementReferrer();
@@ -249,7 +250,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
@@ -326,7 +327,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,
@@ -346,7 +347,7 @@ public class OSBTreeBonsaiLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, true,

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiNonLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiNonLeafBucketTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import org.testng.Assert;
@@ -26,7 +27,7 @@ public class OSBTreeBonsaiNonLeafBucketTest {
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,
@@ -62,7 +63,7 @@ public class OSBTreeBonsaiNonLeafBucketTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,
@@ -127,7 +128,7 @@ public class OSBTreeBonsaiNonLeafBucketTest {
 
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiNonLeafBucketTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiNonLeafBucketTest.java
@@ -31,12 +31,12 @@ public class OSBTreeBonsaiNonLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertFalse(treeBucket.isLeaf());
 
     treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE,
-        null, null);
+        null);
     Assert.assertEquals(treeBucket.size(), 0);
     Assert.assertFalse(treeBucket.isLeaf());
     Assert.assertEquals(treeBucket.getLeftSibling().getPageIndex(), -1);
@@ -67,7 +67,7 @@ public class OSBTreeBonsaiNonLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     int index = 0;
     Map<Long, Integer> keyIndexMap = new HashMap<Long, Integer>();
@@ -132,7 +132,7 @@ public class OSBTreeBonsaiNonLeafBucketTest {
     cacheEntry.acquireExclusiveLock();
 
     OSBTreeBonsaiBucket<Long, OIdentifiable> treeBucket = new OSBTreeBonsaiBucket<Long, OIdentifiable>(cacheEntry, 0, false,
-        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, null);
+        OLongSerializer.INSTANCE, OLinkSerializer.INSTANCE, null);
 
     int index = 0;
     for (Long key : keys) {

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiWALTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiWALTest.java
@@ -311,7 +311,7 @@ public class OSBTreeBonsaiWALTest extends OSBTreeBonsaiLocalTest {
 
             cacheEntry.acquireExclusiveLock();
             try {
-              ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+              ODurablePage durablePage = new ODurablePage(cacheEntry);
               durablePage.restoreChanges(updatePageRecord.getChanges());
               durablePage.setLsn(updatePageRecord.getLsn());
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cache/local/twoq/ReadWriteDiskCacheTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cache/local/twoq/ReadWriteDiskCacheTest.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.zip.CRC32;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
+import com.orientechnologies.orient.core.storage.cache.*;
 import com.orientechnologies.orient.core.storage.cache.local.OWOWCache;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -21,10 +22,6 @@ import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.config.OStorageSegmentConfiguration;
 import com.orientechnologies.orient.core.exception.OAllCacheEntriesAreUsedException;
-import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
-import com.orientechnologies.orient.core.storage.cache.OCachePointer;
-import com.orientechnologies.orient.core.storage.cache.OPageDataVerificationError;
-import com.orientechnologies.orient.core.storage.cache.OWriteCache;
 import com.orientechnologies.orient.core.storage.fs.OFileClassic;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OLocalPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurablePage;
@@ -1208,11 +1205,11 @@ public class ReadWriteDiskCacheTest {
 
   private OCacheEntry generateEntry(long fileId, long pageIndex, ByteBuffer buffer, OByteBufferPool bufferPool, boolean dirty,
       OLogSequenceNumber lsn) {
-    return new OCacheEntry(fileId, pageIndex, new OCachePointer(buffer, bufferPool, lsn, fileId, pageIndex), dirty);
+    return new OCacheEntryImpl(fileId, pageIndex, new OCachePointer(buffer, bufferPool, lsn, fileId, pageIndex), dirty);
   }
 
   private OCacheEntry generateRemovedEntry(long fileId, long pageIndex) {
-    return new OCacheEntry(fileId, pageIndex, null, false);
+    return new OCacheEntryImpl(fileId, pageIndex, null, false);
   }
 
   private void setLsn(ByteBuffer buffer, OLogSequenceNumber lsn) {

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/ClusterPageTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/ClusterPageTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OCacheEntryChanges;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChangesTree;
 import com.orientechnologies.orient.core.record.ORecordVersionHelper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,8 +40,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       addOneRecord(localPage);
       addOneRecord(directLocalPage);
@@ -91,8 +91,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       addThreeRecords(localPage);
       addThreeRecords(directLocalPage);
@@ -160,8 +160,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       addFullPage(localPage);
       addFullPage(directLocalPage);
@@ -225,8 +225,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       deleteAddLowerVersion(localPage);
       deleteAddLowerVersion(directLocalPage);
@@ -278,8 +278,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       deleteAddBiggerVersion(localPage);
       deleteAddBiggerVersion(directLocalPage);
@@ -336,8 +336,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       deleteAddEqualVersion(localPage);
       deleteAddEqualVersion(directLocalPage);
@@ -387,8 +387,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       deleteAddEqualVersionKeepTombstoneVersion(localPage);
       deleteAddEqualVersionKeepTombstoneVersion(directLocalPage);
@@ -438,8 +438,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       deleteTwoOutOfFour(localPage);
       deleteTwoOutOfFour(directLocalPage);
@@ -524,8 +524,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       addFullPageDeleteAndAddAgain(localPage);
       addFullPageDeleteAndAddAgain(directLocalPage);
@@ -615,8 +615,8 @@ public class ClusterPageTest {
     try {
       final long seed = System.currentTimeMillis();
 
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       addBigRecordDeleteAndAddSmallRecords(seed, localPage);
       addBigRecordDeleteAndAddSmallRecords(seed, directLocalPage);
@@ -697,8 +697,8 @@ public class ClusterPageTest {
 
     final long seed = System.currentTimeMillis();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       findFirstRecord(seed, localPage);
       findFirstRecord(seed, directLocalPage);
@@ -786,8 +786,8 @@ public class ClusterPageTest {
 
     final long seed = System.currentTimeMillis();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       findLastRecord(seed, localPage);
       findLastRecord(seed, directLocalPage);
@@ -870,8 +870,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       setGetNextPage(localPage);
       setGetNextPage(directLocalPage);
@@ -908,8 +908,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       setGetPrevPage(localPage);
       setGetPrevPage(directLocalPage);
@@ -947,8 +947,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       replaceOneRecordWithBiggerSize(localPage);
       replaceOneRecordWithBiggerSize(directLocalPage);
@@ -1004,8 +1004,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       replaceOneRecordWithEqualSize(localPage);
       replaceOneRecordWithEqualSize(directLocalPage);
@@ -1062,8 +1062,8 @@ public class ClusterPageTest {
     directCacheEntry.acquireExclusiveLock();
 
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       replaceOneRecordWithSmallerSize(localPage);
       replaceOneRecordWithSmallerSize(directLocalPage);
@@ -1119,8 +1119,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       replaceOneRecordNoVersionUpdate(localPage);
       replaceOneRecordNoVersionUpdate(directLocalPage);
@@ -1176,8 +1176,8 @@ public class ClusterPageTest {
     OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
-      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true, null);
+      OClusterPage localPage = new OClusterPage(new OCacheEntryChanges(cacheEntry), true);
+      OClusterPage directLocalPage = new OClusterPage(directCacheEntry, true);
 
       replaceOneRecordLowerVersion(localPage);
       replaceOneRecordLowerVersion(directLocalPage);
@@ -1223,7 +1223,7 @@ public class ClusterPageTest {
     OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
     try {
-      OClusterPage restoredPage = new OClusterPage(cacheEntry, false, null);
+      OClusterPage restoredPage = new OClusterPage(cacheEntry, false);
 
       OWALChanges changes = localPage.getChanges();
       restoredPage.restoreChanges(changes);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/ClusterPageTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/ClusterPageTest.java
@@ -2,6 +2,7 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated;
 
 import com.orientechnologies.common.directmemory.OByteBufferPool;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
+import com.orientechnologies.orient.core.storage.cache.OCacheEntryImpl;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
@@ -29,14 +30,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -79,14 +80,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -148,14 +149,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -213,14 +214,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -267,14 +268,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -324,14 +325,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -376,14 +377,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -427,14 +428,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -512,14 +513,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -601,14 +602,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -684,14 +685,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     final long seed = System.currentTimeMillis();
@@ -773,14 +774,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     final long seed = System.currentTimeMillis();
@@ -859,14 +860,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -897,14 +898,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -935,14 +936,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -993,14 +994,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -1050,14 +1051,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
 
     try {
@@ -1108,14 +1109,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -1165,14 +1166,14 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(buffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
 
     ByteBuffer directBuffer = bufferPool.acquireDirect(true);
     OCachePointer directCachePointer = new OCachePointer(directBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     directCachePointer.incrementReferrer();
 
-    OCacheEntry directCacheEntry = new OCacheEntry(0, 0, directCachePointer, false);
+    OCacheEntry directCacheEntry = new OCacheEntryImpl(0, 0, directCachePointer, false);
     directCacheEntry.acquireExclusiveLock();
     try {
       OClusterPage localPage = new OClusterPage(cacheEntry, true, new OWALChangesTree());
@@ -1219,7 +1220,7 @@ public class ClusterPageTest {
     OCachePointer cachePointer = new OCachePointer(restoredBuffer, bufferPool, new OLogSequenceNumber(0, 0), 0, 0);
     cachePointer.incrementReferrer();
 
-    OCacheEntry cacheEntry = new OCacheEntry(0, 0, cachePointer, false);
+    OCacheEntry cacheEntry = new OCacheEntryImpl(0, 0, cachePointer, false);
     cacheEntry.acquireExclusiveLock();
     try {
       OClusterPage restoredPage = new OClusterPage(cacheEntry, false, null);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/LocalPaginatedClusterWithWALTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/LocalPaginatedClusterWithWALTest.java
@@ -388,7 +388,7 @@ public class LocalPaginatedClusterWithWALTest extends LocalPaginatedClusterTest 
             }
             cacheEntry.acquireExclusiveLock();
             try {
-              ODurablePage durablePage = new ODurablePage(cacheEntry, null);
+              ODurablePage durablePage = new ODurablePage(cacheEntry);
               durablePage.restoreChanges(updatePageRecord.getChanges());
               durablePage.setLsn(updatePageRecord.getLsn());
 


### PR DESCRIPTION
Hi, 

This is a medium refactor for remove the double call to the atomic operation for get wal changes, the last commit is the one with more changes but that is just a code cleanup, all the required logic is on the first two commits, I haven't seen a big performance change but i think it still make sense merge it.

another thing, for make the refactor work i had to change this assert: https://github.com/orientechnologies/orientdb/commit/379257bdcd2dc8802ac02658a0c2e453fb020e2a#diff-4da6f88c14ce4d0fafc152774eeb7508L195 but it may hide a bigger problem, not due to the refactor, it seems that in some cases we lock an release in a not a balanced way, or is better say we load and lock the same page twice doing: `lock,lock,release,release` causing that assert to fail, this shouldn't be an issue because it happen only for new pages, that exist only in the current thread local, so no concurrency issues, but i would keep an aye on this.

all the rest should be strait forward, let me know if this make sense for you.