### PR TITLE
Allow non-core OrientDB modules to register streamable types with OStreamableHelper

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -51,6 +51,7 @@ import com.orientechnologies.orient.core.metadata.schema.OClassImpl;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.serialization.OStreamableHelper;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OClusterPositionMap;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OPaginatedCluster;
@@ -190,6 +191,11 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
       return;
 
     Orient.instance().addDbLifecycleListener(this);
+
+    // streamable types used for distributed protocol
+    OStreamableHelper.registerType(ODistributedRequestId.class);
+    OStreamableHelper.registerType(ODistributedDatabaseChunk.class);
+    OStreamableHelper.registerType(OTxTaskResult.class);
   }
 
   @Override


### PR DESCRIPTION
At the moment `OStreamableHelper` relies on `Class.forName` to lookup `OStreamable` types. While that works for types that are on the same classpath as the core module, it doesn't work well in OSGi or other modular systems, where types might be isolated to their defining module.

The simplest solution I found was to let non-core modules register their `OStreamable` types, using weak references so those types can still be unloaded when their defining module is unloaded. (To keep things simple dangling keys aren't cleaned up, but this shouldn't matter because there will only be a few entries in the cache and the keys are simple strings.)

We're using this change to deploy OrientDB distributed on top of Karaf and would also like it backported to 2.2.x. (Note the 2.1.x branch doesn't have this issue because it used a different approach for the distributed protocol.)