### PR TITLE
Porting of stresstester.sh to windows platform

### DIFF
--- a/graphdb/script/stresstester.bat
+++ b/graphdb/script/stresstester.bat
@@ -1,0 +1,45 @@
+@echo off
+rem
+rem Copyright (c) OrientDB LTD (http://www.orientdb.com)
+rem
+rem Guess ORIENTDB_HOME if not defined
+set CURRENT_DIR=%cd%
+
+if exist "%JAVA_HOME%\bin\java.exe" goto setJavaHome
+set JAVA="java"
+goto okJava
+
+:setJavaHome
+set JAVA="%JAVA_HOME%\bin\java"
+
+:okJava
+if not "%ORIENTDB_HOME%" == "" goto gotHome
+set ORIENTDB_HOME=%CURRENT_DIR%
+if exist "%ORIENTDB_HOME%\bin\stresstester.bat" goto okHome
+cd ..
+set ORIENTDB_HOME=%cd%
+cd %CURRENT_DIR%
+
+:gotHome
+if exist "%ORIENTDB_HOME%\bin\stresstester.bat" goto okHome
+echo The ORIENTDB_HOME environment variable is not defined correctly
+echo This environment variable is needed to run this program
+goto end
+
+:okHome
+rem Get remaining unshifted command line arguments and save them in the
+set CMD_LINE_ARGS=
+
+:setArgs
+if ""%1""=="""" goto doneSetArgs
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+shift
+goto setArgs
+
+:doneSetArgs
+
+set ORIENTDB_SETTINGS=-XX:MaxDirectMemorySize=512g
+
+call %JAVA% %ORIENTDB_SETTINGS% -cp "%ORIENTDB_HOME%\lib\*" com.orientechnologies.orient.stresstest.OStressTester %CMD_LINE_ARGS%
+
+:end


### PR DESCRIPTION
I have followed the example of other .bat scripts included in the bin
directory, e.g. console.bat

I am not sure if some deploy scripts have to be changed so that this
file can now be included in next releases. Please let me know in case

Thanks,