### PR TITLE
Upgrade Hazelcast version to 3.8

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.6.5</version>
+            <version>3.8</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/AbstractServerClusterTest.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/AbstractServerClusterTest.java
@@ -17,7 +17,6 @@ package com.orientechnologies.orient.server.distributed;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
 import com.orientechnologies.common.concur.OTimeoutException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.util.OCallable;
@@ -103,7 +102,7 @@ public abstract class AbstractServerClusterTest {
   public void init(final int servers) {
     Orient.instance().closeAllStorages();
 
-    System.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "1");
+    System.setProperty("hazelcast.wait.seconds.before.join", "1");
 
     Orient.setRegisterDatabaseByPath(true);
     for (int i = 0; i < servers; ++i)

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ServerRun.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ServerRun.java
@@ -15,7 +15,6 @@
  */
 package com.orientechnologies.orient.server.distributed;
 
-import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
@@ -96,8 +95,8 @@ public class ServerRun {
     final Node currentNode = getHazelcastNode(((OHazelcastPlugin) server.getDistributedManager()).getHazelcastInstance());
     for (ServerRun s : serverIds) {
       final Node otherNode = getHazelcastNode(((OHazelcastPlugin) s.server.getDistributedManager()).getHazelcastInstance());
-      currentNode.clusterService.removeAddress(otherNode.address);
-      otherNode.clusterService.removeAddress(currentNode.address);
+      currentNode.clusterService.removeAddress(otherNode.address, "no reason");
+      otherNode.clusterService.removeAddress(currentNode.address, "no reason");
     }
   }
 
@@ -106,8 +105,7 @@ public class ServerRun {
     for (ServerRun s : serverIds) {
       final Node otherNode = getHazelcastNode(((OHazelcastPlugin) s.server.getDistributedManager()).getHazelcastInstance());
 
-      final ClusterServiceImpl clusterService = currentNode.getClusterService();
-      clusterService.merge(otherNode.address);
+      currentNode.getClusterService().merge(otherNode.address);
     }
   }
 


### PR DESCRIPTION
Tests adjusted for Hazelcast 3.8

The tests use some very internal Hazelcast classes which were changed
in Hazelcast 3.7 and 3.8