### PR TITLE
ORIENTDB_ROOT_PASSWORD log message should be info, not warn

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -1075,7 +1075,7 @@ public class OServer {
       } while (rootPassword != null);
 
     } else
-      OLogManager.instance().warn(this, "Found ORIENTDB_ROOT_PASSWORD variable, using this value as root's password", rootPassword);
+      OLogManager.instance().info(this, "Found ORIENTDB_ROOT_PASSWORD variable, using this value as root's password", rootPassword);
 
     if (!serverCfg.existsUser(OServerConfiguration.DEFAULT_ROOT_USER)) {
       addUser(OServerConfiguration.DEFAULT_ROOT_USER, rootPassword, "*");


### PR DESCRIPTION
We set `ORIENTDB_ROOT_PASSWORD` when embedding OrientDB so the user doesn't have to manually enter it on the console. But when `ORIENTDB_ROOT_PASSWORD` is set there's a log warning which makes it look like something needs fixing, even though everything is ok:
```
Found ORIENTDB_ROOT_PASSWORD variable, using this value as root's password
```
This PR changes this log message from `warn` to `info`, since it's really just informational.