### PR TITLE
Fix split-package regression between orientdb-distributed and orientdb-server

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OClusterHealthChecker.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OClusterHealthChecker.java
@@ -17,12 +17,12 @@
  *  * For more information: http://www.orientechnologies.com
  *
  */
-package com.orientechnologies.orient.server.distributed;
+package com.orientechnologies.orient.server.distributed.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
-import com.orientechnologies.orient.server.distributed.impl.ODistributedStorage;
+import com.orientechnologies.orient.server.distributed.*;
 import com.orientechnologies.orient.server.distributed.impl.task.OHeartbeatTask;
 import com.orientechnologies.orient.server.distributed.task.ODistributedOperationException;
 import com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin;

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OConflictResolverDatabaseRepairer.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OConflictResolverDatabaseRepairer.java
@@ -17,7 +17,7 @@
  *  * For more information: http://www.orientechnologies.com
  *
  */
-package com.orientechnologies.orient.server.distributed;
+package com.orientechnologies.orient.server.distributed.impl;
 
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.Orient;
@@ -31,8 +31,8 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.storage.ORawBuffer;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.OStorageOperationResult;
+import com.orientechnologies.orient.server.distributed.*;
 import com.orientechnologies.orient.server.distributed.conflict.ODistributedConflictResolver;
-import com.orientechnologies.orient.server.distributed.impl.ODistributedTransactionManager;
 import com.orientechnologies.orient.server.distributed.impl.task.*;
 
 import java.io.IOException;

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -43,6 +43,7 @@ import com.orientechnologies.orient.server.OServer;
 import com.orientechnologies.orient.server.config.OServerParameterConfiguration;
 import com.orientechnologies.orient.server.distributed.*;
 import com.orientechnologies.orient.server.distributed.ODistributedServerLog.DIRECTION;
+import com.orientechnologies.orient.server.distributed.impl.OClusterHealthChecker;
 import com.orientechnologies.orient.server.distributed.impl.ODistributedAbstractPlugin;
 import com.orientechnologies.orient.server.distributed.impl.ODistributedDatabaseImpl;
 import com.orientechnologies.orient.server.distributed.impl.ODistributedMessageServiceImpl;


### PR DESCRIPTION
This was originally fixed in #6145 but has subsequently regressed. We need this backported to `2.2.x` in order to embed OrientDB using OSGi. I've also pushed a suggestion in #6602 to show how the build could be changed to automatically report on split-packages.

Note there are two other places involving split-packages, but they don't currently affect us:

* `com.orientechnologies.orient.core.db` split between orientdb-client and orientdb-core
* `com.orientechnologies.orient.server.network.protocol.http` split between orientdb-graphdb and orientdb-server

Both look as if they could be fixed with some small refactoring - the only thing to watch out for in the first case is a string reference to one of the client classes which would also need updating: https://github.com/orientechnologies/orientdb/blob/develop/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBFactory.java#L70