### PR TITLE
Suggestion: add tattletale report...

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -181,6 +181,46 @@
                     </resources>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>pick-orientdb-jars</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.orientechnologies</includeGroupIds>
+                            <outputDirectory>${project.build.directory}/tattletale/orientdb</outputDirectory>
+                            <silent>true</silent>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.tattletale</groupId>
+                <artifactId>tattletale-maven</artifactId>
+                <version>1.1.2.Final</version>
+                <configuration>
+                    <source>${project.build.directory}/tattletale/orientdb</source>
+                    <destination>${project.build.directory}/tattletale/report</destination>
+                    <reports>jar,multiplejarspackage,osgi</reports>
+                    <failOnError>true</failOnError>
+                    <failOnWarn>true</failOnWarn>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>tattletale</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
... to check and fail the build if there are split-packages between OrientDB modules. These can cause problems when deploying to modular systems such as OSGi. Note this PR is configured to fail the build when it detects split-packages, but you can set `failOnWarn` to false if you only want the report. At the moment there are split-packages in three places, so this PR would cause the build to break if merged as-is, unless `failOnWarn` was turned off. But once those are fixed this report would help avoid future split-package regressions. 

The report is generated in distribution/target/tattletale/report/index.html

See http://docs.jboss.org/tattletale/userguide/1.1/html/maven.html for the plugin documentation
