### PR TITLE
ClassCastException in OTransactionAbstract.close()

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -116,11 +116,11 @@ public abstract class OTransactionAbstract implements OTransaction {
 
         if (lockedRecordMetadata.strategy.equals(OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK)) {
           for (int i = 0; i < lockedRecordMetadata.locksCount; i++) {
-            ((OAbstractPaginatedStorage) getDatabase().getStorage()).releaseWriteLock(lock.getKey());
+            ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseWriteLock(lock.getKey());
           }
         } else if (lockedRecordMetadata.strategy.equals(OStorage.LOCKING_STRATEGY.SHARED_LOCK)) {
           for (int i = 0; i < lockedRecordMetadata.locksCount; i++) {
-            ((OAbstractPaginatedStorage) getDatabase().getStorage()).releaseReadLock(lock.getKey());
+            ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseReadLock(lock.getKey());
           }
         }
       } catch (Exception e) {


### PR DESCRIPTION
Hi,

we are evaluating OrientDB if we might use it for us. During evaluation we stumbled on a issue with record locking: when we try to lock records during a transaction (via i.e. `db.getTransaction().lock(rid)`) the lock doesn't get released automatically on the underlaying storage when the transaction is committed or rolled back.
After some investigation we stumbled over a ClassCastException in `OTransactionAbstract.close()`:
```
java.lang.ClassCastException: com.orientechnologies.orient.server.distributed.impl.ODistributedStorage cannot be cast to com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage
     at com.orientechnologies.orient.core.tx.OTransactionAbstract.close(OTransactionAbstract.java:116)
     at com.orientechnologies.orient.core.tx.OTransactionRealAbstract.close(OTransactionRealAbstract.java:105)
     at com.orientechnologies.orient.core.tx.OTransactionOptimistic.close(OTransactionOptimistic.java:521)
     at com.orientechnologies.orient.core.tx.OTransactionOptimistic.doCommit(OTransactionOptimistic.java:554)
     at com.orientechnologies.orient.core.tx.OTransactionOptimistic.commit(OTransactionOptimistic.java:104)
```

When looking on `OTransactionAbstract.lockRecord()` we see that `database.getStorage().getUnderlaying()` is used for the cast operation to `OAbstractPaginatedSource`, whereas close() just uses `database.getStorage()`.

This PR fixes this. We would appreciate we would see it on the next release in the 2.2.x version ;)

Bye,
    Chris