### PR TITLE
Fixed out-of-memory issue on initializing direct byte buffer pool.

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/directmemory/OByteBufferPool.java
+++ b/core/src/main/java/com/orientechnologies/common/directmemory/OByteBufferPool.java
@@ -154,7 +154,7 @@ public class OByteBufferPool implements OByteBufferPoolMXBean {
       pagesPerArea = closestPowerOfTwo(pagesPerArea);
 
       // we need not the biggest value, it may cause buffer overflow, but biggest after that.
-      while ((long) pagesPerArea * pageSize > maxChunkSize) {
+      while ((long) pagesPerArea * pageSize >= maxChunkSize) {
         pagesPerArea = pagesPerArea >>> 1;
       }
 


### PR DESCRIPTION
With 32-bit Java and smaller memory footprints, this bug manifests. For example, if you run with a max heap size of 494MB and a MaxDirectMemorySize of 512MB, you will instantly get an out of memory error when trying to initialize a direct memory buffer. This little commit fixes the issue.