### PR TITLE
Fix misspellings

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ORecordLazyList.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ORecordLazyList.java
@@ -105,7 +105,7 @@ public class ORecordLazyList extends ORecordTrackedList implements ORecordLazyMu
   }
 
   /**
-   * @return iterator that just returns the elements without convertion.
+   * @return iterator that just returns the elements without conversion.
    */
   public Iterator<OIdentifiable> rawIterator() {
     lazyLoad(false);

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -1815,7 +1815,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
 
     final OPropertyImpl prop;
 
-    // This check are doubled becouse used by sql commands
+    // This check are doubled because used by sql commands
     if (linkedType != null)
       OPropertyImpl.checkLinkTypeSupport(type);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/OBase64Utils.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/OBase64Utils.java
@@ -98,7 +98,7 @@ import com.orientechnologies.common.util.OCommonConst;
  * <li><em>Does not break lines, by default.</em> This is to keep in compliance with
  * <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>.</li>
  * <li><em>Throws exceptions instead of returning null values.</em> Because some operations (especially those that may permit the
- * GZIP option) use IO streams, there is a possiblity of an java.io.IOException being thrown. After some discussion and thought,
+ * GZIP option) use IO streams, there is a possibility of an java.io.IOException being thrown. After some discussion and thought,
  * I've changed the behavior of the methods to throw java.io.IOExceptions rather than return null if ever there's an error. I think
  * this is more appropriate, though it will require some changes to your code. Sorry, it should have been done this way to begin
  * with.</li>
