### PR TITLE
Current Live query works only  final matched datas after crud operation

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/query/live/OLiveQueryValidateListener.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/query/live/OLiveQueryValidateListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 OrientDB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.orientechnologies.orient.core.query.live;
+
+/**
+ * Listener  for BeforeUpdate  on Live Query 
+ * @author Saltuk Bugra Avci 
+ */
+public interface OLiveQueryValidateListener extends OLiveQueryListener {
+
+    /**
+     * Checks Validation
+     *
+     * @param row
+     */
+    public void validate(ORecordLiveOperation row);
+
+    
+    
+    
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/query/live/ORecordLiveOperation.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/query/live/ORecordLiveOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 OrientDB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.orientechnologies.orient.core.query.live;
+
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.db.record.ORecordElement;
+import com.orientechnologies.orient.core.db.record.ORecordOperation;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+
+/**
+ *
+ * @author saltuk
+ */
+public class ORecordLiveOperation extends ORecordOperation {
+
+    public final OIdentifiable before;
+
+    public ORecordLiveOperation(OIdentifiable before, OIdentifiable current, byte iStatus) {
+        super(current, iStatus);
+        if (before != null) {
+            final ODocument doc  =before.getRecord();
+            doc.setInternalStatus(ORecordElement.STATUS.LOADED);
+            
+            this.before = doc;
+        } else {
+            this.before = null;
+        }
+    }
+
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilter.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilter.java
@@ -102,6 +102,13 @@ public class OSQLFilter extends OSQLPredicate implements OCommandPredicate {
 
     return rootCondition.evaluate(iRecord, iCurrentResult, iContext);
   }
+public Object evaluateLive(final OIdentifiable iRecord, final ODocument iCurrentResult, final OCommandContext iContext) {
+    if (rootCondition == null) {
+      return true;
+    }
+
+    return rootCondition.evaluateLive(iRecord, iCurrentResult, iContext);
+  }
 
   public OSQLFilterCondition getRootCondition() {
     return rootCondition;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilterCondition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLFilterCondition.java
@@ -46,10 +46,14 @@ import com.orientechnologies.orient.core.sql.functions.OSQLFunctionRuntime;
 import com.orientechnologies.orient.core.sql.operator.OQueryOperator;
 import com.orientechnologies.orient.core.sql.operator.OQueryOperatorMatches;
 import com.orientechnologies.orient.core.sql.query.OSQLQuery;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -58,431 +62,440 @@ import java.util.regex.Pattern;
  * @author Luca Garulli
  */
 public class OSQLFilterCondition {
-  private static final String NULL_VALUE = "null";
-  protected Object            left;
-  protected OQueryOperator    operator;
-  protected Object            right;
-  protected boolean           inBraces   = false;
 
-  public OSQLFilterCondition(final Object iLeft, final OQueryOperator iOperator) {
-    this.left = iLeft;
-    this.operator = iOperator;
-  }
+    private static final String NULL_VALUE = "null";
+    protected Object left;
+    protected OQueryOperator operator;
+    protected Object right;
+    protected boolean inBraces = false;
 
-  public OSQLFilterCondition(final Object iLeft, final OQueryOperator iOperator, final Object iRight) {
-    this.left = iLeft;
-    this.operator = iOperator;
-    this.right = iRight;
-  }
+    public OSQLFilterCondition(final Object iLeft, final OQueryOperator iOperator) {
+        this.left = iLeft;
+        this.operator = iOperator;
+    }
 
-  public Object evaluate(final OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final OCommandContext iContext) {
-    boolean binaryEvaluation = operator != null && operator.isSupportingBinaryEvaluate() && iCurrentRecord!= null && iCurrentRecord.getIdentity().isPersistent();
+    public OSQLFilterCondition(final Object iLeft, final OQueryOperator iOperator, final Object iRight) {
+        this.left = iLeft;
+        this.operator = iOperator;
+        this.right = iRight;
+    }
 
-    if (left instanceof OSQLQuery<?>)
-      // EXECUTE SUB QUERIES ONLY ONCE
-      left = ((OSQLQuery<?>) left).setContext(iContext).execute();
+    public Object evaluate(final OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final OCommandContext iContext) {
+        return evaluate(iCurrentRecord, iCurrentResult, iContext, false);
+    }
+  public Object evaluateLive(final OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final OCommandContext iContext) {
+        return evaluate(iCurrentRecord, iCurrentResult, iContext, true);
+    }
 
-    Object l = evaluate(iCurrentRecord, iCurrentResult, left, iContext, binaryEvaluation);
+    private Object evaluate(final OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final OCommandContext iContext, boolean isLive) {
+        // IsLive parameter required for evaluate  to validate   Temporary Document which is created on Before Update 
+        boolean binaryEvaluation = operator != null && operator.isSupportingBinaryEvaluate() && iCurrentRecord != null && (iCurrentRecord.getIdentity().isPersistent() || isLive);
 
-    if (operator == null || operator.canShortCircuit(l))
-      return l;
-
-    if (right instanceof OSQLQuery<?>)
-      // EXECUTE SUB QUERIES ONLY ONCE
-      right = ((OSQLQuery<?>) right).setContext(iContext).execute();
-
-    Object r = evaluate(iCurrentRecord, iCurrentResult, right, iContext, binaryEvaluation);
-
-    if (binaryEvaluation && l instanceof OBinaryField) {
-      if (r != null && !(r instanceof OBinaryField)) {
-        final OType type = OType.getTypeByValue(r);
-
-        if (ORecordSerializerBinary.INSTANCE.getCurrentSerializer().getComparator().isBinaryComparable(type)) {
-          final BytesContainer bytes = new BytesContainer();
-          ORecordSerializerBinary.INSTANCE.getCurrentSerializer().serializeValue(bytes, r, type, null);
-          bytes.offset = 0;
-          final OCollate collate = r instanceof OSQLFilterItemField ? ((OSQLFilterItemField) r).getCollate(iCurrentRecord) : null;
-          r = new OBinaryField(null, type, bytes, collate);
-          if (!(right instanceof OSQLFilterItem || right instanceof OSQLFilterCondition))
-            // FIXED VALUE, REPLACE IT
-            right = r;
+        if (left instanceof OSQLQuery<?>) // EXECUTE SUB QUERIES ONLY ONCE
+        {
+            left = ((OSQLQuery<?>) left).setContext(iContext).execute();
         }
-      } else if (r instanceof OBinaryField)
-        // GET THE COPY OR MT REASONS
-        r = ((OBinaryField) r).copy();
-    }
 
-    if (binaryEvaluation && r instanceof OBinaryField) {
-      if (l != null && !(l instanceof OBinaryField)) {
-        final OType type = OType.getTypeByValue(l);
-        if (ORecordSerializerBinary.INSTANCE.getCurrentSerializer().getComparator().isBinaryComparable(type)) {
-          final BytesContainer bytes = new BytesContainer();
-          ORecordSerializerBinary.INSTANCE.getCurrentSerializer().serializeValue(bytes, l, type, null);
-          bytes.offset = 0;
-          final OCollate collate = l instanceof OSQLFilterItemField ? ((OSQLFilterItemField) l).getCollate(iCurrentRecord) : null;
-          l = new OBinaryField(null, type, bytes, collate);
-          if (!(left instanceof OSQLFilterItem || left instanceof OSQLFilterCondition))
-            // FIXED VALUE, REPLACE IT
-            left = l;
+        Object l = evaluate(iCurrentRecord, iCurrentResult, left, iContext, binaryEvaluation);
+
+        if (operator == null || operator.canShortCircuit(l)) {
+            return l;
         }
-      } else if (l instanceof OBinaryField)
-        // GET THE COPY OR MT REASONS
-        l = ((OBinaryField) l).copy();
-    }
 
-    if (binaryEvaluation)
-      binaryEvaluation = l instanceof OBinaryField && r instanceof OBinaryField;
-
-
-    if (!binaryEvaluation) {
-      // no collate for regular expressions, otherwise quotes will result in no match
-      final OCollate collate = operator instanceof OQueryOperatorMatches ? null : getCollate(iCurrentRecord);
-      final Object[] convertedValues = checkForConversion(iCurrentRecord, l, r, collate);
-      if (convertedValues != null) {
-        l = convertedValues[0];
-        r = convertedValues[1];
-      }
-    }
-
-    Object result;
-    try {
-      result = operator.evaluateRecord(iCurrentRecord, iCurrentResult, this, l, r, iContext);
-    } catch (OCommandExecutionException e) {
-      throw e;
-    } catch (Exception e) {
-      if (OLogManager.instance().isDebugEnabled())
-        OLogManager.instance().debug(this, "Error on evaluating expression (%s)", e, toString());
-      result = Boolean.FALSE;
-    }
-
-    return result;
-  }
-
-  @Deprecated
-  public OCollate getCollate() {
-    if (left instanceof OSQLFilterItemField) {
-      return ((OSQLFilterItemField) left).getCollate();
-    } else if (right instanceof OSQLFilterItemField) {
-      return ((OSQLFilterItemField) right).getCollate();
-    }
-    return null;
-  }
-
-  public OCollate getCollate(OIdentifiable doc) {
-    if (left instanceof OSQLFilterItemField) {
-      return ((OSQLFilterItemField) left).getCollate(doc);
-    } else if (right instanceof OSQLFilterItemField) {
-      return ((OSQLFilterItemField) right).getCollate(doc);
-    }
-    return null;
-  }
-
-  public ORID getBeginRidRange() {
-    if (operator == null) {
-      if (left instanceof OSQLFilterCondition) {
-        return ((OSQLFilterCondition) left).getBeginRidRange();
-      } else {
-        return null;
-      }
-    }
-
-    return operator.getBeginRidRange(left, right);
-  }
-
-  public ORID getEndRidRange() {
-    if (operator == null) {
-      if (left instanceof OSQLFilterCondition) {
-        return ((OSQLFilterCondition) left).getEndRidRange();
-      } else {
-        return null;
-      }
-    }
-
-    return operator.getEndRidRange(left, right);
-  }
-
-  public List<String> getInvolvedFields(final List<String> list) {
-    extractInvolvedFields(getLeft(), list);
-    extractInvolvedFields(getRight(), list);
-
-    return list;
-  }
-
-  private void extractInvolvedFields(Object left, List<String> list) {
-    if (left != null) {
-      if (left instanceof OSQLFilterItemField) {
-        if (((OSQLFilterItemField) left).isFieldChain()) {
-          list.add(((OSQLFilterItemField) left).getFieldChain().getItemName(
-              ((OSQLFilterItemField) left).getFieldChain().getItemCount() - 1));
+        if (right instanceof OSQLQuery<?>) // EXECUTE SUB QUERIES ONLY ONCE
+        {
+            right = ((OSQLQuery<?>) right).setContext(iContext).execute();
         }
-      } else if (left instanceof OSQLFilterCondition) {
-        ((OSQLFilterCondition) left).getInvolvedFields(list);
-      }
-    }
-  }
 
-  @Override
-  public String toString() {
-    StringBuilder buffer = new StringBuilder(128);
+        Object r = evaluate(iCurrentRecord, iCurrentResult, right, iContext, binaryEvaluation);
 
-    buffer.append('(');
-    buffer.append(left);
-    if (operator != null) {
-      buffer.append(' ');
-      buffer.append(operator);
-      buffer.append(' ');
-      if (right instanceof String) {
-        buffer.append('\'');
-      }
-      buffer.append(right);
-      if (right instanceof String) {
-        buffer.append('\'');
-      }
-      buffer.append(')');
-    }
+        if (binaryEvaluation && l instanceof OBinaryField) {
+            if (r != null && !(r instanceof OBinaryField)) {
+                final OType type = OType.getTypeByValue(r);
 
-    return buffer.toString();
-  }
+                if (ORecordSerializerBinary.INSTANCE.getCurrentSerializer().getComparator().isBinaryComparable(type)) {
+                    final BytesContainer bytes = new BytesContainer();
+                    ORecordSerializerBinary.INSTANCE.getCurrentSerializer().serializeValue(bytes, r, type, null);
+                    bytes.offset = 0;
+                    final OCollate collate = r instanceof OSQLFilterItemField ? ((OSQLFilterItemField) r).getCollate(iCurrentRecord) : null;
+                    r = new OBinaryField(null, type, bytes, collate);
+                    if (!(right instanceof OSQLFilterItem || right instanceof OSQLFilterCondition)) // FIXED VALUE, REPLACE IT
+                    {
+                        right = r;
+                    }
+                }
+            } else if (r instanceof OBinaryField) // GET THE COPY OR MT REASONS
+            {
+                r = ((OBinaryField) r).copy();
+            }
+        }
 
-  public Object getLeft() {
-    return left;
-  }
+        if (binaryEvaluation && r instanceof OBinaryField) {
+            if (l != null && !(l instanceof OBinaryField)) {
+                final OType type = OType.getTypeByValue(l);
+                if (ORecordSerializerBinary.INSTANCE.getCurrentSerializer().getComparator().isBinaryComparable(type)) {
+                    final BytesContainer bytes = new BytesContainer();
+                    ORecordSerializerBinary.INSTANCE.getCurrentSerializer().serializeValue(bytes, l, type, null);
+                    bytes.offset = 0;
+                    final OCollate collate = l instanceof OSQLFilterItemField ? ((OSQLFilterItemField) l).getCollate(iCurrentRecord) : null;
+                    l = new OBinaryField(null, type, bytes, collate);
+                    if (!(left instanceof OSQLFilterItem || left instanceof OSQLFilterCondition)) // FIXED VALUE, REPLACE IT
+                    {
+                        left = l;
+                    }
+                }
+            } else if (l instanceof OBinaryField) // GET THE COPY OR MT REASONS
+            {
+                l = ((OBinaryField) l).copy();
+            }
+        }
 
-  public void setLeft(final Object iValue) {
-    left = iValue;
-  }
+        if (binaryEvaluation) {
+            binaryEvaluation = l instanceof OBinaryField && r instanceof OBinaryField;
+        }
 
-  public Object getRight() {
-    return right;
-  }
+        if (!binaryEvaluation) {
+            // no collate for regular expressions, otherwise quotes will result in no match
+            final OCollate collate = operator instanceof OQueryOperatorMatches ? null : getCollate(iCurrentRecord);
+            final Object[] convertedValues = checkForConversion(iCurrentRecord, l, r, collate);
+            if (convertedValues != null) {
+                l = convertedValues[0];
+                r = convertedValues[1];
+            }
+        }
 
-  public void setRight(final Object iValue) {
-    right = iValue;
-  }
-
-  public OQueryOperator getOperator() {
-    return operator;
-  }
-
-  protected Integer getInteger(Object iValue) {
-    if (iValue == null) {
-      return null;
-    }
-
-    final String stringValue = iValue.toString();
-
-    if (NULL_VALUE.equals(stringValue)) {
-      return null;
-    }
-    if (OSQLHelper.DEFINED.equals(stringValue)) {
-      return null;
-    }
-
-    if (OStringSerializerHelper.contains(stringValue, '.') || OStringSerializerHelper.contains(stringValue, ',')) {
-      return (int) Float.parseFloat(stringValue);
-    } else {
-      return stringValue.length() > 0 ? new Integer(stringValue) : new Integer(0);
-    }
-  }
-
-  protected Float getFloat(final Object iValue) {
-    if (iValue == null) {
-      return null;
-    }
-
-    final String stringValue = iValue.toString();
-
-    if (NULL_VALUE.equals(stringValue)) {
-      return null;
-    }
-
-    return stringValue.length() > 0 ? new Float(stringValue) : new Float(0);
-  }
-
-  protected Date getDate(final Object value) {
-    if (value == null) {
-      return null;
-    }
-
-    final OStorageConfiguration config = ODatabaseRecordThreadLocal.INSTANCE.get().getStorage().getConfiguration();
-
-    if (value instanceof Long) {
-      Calendar calendar = Calendar.getInstance(config.getTimeZone());
-      calendar.setTimeInMillis(((Long) value));
-      return calendar.getTime();
-    }
-
-    String stringValue = value.toString();
-
-    if (NULL_VALUE.equals(stringValue)) {
-      return null;
-    }
-
-    if (stringValue.length() <= 0) {
-      return null;
-    }
-
-    if (Pattern.matches("^\\d+$", stringValue)) {
-      return new Date(Long.valueOf(stringValue).longValue());
-    }
-
-    SimpleDateFormat formatter = config.getDateFormatInstance();
-
-    if (stringValue.length() > config.dateFormat.length())
-    // ASSUMES YOU'RE USING THE DATE-TIME FORMATTE
-    {
-      formatter = config.getDateTimeFormatInstance();
-    }
-
-    try {
-      return formatter.parse(stringValue);
-    } catch (ParseException pe) {
-      try {
-        return new Date(new Double(stringValue).longValue());
-      } catch (Exception pe2) {
-        throw OException.wrapException(new OQueryParsingException("Error on conversion of date '" + stringValue
-            + "' using the format: " + formatter.toPattern()), pe2);
-      }
-    }
-  }
-
-  protected Object evaluate(OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final Object iValue,
-      final OCommandContext iContext, final boolean binaryEvaluation) {
-    if (iValue == null)
-      return null;
-
-    if (iValue instanceof BytesContainer)
-      return iValue;
-
-    if (iCurrentRecord != null) {
-      iCurrentRecord = iCurrentRecord.getRecord();
-      if (iCurrentRecord != null && ((ORecord) iCurrentRecord).getInternalStatus() == ORecordElement.STATUS.NOT_LOADED) {
+        Object result;
         try {
-          iCurrentRecord = iCurrentRecord.getRecord().load();
-        } catch (ORecordNotFoundException e) {
-          return null;
+            result = operator.evaluateRecord(iCurrentRecord, iCurrentResult, this, l, r, iContext);
+        } catch (OCommandExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            if (OLogManager.instance().isDebugEnabled()) {
+                OLogManager.instance().debug(this, "Error on evaluating expression (%s)", e, toString());
+            }
+            result = Boolean.FALSE;
         }
-      }
+
+        return result;
     }
 
-    if (binaryEvaluation && iValue instanceof OSQLFilterItemField) {
-      final OBinaryField bField = ((OSQLFilterItemField) iValue).getBinaryField(iCurrentRecord);
-      if (bField != null)
-        return bField;
+    @Deprecated
+    public OCollate getCollate() {
+        if (left instanceof OSQLFilterItemField) {
+            return ((OSQLFilterItemField) left).getCollate();
+        } else if (right instanceof OSQLFilterItemField) {
+            return ((OSQLFilterItemField) right).getCollate();
+        }
+        return null;
     }
 
-    if (iValue instanceof OSQLFilterItem) {
-      return ((OSQLFilterItem) iValue).getValue(iCurrentRecord, iCurrentResult, iContext);
+    public OCollate getCollate(OIdentifiable doc) {
+        if (left instanceof OSQLFilterItemField) {
+            return ((OSQLFilterItemField) left).getCollate(doc);
+        } else if (right instanceof OSQLFilterItemField) {
+            return ((OSQLFilterItemField) right).getCollate(doc);
+        }
+        return null;
     }
 
-    if (iValue instanceof OSQLFilterCondition) {
-      // NESTED CONDITION: EVALUATE IT RECURSIVELY
-      return ((OSQLFilterCondition) iValue).evaluate(iCurrentRecord, iCurrentResult, iContext);
+    public ORID getBeginRidRange() {
+        if (operator == null) {
+            if (left instanceof OSQLFilterCondition) {
+                return ((OSQLFilterCondition) left).getBeginRidRange();
+            } else {
+                return null;
+            }
+        }
+
+        return operator.getBeginRidRange(left, right);
     }
 
-    if (iValue instanceof OSQLFunctionRuntime) {
-      // STATELESS FUNCTION: EXECUTE IT
-      final OSQLFunctionRuntime f = (OSQLFunctionRuntime) iValue;
-      return f.execute(iCurrentRecord, iCurrentRecord, iCurrentResult, iContext);
+    public ORID getEndRidRange() {
+        if (operator == null) {
+            if (left instanceof OSQLFilterCondition) {
+                return ((OSQLFilterCondition) left).getEndRidRange();
+            } else {
+                return null;
+            }
+        }
+
+        return operator.getEndRidRange(left, right);
     }
 
-    if (OMultiValue.isMultiValue(iValue)) {
-      final Iterable<?> multiValue = OMultiValue.getMultiValueIterable(iValue, false);
+    public List<String> getInvolvedFields(final List<String> list) {
+        extractInvolvedFields(getLeft(), list);
+        extractInvolvedFields(getRight(), list);
 
-      // MULTI VALUE: RETURN A COPY
-      final ArrayList<Object> result = new ArrayList<Object>(OMultiValue.getSize(iValue));
+        return list;
+    }
 
-      for (final Object value : multiValue) {
-        if (value instanceof OSQLFilterItem) {
-          result.add(((OSQLFilterItem) value).getValue(iCurrentRecord, iCurrentResult, iContext));
+    private void extractInvolvedFields(Object left, List<String> list) {
+        if (left != null) {
+            if (left instanceof OSQLFilterItemField) {
+                if (((OSQLFilterItemField) left).isFieldChain()) {
+                    list.add(((OSQLFilterItemField) left).getFieldChain().getItemName(
+                            ((OSQLFilterItemField) left).getFieldChain().getItemCount() - 1));
+                }
+            } else if (left instanceof OSQLFilterCondition) {
+                ((OSQLFilterCondition) left).getInvolvedFields(list);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder(128);
+
+        buffer.append('(');
+        buffer.append(left);
+        if (operator != null) {
+            buffer.append(' ');
+            buffer.append(operator);
+            buffer.append(' ');
+            if (right instanceof String) {
+                buffer.append('\'');
+            }
+            buffer.append(right);
+            if (right instanceof String) {
+                buffer.append('\'');
+            }
+            buffer.append(')');
+        }
+
+        return buffer.toString();
+    }
+
+    public Object getLeft() {
+        return left;
+    }
+
+    public void setLeft(final Object iValue) {
+        left = iValue;
+    }
+
+    public Object getRight() {
+        return right;
+    }
+
+    public void setRight(final Object iValue) {
+        right = iValue;
+    }
+
+    public OQueryOperator getOperator() {
+        return operator;
+    }
+
+    protected Integer getInteger(Object iValue) {
+        if (iValue == null) {
+            return null;
+        }
+
+        final String stringValue = iValue.toString();
+
+        if (NULL_VALUE.equals(stringValue)) {
+            return null;
+        }
+        if (OSQLHelper.DEFINED.equals(stringValue)) {
+            return null;
+        }
+
+        if (OStringSerializerHelper.contains(stringValue, '.') || OStringSerializerHelper.contains(stringValue, ',')) {
+            return (int) Float.parseFloat(stringValue);
         } else {
-          result.add(value);
+            return stringValue.length() > 0 ? new Integer(stringValue) : new Integer(0);
         }
-      }
-      return result;
     }
 
-    // SIMPLE VALUE: JUST RETURN IT
-    return iValue;
-  }
+    protected Float getFloat(final Object iValue) {
+        if (iValue == null) {
+            return null;
+        }
 
-  private Object[] checkForConversion(final OIdentifiable o, Object l, Object r, final OCollate collate) {
-    Object[] result = null;
+        final String stringValue = iValue.toString();
 
-    final Object oldL = l;
-    final Object oldR = r;
-    if (collate != null) {
+        if (NULL_VALUE.equals(stringValue)) {
+            return null;
+        }
 
-      l = collate.transform(l);
-      r = collate.transform(r);
-
-      if (l != oldL || r != oldR)
-      // CHANGED
-      {
-        result = new Object[] { l, r };
-      }
+        return stringValue.length() > 0 ? new Float(stringValue) : new Float(0);
     }
 
-    try {
-      // DEFINED OPERATOR
-      if ((oldR instanceof String && oldR.equals(OSQLHelper.DEFINED))
-          || (oldL instanceof String && oldL.equals(OSQLHelper.DEFINED))) {
-        result = new Object[] { ((OSQLFilterItemAbstract) this.left).getRoot(), r };
-      }
-
-      // NOT_NULL OPERATOR
-      else if ((oldR instanceof String && oldR.equals(OSQLHelper.NOT_NULL))
-          || (oldL instanceof String && oldL.equals(OSQLHelper.NOT_NULL))) {
-        result = null;
-      } else if (l != null && r != null && !l.getClass().isAssignableFrom(r.getClass())
-          && !r.getClass().isAssignableFrom(l.getClass()))
-      // INTEGERS
-      {
-        if (r instanceof Integer && !(l instanceof Number || l instanceof Collection)) {
-          if (l instanceof String && ((String) l).indexOf('.') > -1) {
-            result = new Object[] { new Float((String) l).intValue(), r };
-          } else if (l instanceof Date) {
-            result = new Object[] { ((Date) l).getTime(), r };
-          } else if (!(l instanceof OQueryRuntimeValueMulti) && !(l instanceof Collection<?>) && !l.getClass().isArray()
-              && !(l instanceof Map)) {
-            result = new Object[] { getInteger(l), r };
-          }
-        } else if (l instanceof Integer && !(r instanceof Number || r instanceof Collection)) {
-          if (r instanceof String && ((String) r).indexOf('.') > -1) {
-            result = new Object[] { l, new Float((String) r).intValue() };
-          } else if (r instanceof Date) {
-            result = new Object[] { l, ((Date) r).getTime() };
-          } else if (!(r instanceof OQueryRuntimeValueMulti) && !(r instanceof Collection<?>) && !r.getClass().isArray()
-              && !(r instanceof Map)) {
-            result = new Object[] { l, getInteger(r) };
-          }
+    protected Date getDate(final Object value) {
+        if (value == null) {
+            return null;
         }
 
-        // DATES
-        else if (r instanceof Date && !(l instanceof Collection || l instanceof Date)) {
-          result = new Object[] { getDate(l), r };
-        } else if (l instanceof Date && !(r instanceof Collection || r instanceof Date)) {
-          result = new Object[] { l, getDate(r) };
+        final OStorageConfiguration config = ODatabaseRecordThreadLocal.INSTANCE.get().getStorage().getConfiguration();
+
+        if (value instanceof Long) {
+            Calendar calendar = Calendar.getInstance(config.getTimeZone());
+            calendar.setTimeInMillis(((Long) value));
+            return calendar.getTime();
         }
 
-        // FLOATS
-        else if (r instanceof Float && !(l instanceof Float || l instanceof Collection)) {
-          result = new Object[] { getFloat(l), r };
-        } else if (l instanceof Float && !(r instanceof Float || r instanceof Collection)) {
-          result = new Object[] { l, getFloat(r) };
+        String stringValue = value.toString();
+
+        if (NULL_VALUE.equals(stringValue)) {
+            return null;
         }
 
-        // RIDS
-        else if (r instanceof ORID && l instanceof String && !oldL.equals(OSQLHelper.NOT_NULL)) {
-          result = new Object[] { new ORecordId((String) l), r };
-        } else if (l instanceof ORID && r instanceof String && !oldR.equals(OSQLHelper.NOT_NULL)) {
-          result = new Object[] { l, new ORecordId((String) r) };
+        if (stringValue.length() <= 0) {
+            return null;
         }
-      }
-    } catch (Exception e) {
-      // JUST IGNORE CONVERSION ERRORS
+
+        if (Pattern.matches("^\\d+$", stringValue)) {
+            return new Date(Long.valueOf(stringValue).longValue());
+        }
+
+        SimpleDateFormat formatter = config.getDateFormatInstance();
+
+        if (stringValue.length() > config.dateFormat.length()) // ASSUMES YOU'RE USING THE DATE-TIME FORMATTE
+        {
+            formatter = config.getDateTimeFormatInstance();
+        }
+
+        try {
+            return formatter.parse(stringValue);
+        } catch (ParseException pe) {
+            try {
+                return new Date(new Double(stringValue).longValue());
+            } catch (Exception pe2) {
+                throw OException.wrapException(new OQueryParsingException("Error on conversion of date '" + stringValue
+                        + "' using the format: " + formatter.toPattern()), pe2);
+            }
+        }
     }
 
-    return result;
-  }
+    protected Object evaluate(OIdentifiable iCurrentRecord, final ODocument iCurrentResult, final Object iValue,
+            final OCommandContext iContext, final boolean binaryEvaluation) {
+        if (iValue == null) {
+            return null;
+        }
+
+        if (iValue instanceof BytesContainer) {
+            return iValue;
+        }
+
+        if (iCurrentRecord != null) {
+            iCurrentRecord = iCurrentRecord.getRecord();
+            if (iCurrentRecord != null && ((ORecord) iCurrentRecord).getInternalStatus() == ORecordElement.STATUS.NOT_LOADED) {
+                try {
+                    iCurrentRecord = iCurrentRecord.getRecord().load();
+                } catch (ORecordNotFoundException e) {
+                    return null;
+                }
+            }
+        }
+
+        if (binaryEvaluation && iValue instanceof OSQLFilterItemField) {
+            final OBinaryField bField = ((OSQLFilterItemField) iValue).getBinaryField(iCurrentRecord);
+            if (bField != null) {
+                return bField;
+            }
+        }
+
+        if (iValue instanceof OSQLFilterItem) {
+            return ((OSQLFilterItem) iValue).getValue(iCurrentRecord, iCurrentResult, iContext);
+        }
+
+        if (iValue instanceof OSQLFilterCondition) {
+            // NESTED CONDITION: EVALUATE IT RECURSIVELY
+            return ((OSQLFilterCondition) iValue).evaluate(iCurrentRecord, iCurrentResult, iContext);
+        }
+
+        if (iValue instanceof OSQLFunctionRuntime) {
+            // STATELESS FUNCTION: EXECUTE IT
+            final OSQLFunctionRuntime f = (OSQLFunctionRuntime) iValue;
+            return f.execute(iCurrentRecord, iCurrentRecord, iCurrentResult, iContext);
+        }
+
+        if (OMultiValue.isMultiValue(iValue)) {
+            final Iterable<?> multiValue = OMultiValue.getMultiValueIterable(iValue, false);
+
+            // MULTI VALUE: RETURN A COPY
+            final ArrayList<Object> result = new ArrayList<Object>(OMultiValue.getSize(iValue));
+
+            for (final Object value : multiValue) {
+                if (value instanceof OSQLFilterItem) {
+                    result.add(((OSQLFilterItem) value).getValue(iCurrentRecord, iCurrentResult, iContext));
+                } else {
+                    result.add(value);
+                }
+            }
+            return result;
+        }
+
+        // SIMPLE VALUE: JUST RETURN IT
+        return iValue;
+    }
+
+    private Object[] checkForConversion(final OIdentifiable o, Object l, Object r, final OCollate collate) {
+        Object[] result = null;
+
+        final Object oldL = l;
+        final Object oldR = r;
+        if (collate != null) {
+
+            l = collate.transform(l);
+            r = collate.transform(r);
+
+            if (l != oldL || r != oldR) // CHANGED
+            {
+                result = new Object[]{l, r};
+            }
+        }
+
+        try {
+            // DEFINED OPERATOR
+            if ((oldR instanceof String && oldR.equals(OSQLHelper.DEFINED))
+                    || (oldL instanceof String && oldL.equals(OSQLHelper.DEFINED))) {
+                result = new Object[]{((OSQLFilterItemAbstract) this.left).getRoot(), r};
+            } // NOT_NULL OPERATOR
+            else if ((oldR instanceof String && oldR.equals(OSQLHelper.NOT_NULL))
+                    || (oldL instanceof String && oldL.equals(OSQLHelper.NOT_NULL))) {
+                result = null;
+            } else if (l != null && r != null && !l.getClass().isAssignableFrom(r.getClass())
+                    && !r.getClass().isAssignableFrom(l.getClass())) // INTEGERS
+            {
+                if (r instanceof Integer && !(l instanceof Number || l instanceof Collection)) {
+                    if (l instanceof String && ((String) l).indexOf('.') > -1) {
+                        result = new Object[]{new Float((String) l).intValue(), r};
+                    } else if (l instanceof Date) {
+                        result = new Object[]{((Date) l).getTime(), r};
+                    } else if (!(l instanceof OQueryRuntimeValueMulti) && !(l instanceof Collection<?>) && !l.getClass().isArray()
+                            && !(l instanceof Map)) {
+                        result = new Object[]{getInteger(l), r};
+                    }
+                } else if (l instanceof Integer && !(r instanceof Number || r instanceof Collection)) {
+                    if (r instanceof String && ((String) r).indexOf('.') > -1) {
+                        result = new Object[]{l, new Float((String) r).intValue()};
+                    } else if (r instanceof Date) {
+                        result = new Object[]{l, ((Date) r).getTime()};
+                    } else if (!(r instanceof OQueryRuntimeValueMulti) && !(r instanceof Collection<?>) && !r.getClass().isArray()
+                            && !(r instanceof Map)) {
+                        result = new Object[]{l, getInteger(r)};
+                    }
+                } // DATES
+                else if (r instanceof Date && !(l instanceof Collection || l instanceof Date)) {
+                    result = new Object[]{getDate(l), r};
+                } else if (l instanceof Date && !(r instanceof Collection || r instanceof Date)) {
+                    result = new Object[]{l, getDate(r)};
+                } // FLOATS
+                else if (r instanceof Float && !(l instanceof Float || l instanceof Collection)) {
+                    result = new Object[]{getFloat(l), r};
+                } else if (l instanceof Float && !(r instanceof Float || r instanceof Collection)) {
+                    result = new Object[]{l, getFloat(r)};
+                } // RIDS
+                else if (r instanceof ORID && l instanceof String && !oldL.equals(OSQLHelper.NOT_NULL)) {
+                    result = new Object[]{new ORecordId((String) l), r};
+                } else if (l instanceof ORID && r instanceof String && !oldR.equals(OSQLHelper.NOT_NULL)) {
+                    result = new Object[]{l, new ORecordId((String) r)};
+                }
+            }
+        } catch (Exception e) {
+            // JUST IGNORE CONVERSION ERRORS
+        }
+
+        return result;
+    }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/OLiveQueryTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/OLiveQueryTest.java
@@ -28,114 +28,144 @@ import com.orientechnologies.orient.core.sql.query.OLiveQuery;
 import com.orientechnologies.orient.core.sql.query.OLiveResultListener;
 import com.orientechnologies.orient.core.sql.query.OResultSet;
 import com.orientechnologies.orient.core.storage.OCluster;
-import org.junit.Assert; import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Created by luigidellaquila on 13/04/15.
  */
+@Test
 public class OLiveQueryTest {
 
-  private CountDownLatch latch = new CountDownLatch(2);
+    private CountDownLatch latch = new CountDownLatch(7);
 
-  class MyLiveQueryListener implements OLiveResultListener {
+    class MyLiveQueryListener implements OLiveResultListener {
 
-    public List<ORecordOperation> ops = new ArrayList<ORecordOperation>();
+        public int rowCount = 0;
 
-    @Override
-    public void onLiveResult(int iLiveToken, ORecordOperation iOp) throws OException {
-      ops.add(iOp);
-      latch.countDown();
+        @Override
+        public void onLiveResult(int iLiveToken, ORecordOperation iOp) throws OException {
+            switch (iOp.type) {
+                case ORecordOperation.CREATED: {
+                    this.rowCount++;
+                    break;
+                }
+                case ORecordOperation.DELETED: {
+                    this.rowCount--;
+                    break;
+                }
+            }
+            
+            System.out.println();
+            System.out.println("Operation :" + ORecordOperation.getName(iOp.type));            
+            System.out.println("Data: " + iOp.getRecord().toJSON());
+            System.out.println();
+            System.out.println("----------------------------------------------------------");
+
+            latch.countDown();
+        }
+
+        @Override
+        public void onError(int iLiveToken) {
+
+        }
+
+        @Override
+        public void onUnsubscribe(int iLiveToken) {
+
+        }
     }
 
-    @Override
-    public void onError(int iLiveToken) {
+    @Test
+    public void testLiveInsert() throws InterruptedException {
 
+        ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OLiveQueryTest");
+        db.activateOnCurrentThread();
+
+        if (!db.exists()) {
+            db.create();
+        }
+        try {
+            db.getMetadata().getSchema().createClass("test");
+            db.getMetadata().getSchema().createClass("test2");
+            MyLiveQueryListener listener = new MyLiveQueryListener();
+
+            OResultSet<ODocument> tokens = db.query(new OLiveQuery<ODocument>("live select _id as  id , surname.toUpperCase() as upName  from test where name='foo'", listener));
+            Assert.assertEquals(tokens.size(), 1);
+
+            ODocument tokenDoc = tokens.get(0);
+            Integer token = tokenDoc.field("token");
+            Assert.assertNotNull(token);
+
+            db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'bar', _id=1")).execute();
+            db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'baz', _id=2")).execute();
+            db.command(new OCommandSQL("insert into test set name = 'not foo', surname = 'bat', _id=3")).execute();
+            db.command(new OCommandSQL("insert into test2 set name = 'foo'")).execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(listener.rowCount, 2);
+
+            db.command(new OCommandSQL("update test set name = 'foo2' where  _id=2")).execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(listener.rowCount, 1);
+            db.command(new OCommandSQL("update  test set name = 'foo', surname = 'buzzzz' where  _id=3")).execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(listener.rowCount, 2);
+            db.command(new OCommandSQL("update test set  surname = 'Looks Fantastic' where  _id=1")).execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(listener.rowCount, 2);
+
+            db.command(new OCommandSQL("live unsubscribe " + token)).execute();
+
+            db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'bax'")).execute();
+            db.command(new OCommandSQL("insert into test2 set name = 'foo'"));
+            db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'baz'")).execute();
+
+            Assert.assertEquals(listener.rowCount, 2);
+        } catch (Exception ex) {
+            System.out.println(ex);
+
+        } finally {
+
+            db.drop();
+        }
     }
 
-    @Override
-    public void onUnsubscribe(int iLiveToken) {
+    @Test
+    public void testLiveInsertOnCluster() throws InterruptedException {
+        ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OLiveQueryTest");
+        db.activateOnCurrentThread();
+        db.create();
+        try {
+            OClass clazz = db.getMetadata().getSchema().createClass("test");
 
+            int defaultCluster = clazz.getDefaultClusterId();
+            OCluster cluster = db.getStorage().getClusterById(defaultCluster);
+
+            MyLiveQueryListener listener = new MyLiveQueryListener();
+
+            db.query(new OLiveQuery<ODocument>("live select from cluster:" + cluster.getName() + " where name='foo'", listener));
+
+            db.command(new OCommandSQL("insert into cluster:" + cluster.getName() + " set name = 'foo', surname = 'bar', _id =2"))
+                    .execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(1, listener.rowCount);
+            
+            db.command(new OCommandSQL("update   cluster:" + cluster.getName() + " set name = 'not foo' where _id=2"))
+                    .execute();
+            latch.await(150 , TimeUnit.MILLISECONDS);
+            Assert.assertEquals(0, listener.rowCount);
+            db.command(new OCommandSQL("update   cluster:" + cluster.getName() + " set name = 'foo' , surname='foo backs so it  is new create '  where _id=2")).execute();
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            Assert.assertEquals(listener.rowCount,1);
+        } finally {
+            db.drop();
+        }
     }
-  }
-
-  @Test
-  public void testLiveInsert() throws InterruptedException {
-
-    ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OLiveQueryTest");
-    db.activateOnCurrentThread();
-    db.create();
-    try {
-      db.getMetadata().getSchema().createClass("test");
-      db.getMetadata().getSchema().createClass("test2");
-      MyLiveQueryListener listener = new MyLiveQueryListener();
-
-      OResultSet<ODocument> tokens = db.query(new OLiveQuery<ODocument>("live select from test", listener));
-      Assert.assertEquals(tokens.size(), 1);
-
-      ODocument tokenDoc = tokens.get(0);
-      Integer token = tokenDoc.field("token");
-      Assert.assertNotNull(token);
-
-      db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'bar'")).execute();
-      db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'baz'")).execute();
-      db.command(new OCommandSQL("insert into test2 set name = 'foo'")).execute();
-
-      latch.await(1, TimeUnit.MINUTES);
-
-      db.command(new OCommandSQL("live unsubscribe " + token)).execute();
-
-      db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'bax'")).execute();
-      db.command(new OCommandSQL("insert into test2 set name = 'foo'"));
-      db.command(new OCommandSQL("insert into test set name = 'foo', surname = 'baz'")).execute();
-
-
-      Assert.assertEquals(listener.ops.size(), 2);
-      for (ORecordOperation doc : listener.ops) {
-        Assert.assertEquals(doc.type, ORecordOperation.CREATED);
-        Assert.assertEquals(((ODocument) doc.record).field("name"), "foo");
-      }
-    } finally {
-
-      db.drop();
-    }
-  }
-
-  @Test
-  public void testLiveInsertOnCluster() {
-    ODatabaseDocumentTx db = new ODatabaseDocumentTx("memory:OLiveQueryTest");
-    db.activateOnCurrentThread();
-    db.create();
-    try {
-      OClass clazz = db.getMetadata().getSchema().createClass("test");
-
-      int defaultCluster = clazz.getDefaultClusterId();
-      OCluster cluster = db.getStorage().getClusterById(defaultCluster);
-
-      MyLiveQueryListener listener = new MyLiveQueryListener();
-
-      db.query(new OLiveQuery<ODocument>("live select from cluster:" + cluster.getName(), listener));
-
-      db.command(new OCommandSQL("insert into cluster:" + cluster.getName() + " set name = 'foo', surname = 'bar'"))
-          .execute();
-
-      try {
-        Thread.sleep(3000);
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-      Assert.assertEquals(listener.ops.size(), 1);
-      for (ORecordOperation doc : listener.ops) {
-        Assert.assertEquals(doc.type, ORecordOperation.CREATED);
-        Assert.assertEquals(((ODocument) doc.record).field("name"), "foo");
-      }
-    } finally {
-      db.drop();
-    }
-  }
 
 }


### PR DESCRIPTION
there is no problem with  logic create and delete
but  in update  there is a logic problem 
for example  if  we have a table  discount  for products .. 

   select name , discount from products where discount>10 limit 5 ; 

and think that result is like that 
    Apple   20
    Peace   15 
    Milk    12
current  update logic  works only   if discount matches  handle  update .. 
first problem  is  if Bread's promotion is changed as  25  ,  it is not update for  this query  it is a new create... 
second problem  if Apple's discount  is changed as  5 , it must a be a delete for this query 
this commit supports  this logic and adds projections to Live query ..
