### PR TITLE
The UNSAFE mode doesn't work on CREATE PROPERTY command

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateProperty.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateProperty.java
@@ -167,7 +167,7 @@ public class OCommandExecutorSQLCreateProperty extends OCommandExecutorSQLAbstra
         }
 
         // UNSAFE
-        if (m.group(3) != null) {
+        if (m.group(1) != null && m.group(1).equalsIgnoreCase("UNSAFE")) {
           this.unsafe = true;
         }
       } else {


### PR DESCRIPTION
For class have huge amount of records, append UNSAFE when execute CREATE PROPERTY can really save lots of time. But it doesn't work. I fixed the issue and tested on my company's product. Works well. 