@@ -830,7 +830,7 @@ public class OBase64Utils {
    * <p>
    * Encodes up to three bytes of the array <var>source</var> and writes the resulting four Base64 bytes to <var>destination</var>.
    * The source and destination arrays can be manipulated anywhere along their length by specifying <var>srcOffset</var> and
-   * <var>destOffset</var>. This method does not check to make sure your arrays are large enough to accomodate <var>srcOffset</var>
+   * <var>destOffset</var>. This method does not check to make sure your arrays are large enough to accommodate <var>srcOffset</var>
    * + 3 for the <var>source</var> array or <var>destOffset</var> + 4 for the <var>destination</var> array. The actual number of
    * significant bytes in your array is given by <var>numSigBytes</var>.
    * </p>
@@ -1410,7 +1410,7 @@ public class OBase64Utils {
   /**
    * Decodes four bytes from array <var>source</var> and writes the resulting bytes (up to three of them) to <var>destination</var>.
    * The source and destination arrays can be manipulated anywhere along their length by specifying <var>srcOffset</var> and
-   * <var>destOffset</var>. This method does not check to make sure your arrays are large enough to accomodate <var>srcOffset</var>
+   * <var>destOffset</var>. This method does not check to make sure your arrays are large enough to accommodate <var>srcOffset</var>
    * + 4 for the <var>source</var> array or <var>destOffset</var> + 3 for the <var>destination</var> array. This method returns the
    * actual number of bytes that were converted from the Base64 encoding.
    * <p>

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/MatchEdgeTraverser.java
@@ -156,7 +156,7 @@ public class MatchEdgeTraverser {
     return filter == null || filter.matchesFilters(origin, iCommandContext);
   }
 
-  //TODO refactor this method to recieve the item.
+  //TODO refactor this method to receive the item.
 
   protected Iterable<OIdentifiable> traversePatternEdge(OIdentifiable startingPoint, OCommandContext iCommandContext) {
 

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
@@ -1165,7 +1165,7 @@ public class OSelectExecutionPlanner {
   }
 
   /**
-   * given a flat AND block and a set of indexes, returns the best index to be used to process it, with the complete descripton on how to use it
+   * given a flat AND block and a set of indexes, returns the best index to be used to process it, with the complete description on how to use it
    *
    * @param ctx
    * @param indexes

--- a/core/src/test/java/com/orientechnologies/orient/core/db/record/DocumentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/record/DocumentTest.java
@@ -80,7 +80,7 @@ public class DocumentTest {
   }
 
   @Test
-  public void testConvertionOnTypeSet() {
+  public void testConversionOnTypeSet() {
     ODocument doc = new ODocument();
 
     doc.field("some", 3);

--- a/core/src/test/java/com/orientechnologies/orient/core/db/record/ORecordLazySetPersistentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/record/ORecordLazySetPersistentTest.java
@@ -14,13 +14,13 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class ORecordLazySetPeristentTest {
+public class ORecordLazySetPersistentTest {
 
   private ODatabaseDocument db;
 
   @Before
   public void init() throws Exception {
-    String url = "memory:" + ORecordLazySetPeristentTest.class.getSimpleName();
+    String url = "memory:" + ORecordLazySetPersistentTest.class.getSimpleName();
     db = new ODatabaseDocumentTx(url);
     db = db.create();
   }

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/security/ORestricetedUserCleanUpTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/security/ORestricetedUserCleanUpTest.java
@@ -22,7 +22,7 @@ public class ORestricetedUserCleanUpTest {
       schema.createClass("TestRecord", schema.getClass(OSecurityShared.RESTRICTED_CLASSNAME));
 
       OSecurity security = db.getMetadata().getSecurity();
-      OUser auser = security.createUser("auser", "whereever", new String[] {});
+      OUser auser = security.createUser("auser", "wherever", new String[] {});
       OUser reader = security.getUser("admin");
       ODocument doc = new ODocument("TestRecord");
       Set<OIdentifiable> users = new HashSet<OIdentifiable>();

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentFieldConversionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentFieldConversionTest.java
@@ -99,7 +99,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionInteger() {
+  public void testLiteralToSchemaConversionInteger() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
     doc.field("integer", 2L);
@@ -139,7 +139,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionString() {
+  public void testLiteralToSchemaConversionString() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 
@@ -170,7 +170,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionFloat() {
+  public void testLiteralToSchemaConversionFloat() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 
@@ -210,7 +210,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionDouble() {
+  public void testLiteralToSchemaConversionDouble() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 
@@ -251,7 +251,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionLong() {
+  public void testLiteralToSchemaConversionLong() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 
@@ -292,7 +292,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionBoolean() {
+  public void testLiteralToSchemaConversionBoolean() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 
@@ -323,7 +323,7 @@ public class ODocumentFieldConversionTest {
   }
 
   @Test
-  public void testLiteralToSchemaConvertionDecimal() {
+  public void testLiteralToSchemaConversionDecimal() {
     ODatabaseRecordThreadLocal.INSTANCE.set(db);
     ODocument doc = new ODocument(clazz);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OLogSegmentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OLogSegmentTest.java
@@ -29,7 +29,7 @@ public class OLogSegmentTest {
     assertEquals(OWALPage.RECORDS_OFFSET, res.writeFrom);
     assertEquals(OWALPage.RECORDS_OFFSET * 2 + OWALPage.calculateSerializedSize(OWALPage.MAX_ENTRY_SIZE) + OWALPage.calculateSerializedSize(0), res.writeTo);
 
-    //it not fit becasue start from somewhere in the page
+    //it not fit because start from somewhere in the page
     res = OLogSegment.generateLogRecord(50, new byte[OWALPage.calculateRecordSize(OWALPage.MAX_ENTRY_SIZE)]);
     assertEquals(50, res.writeFrom);
     assertEquals(50 + OWALPage.RECORDS_OFFSET + OWALPage.MAX_ENTRY_SIZE + OWALPage.calculateSerializedSize(0), res.writeTo);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DefaultValuesTrivialTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DefaultValuesTrivialTest.java
@@ -98,7 +98,7 @@ public class DefaultValuesTrivialTest {
   }
 
   @Test
-  public void testDefaultValueConvertion() {
+  public void testDefaultValueConversion() {
     OSchema schema = database.getMetadata().getSchema();
     OClass classPerson = schema.createClass("Person");
     classPerson.createProperty("users", OType.LINKSET).setDefaultValue("[#5:1]");


### PR DESCRIPTION
Hi, I found and fixed some misspellings. :)
convertion -> conversion
becouse -> because
possiblity -> possibility
accomodate -> accommodate
recieve -> receive
descripton -> description
Peristent -> Persistent
whereever -> wherever

ORecordLazySetPeristentTest.java -> ORecordLazySetPersistentTest.java