### PR TITLE
add logs command to orientdb script

### DIFF
--- a/server/script/orientdb.sh
+++ b/server/script/orientdb.sh
@@ -13,7 +13,7 @@ ORIENTDB_USER="USER_YOU_WANT_ORIENTDB_RUN_WITH"
 LOG_DIR="../log"
 
 usage() {
-	echo "Usage: `basename $0`: <start|stop|status>"
+	echo "Usage: `basename $0`: <start|stop|logs|status>"
 	exit 1
 }
 
@@ -41,6 +41,11 @@ stop() {
 	su $ORIENTDB_USER -c "cd \"$ORIENTDB_DIR/bin\"; /usr/bin/nohup ./shutdown.sh 1>>$LOG_DIR/orientdb.log 2>>$LOG_DIR/orientdb.err &"
 }
 
+logs() {
+	echo "Tailing OrientDB server logs, press Ctrl+C to stop."
+	tail -qF -n0 $LOG_DIR/orientdb.err $LOG_DIR/orientdb.log
+}
+
 status() {
 	PID=` ps auxw | grep 'orientdb.www.path' | grep java | grep -v grep | awk '{print $2}'`
 	if [ "x$PID" = "x" ]
@@ -61,6 +66,12 @@ fi
 if [ "x$1" = "xstop" ]
 then
 	stop
+	exit 0
+fi
+
+if [ "x$1" = "xlogs" ]
+then
+	logs
 	exit 0
 fi
 


### PR DESCRIPTION
As a first time user, I was searching for something like this, thought I would submit it in case y'all thought it had more broad usefulness.

my flow as a first time user:

1. let's install this
```
brew install orientdb
```
2. lets run the command with the same name and see what happens
```
brew orientdb
```
```
Usage: orientdb: <start|stop|status>
```
3. Great! Let's start it up.

```
orientdb start
```
```
Starting OrientDB server daemon...
```
4. Bummer, I want to see what is going on. There is no flag to run it in the foreground. Now I have to figure out where logs are and which streams to tail... 
