### PR TITLE
Network refactor for the new protocol v37

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/binary/OBinaryRequestExecutor.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/binary/OBinaryRequestExecutor.java
@@ -87,7 +87,11 @@ public interface OBinaryRequestExecutor {
 
   OBinaryResponse executeConnect(OConnectRequest request);
 
+  OBinaryResponse executeConnect37(OConnect37Request request);
+
   OBinaryResponse executeDatabaseOpen(OOpenRequest request);
+
+  OBinaryResponse executeDatabaseOpen37(OOpenRequest37 request);
 
   OBinaryResponse executeShutdown(OShutdownRequest request);
 

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OServerAdmin.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OServerAdmin.java
@@ -19,38 +19,10 @@
  */
 package com.orientechnologies.orient.client.remote;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.client.binary.OChannelBinaryAsynchClient;
-import com.orientechnologies.orient.client.remote.message.OConnectRequest;
-import com.orientechnologies.orient.client.remote.message.OConnectResponse;
-import com.orientechnologies.orient.client.remote.message.OCreateDatabaseRequest;
-import com.orientechnologies.orient.client.remote.message.OCreateDatabaseResponse;
-import com.orientechnologies.orient.client.remote.message.ODistributedStatusRequest;
-import com.orientechnologies.orient.client.remote.message.ODistributedStatusResponse;
-import com.orientechnologies.orient.client.remote.message.ODropDatabaseRequest;
-import com.orientechnologies.orient.client.remote.message.ODropDatabaseResponse;
-import com.orientechnologies.orient.client.remote.message.OExistsDatabaseRequest;
-import com.orientechnologies.orient.client.remote.message.OExistsDatabaseResponse;
-import com.orientechnologies.orient.client.remote.message.OFreezeDatabaseRequest;
-import com.orientechnologies.orient.client.remote.message.OFreezeDatabaseResponse;
-import com.orientechnologies.orient.client.remote.message.OGetGlobalConfigurationRequest;
-import com.orientechnologies.orient.client.remote.message.OGetGlobalConfigurationResponse;
-import com.orientechnologies.orient.client.remote.message.OListGlobalConfigurationsRequest;
-import com.orientechnologies.orient.client.remote.message.OListGlobalConfigurationsResponse;
-import com.orientechnologies.orient.client.remote.message.OServerInfoRequest;
-import com.orientechnologies.orient.client.remote.message.OServerInfoResponse;
-import com.orientechnologies.orient.client.remote.message.OListDatabasesResponse;
-import com.orientechnologies.orient.client.remote.message.OListDatabasesRequest;
-import com.orientechnologies.orient.client.remote.message.OReleaseDatabaseRequest;
-import com.orientechnologies.orient.client.remote.message.OReleaseDatabaseResponse;
-import com.orientechnologies.orient.client.remote.message.OSetGlobalConfigurationRequest;
-import com.orientechnologies.orient.client.remote.message.OSetGlobalConfigurationResponse;
+import com.orientechnologies.orient.client.remote.message.*;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
@@ -58,8 +30,12 @@ import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.security.OCredentialInterceptor;
 import com.orientechnologies.orient.core.security.OSecurityManager;
-import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerSchemaAware2CSV;
 import com.orientechnologies.orient.core.storage.OStorage;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Remote administration class of OrientDB Server instances.
@@ -122,7 +98,7 @@ public class OServerAdmin {
       username = iUserName;
       password = iUserPassword;
     }
-    OConnectRequest request = new OConnectRequest(username, password);
+    OConnect37Request request = new OConnect37Request(username, password);
 
     networkAdminOperation((network, session) -> {
       OStorageRemoteNodeSession nodeSession = session.getOrCreateServerSession(network.getServerURL());

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1260,7 +1260,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy {
     try {
       OStorageRemoteSession session = getCurrentSession();
       OStorageRemoteNodeSession nodeSession = session.getOrCreateServerSession(network.getServerURL());
-      OOpenRequest request = new OOpenRequest(name, session.connectionUserName, session.connectionUserPassword);
+      OOpenRequest37 request = new OOpenRequest37(name, session.connectionUserName, session.connectionUserPassword);
       try {
         network.writeByte(request.getCommand());
         network.writeInt(nodeSession.getSessionId());

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OBeginTransactionRequest.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OBeginTransactionRequest.java
@@ -9,14 +9,16 @@ import com.orientechnologies.orient.client.remote.message.tx.ORecordOperationReq
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class OBeginTransactionRequest implements OBinaryRequest<OBinaryResponse> {
 
@@ -64,7 +66,7 @@ public class OBeginTransactionRequest implements OBinaryRequest<OBinaryResponse>
   @Override
   public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
     //from 3.0 the the serializer is bound to the protocol
-    ORecordSerializerNetwork serializer = ORecordSerializerNetwork.INSTANCE;
+    ORecordSerializerNetworkV37 serializer = ORecordSerializerNetworkV37.INSTANCE;
 
     network.writeInt(txId);
     network.writeBoolean(usingLog);
@@ -82,7 +84,6 @@ public class OBeginTransactionRequest implements OBinaryRequest<OBinaryResponse>
 
   @Override
   public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
-    assert serializer instanceof ORecordSerializerNetwork;
     txId = channel.readInt();
     usingLog = channel.readBoolean();
     operations = new ArrayList<>();
@@ -96,7 +97,7 @@ public class OBeginTransactionRequest implements OBinaryRequest<OBinaryResponse>
     } while (hasEntry == 1);
 
     // RECEIVE MANUAL INDEX CHANGES
-    this.indexChanges = OMessageHelper.readTransactionIndexChanges(channel, (ORecordSerializerNetwork) serializer);
+    this.indexChanges = OMessageHelper.readTransactionIndexChanges(channel, (ORecordSerializerNetworkV37) serializer);
   }
 
   @Override

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OCommit37Request.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OCommit37Request.java
@@ -9,7 +9,7 @@ import com.orientechnologies.orient.client.remote.message.tx.ORecordOperationReq
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
@@ -71,7 +71,7 @@ public class OCommit37Request implements OBinaryRequest<OCommitResponse> {
   @Override
   public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
     //from 3.0 the the serializer is bound to the protocol
-    ORecordSerializerNetwork serializer = ORecordSerializerNetwork.INSTANCE;
+    ORecordSerializerNetworkV37 serializer = ORecordSerializerNetworkV37.INSTANCE;
     network.writeInt(txId);
     network.writeBoolean(hasContent);
     network.writeBoolean(usingLog);
@@ -90,7 +90,6 @@ public class OCommit37Request implements OBinaryRequest<OCommitResponse> {
 
   @Override
   public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
-    assert serializer instanceof ORecordSerializerNetwork;
     txId = channel.readInt();
     hasContent = channel.readBoolean();
     usingLog = channel.readBoolean();
@@ -106,7 +105,7 @@ public class OCommit37Request implements OBinaryRequest<OCommitResponse> {
       } while (hasEntry == 1);
 
       // RECEIVE MANUAL INDEX CHANGES
-      this.indexChanges = OMessageHelper.readTransactionIndexChanges(channel, (ORecordSerializerNetwork) serializer);
+      this.indexChanges = OMessageHelper.readTransactionIndexChanges(channel, (ORecordSerializerNetworkV37) serializer);
     }
   }
 

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OConnect37Request.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OConnect37Request.java
@@ -3,45 +3,34 @@ package com.orientechnologies.orient.client.remote.message;
 import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
 import com.orientechnologies.orient.client.remote.OBinaryRequest;
 import com.orientechnologies.orient.client.remote.OBinaryResponse;
-import com.orientechnologies.orient.client.remote.OStorageRemote;
 import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
-import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
 
 import java.io.IOException;
 
-public class OConnectRequest implements OBinaryRequest<OConnectResponse> {
-  private String  username;
-  private String  password;
-  private String  driverName      = OStorageRemote.DRIVER_NAME;
-  private String  driverVersion   = OConstants.ORIENT_VERSION;
-  private short   protocolVersion = OChannelBinaryProtocol.CURRENT_PROTOCOL_VERSION;
-  private String  clientId        = null;
-  private String  recordFormat    = ORecordSerializerNetworkV37.NAME;
-  private boolean tokenBased      = true;
-  private boolean supportPush     = true;
-  private boolean collectStats    = true;
+public class OConnect37Request implements OBinaryRequest<OConnectResponse> {
+  private String username;
+  private String password;
+  private String  clientId     = null;
+  private boolean tokenBased   = true;
+  private boolean supportPush  = true;
+  private boolean collectStats = true;
 
-  public OConnectRequest(String username, String password) {
+  public OConnect37Request(String username, String password) {
     this.username = username;
     this.password = password;
   }
 
-  public OConnectRequest() {
+  public OConnect37Request() {
   }
 
   @Override
   public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
-    network.writeString(driverName);
-    network.writeString(driverVersion);
-    network.writeShort(protocolVersion);
     network.writeString(clientId);
 
-    network.writeString(recordFormat);
     network.writeBoolean(tokenBased);
     network.writeBoolean(supportPush);
     network.writeBoolean(collectStats);
@@ -53,24 +42,12 @@ public class OConnectRequest implements OBinaryRequest<OConnectResponse> {
   @Override
   public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
 
-    driverName = channel.readString();
-    driverVersion = channel.readString();
-    this.protocolVersion = channel.readShort();
     clientId = channel.readString();
-    recordFormat = channel.readString();
 
-    if (this.protocolVersion > OChannelBinaryProtocol.PROTOCOL_VERSION_26)
-      tokenBased = channel.readBoolean();
-    else
-      tokenBased = false;
+    tokenBased = channel.readBoolean();
 
-    if (this.protocolVersion > OChannelBinaryProtocol.PROTOCOL_VERSION_33) {
-      supportPush = channel.readBoolean();
-      collectStats = channel.readBoolean();
-    } else {
-      supportPush = true;
-      collectStats = true;
-    }
+    supportPush = channel.readBoolean();
+    collectStats = channel.readBoolean();
 
     username = channel.readString();
     password = channel.readString();
@@ -91,29 +68,17 @@ public class OConnectRequest implements OBinaryRequest<OConnectResponse> {
     return clientId;
   }
 
-  public String getDriverName() {
-    return driverName;
-  }
 
-  public String getDriverVersion() {
-    return driverVersion;
-  }
 
   public String getPassword() {
     return password;
   }
 
-  public short getProtocolVersion() {
-    return protocolVersion;
-  }
 
   public String getUsername() {
     return username;
   }
 
-  public String getRecordFormat() {
-    return recordFormat;
-  }
 
   public boolean isCollectStats() {
     return collectStats;
@@ -139,7 +104,7 @@ public class OConnectRequest implements OBinaryRequest<OConnectResponse> {
 
   @Override
   public OBinaryResponse execute(OBinaryRequestExecutor executor) {
-    return executor.executeConnect(this);
+    return executor.executeConnect37(this);
   }
 
 }

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OFetchTransactionResponse.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OFetchTransactionResponse.java
@@ -7,14 +7,13 @@ import com.orientechnologies.orient.client.remote.message.tx.ORecordOperationReq
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -72,12 +71,12 @@ public class OFetchTransactionResponse implements OBinaryResponse {
     channel.writeByte((byte) 0);
 
     // SEND MANUAL INDEX CHANGES
-    OMessageHelper.writeTransactionIndexChanges(channel, (ORecordSerializerNetwork) serializer, indexChanges);
+    OMessageHelper.writeTransactionIndexChanges(channel, (ORecordSerializerNetworkV37) serializer, indexChanges);
   }
 
   @Override
   public void read(OChannelDataInput network, OStorageRemoteSession session) throws IOException {
-    ORecordSerializerNetwork serializer = ORecordSerializerNetwork.INSTANCE;
+    ORecordSerializerNetworkV37 serializer = ORecordSerializerNetworkV37.INSTANCE;
     txId = network.readInt();
     operations = new ArrayList<>();
     byte hasEntry;
@@ -90,7 +89,7 @@ public class OFetchTransactionResponse implements OBinaryResponse {
     } while (hasEntry == 1);
 
     // RECEIVE MANUAL INDEX CHANGES
-    this.indexChanges = OMessageHelper.readTransactionIndexChanges(network, (ORecordSerializerNetwork) serializer);
+    this.indexChanges = OMessageHelper.readTransactionIndexChanges(network, serializer);
   }
 
   public int getTxId() {

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OListDatabasesResponse.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OListDatabasesResponse.java
@@ -1,14 +1,15 @@
 package com.orientechnologies.orient.client.remote.message;
 
-import java.io.IOException;
-import java.util.Map;
-
 import com.orientechnologies.orient.client.remote.OBinaryResponse;
 import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class OListDatabasesResponse implements OBinaryResponse{
   private Map<String, String> databases;
@@ -30,8 +31,9 @@ public class OListDatabasesResponse implements OBinaryResponse{
 
   @Override
   public void read(OChannelDataInput network, OStorageRemoteSession session) throws IOException {
+    ORecordSerializer serializer = ORecordSerializerNetworkFactory.INSTANCE.current();
     final ODocument result = new ODocument();
-    result.fromStream(network.readBytes());
+    serializer.fromStream(network.readBytes(),result,null);
     databases = result.field("databases");
   }
 

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OMessageHelper.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OMessageHelper.java
@@ -1,9 +1,5 @@
 package com.orientechnologies.orient.client.remote.message;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.Map.Entry;
-
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.client.remote.OClusterRemote;
@@ -24,7 +20,7 @@ import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.storage.OCluster;
 import com.orientechnologies.orient.core.storage.OPhysicalPosition;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
@@ -32,6 +28,10 @@ import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class OMessageHelper {
 
@@ -227,7 +227,7 @@ public class OMessageHelper {
     return entry;
   }
 
-  static void writeTransactionIndexChanges(OChannelDataOutput network, ORecordSerializerNetwork serializer,
+  static void writeTransactionIndexChanges(OChannelDataOutput network, ORecordSerializerNetworkV37 serializer,
       List<IndexChange> changes) throws IOException {
     network.writeInt(changes.size());
     for (IndexChange indexChange : changes) {
@@ -269,7 +269,7 @@ public class OMessageHelper {
     }
   }
 
-  static List<IndexChange> readTransactionIndexChanges(OChannelDataInput channel, ORecordSerializerNetwork serializer)
+  static List<IndexChange> readTransactionIndexChanges(OChannelDataInput channel, ORecordSerializerNetworkV37 serializer)
       throws IOException {
     List<IndexChange> changes = new ArrayList<>();
     int val = channel.readInt();

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OOpenRequest37.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OOpenRequest37.java
@@ -1,0 +1,113 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
+import com.orientechnologies.orient.client.remote.OBinaryRequest;
+import com.orientechnologies.orient.client.remote.OBinaryResponse;
+import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+
+public class OOpenRequest37 implements OBinaryRequest<OOpenResponse> {
+
+  private String  clientId     = null;
+  private boolean useToken     = true;
+  private boolean supportsPush = true;
+  private boolean collectStats = true;
+  private String databaseName;
+  private String userName;
+  private String userPassword;
+
+  public OOpenRequest37(String databaseName, String userName, String userPassword) {
+    this.databaseName = databaseName;
+    this.userName = userName;
+    this.userPassword = userPassword;
+  }
+
+  public OOpenRequest37() {
+
+  }
+
+  @Override
+  public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
+    network.writeString(clientId);
+    network.writeBoolean(useToken);
+    network.writeBoolean(supportsPush);
+    network.writeBoolean(collectStats);
+    network.writeString(databaseName);
+    network.writeString(userName);
+    network.writeString(userPassword);
+  }
+
+  @Override
+  public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
+
+    clientId = channel.readString();
+
+    useToken = channel.readBoolean();
+    supportsPush = channel.readBoolean();
+    collectStats = channel.readBoolean();
+
+    databaseName = channel.readString();
+    userName = channel.readString();
+    userPassword = channel.readString();
+  }
+
+  @Override
+  public byte getCommand() {
+    return OChannelBinaryProtocol.REQUEST_DB_OPEN;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Open Database";
+  }
+
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public String getUserPassword() {
+    return userPassword;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+
+  public boolean isCollectStats() {
+    return collectStats;
+  }
+
+  public boolean isSupportsPush() {
+    return supportsPush;
+  }
+
+  public boolean isUseToken() {
+    return useToken;
+  }
+
+  @Override
+  public boolean requireDatabaseSession() {
+    return false;
+  }
+
+  @Override
+  public OOpenResponse createResponse() {
+    return new OOpenResponse();
+  }
+
+  @Override
+  public OBinaryResponse execute(OBinaryRequestExecutor executor) {
+    return executor.executeDatabaseOpen37(this);
+  }
+
+}

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -20,10 +20,6 @@
 
 package com.orientechnologies.orient.core.db.document;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.client.remote.ORemoteQueryResult;
@@ -33,11 +29,7 @@ import com.orientechnologies.orient.client.remote.message.ORemoteResultSet;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
 import com.orientechnologies.orient.core.command.script.OCommandScriptException;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
-import com.orientechnologies.orient.core.db.ODatabase;
-import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.db.ODatabaseListener;
-import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
-import com.orientechnologies.orient.core.db.OrientDBConfig;
+import com.orientechnologies.orient.core.db.*;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
 import com.orientechnologies.orient.core.exception.ODatabaseException;
 import com.orientechnologies.orient.core.hook.ORecordHook;
@@ -47,11 +39,15 @@ import com.orientechnologies.orient.core.metadata.security.ORole;
 import com.orientechnologies.orient.core.metadata.security.OToken;
 import com.orientechnologies.orient.core.metadata.security.OUser;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializerFactory;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.tx.OTransaction;
 import com.orientechnologies.orient.core.tx.OTransactionOptimistic;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Created by tglman on 30/06/16.
@@ -173,7 +169,7 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
       return;
 
     ORecordSerializerFactory serializerFactory = ORecordSerializerFactory.instance();
-    serializer = serializerFactory.getFormat(ORecordSerializerNetwork.NAME);
+    serializer = serializerFactory.getFormat(ORecordSerializerNetworkV37.NAME);
     localCache.startup();
     componentsFactory = getStorage().getComponentsFactory();
     user = null;

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/message/OQueryRequestTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/message/OQueryRequestTest.java
@@ -1,6 +1,6 @@
 package com.orientechnologies.orient.client.remote.message;
 
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,7 +15,7 @@ public class OQueryRequestTest {
 
   @Test public void testWithPositionalParams() throws IOException {
     Object[] params = new Object[] { 1, "Foo" };
-    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetwork.INSTANCE, 123);
+    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetworkFactory.INSTANCE.current(), 123);
 
     MockChannel channel = new MockChannel();
     request.write(channel, null);
@@ -23,7 +23,7 @@ public class OQueryRequestTest {
     channel.close();
 
     OQueryRequest other = new OQueryRequest();
-    other.read(channel, -1, ORecordSerializerNetwork.INSTANCE);
+    other.read(channel, -1, ORecordSerializerNetworkFactory.INSTANCE.current());
 
     Assert.assertEquals(request.getCommand(), other.getCommand());
 
@@ -38,7 +38,7 @@ public class OQueryRequestTest {
     Map<String, Object> params = new HashMap<>();
     params.put("foo", "bar");
     params.put("baz", 12);
-    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetwork.INSTANCE, 123);
+    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetworkFactory.INSTANCE.current(), 123);
 
     MockChannel channel = new MockChannel();
     request.write(channel, null);
@@ -46,7 +46,7 @@ public class OQueryRequestTest {
     channel.close();
 
     OQueryRequest other = new OQueryRequest();
-    other.read(channel, -1, ORecordSerializerNetwork.INSTANCE);
+    other.read(channel, -1, ORecordSerializerNetworkFactory.INSTANCE.current());
 
     Assert.assertEquals(request.getCommand(), other.getCommand());
     Assert.assertTrue(other.isNamedParams());
@@ -57,7 +57,7 @@ public class OQueryRequestTest {
 
   @Test public void testWithNoParams() throws IOException {
     Map<String, Object> params = null;
-    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetwork.INSTANCE, 123);
+    OQueryRequest request = new OQueryRequest("sql", "select from Foo where a = ?", params, true, ORecordSerializerNetworkFactory.INSTANCE.current(), 123);
 
     MockChannel channel = new MockChannel();
     request.write(channel, null);
@@ -65,7 +65,7 @@ public class OQueryRequestTest {
     channel.close();
 
     OQueryRequest other = new OQueryRequest();
-    other.read(channel, -1, ORecordSerializerNetwork.INSTANCE);
+    other.read(channel, -1, ORecordSerializerNetworkFactory.INSTANCE.current());
 
     Assert.assertEquals(request.getCommand(), other.getCommand());
     Assert.assertTrue(other.isNamedParams());

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/message/OQueryResponseTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/message/OQueryResponseTest.java
@@ -1,6 +1,6 @@
 package com.orientechnologies.orient.client.remote.message;
 
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
 import com.orientechnologies.orient.core.sql.executor.OInternalResultSet;
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultInternal;
@@ -28,7 +28,7 @@ public class OQueryResponseTest {
     response.setResult(new OLocalResultSetLifecycleDecorator(rs));
 
     MockChannel channel = new MockChannel();
-    response.write(channel, OChannelBinaryProtocol.CURRENT_PROTOCOL_VERSION, ORecordSerializerNetwork.INSTANCE);
+    response.write(channel, OChannelBinaryProtocol.CURRENT_PROTOCOL_VERSION, ORecordSerializerNetworkFactory.INSTANCE.current());
 
     channel.close();
 

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/message/ORemoteTransactionMessagesTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/message/ORemoteTransactionMessagesTest.java
@@ -1,26 +1,20 @@
 package com.orientechnologies.orient.client.remote.message;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import org.junit.Test;
-
 import com.orientechnologies.common.comparator.ODefaultComparator;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges.OPERATION;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class ORemoteTransactionMessagesTest {
 
@@ -46,7 +40,7 @@ public class ORemoteTransactionMessagesTest {
     channel.close();
 
     OBeginTransactionRequest readRequest = new OBeginTransactionRequest();
-    readRequest.read(channel, 0, ORecordSerializerNetwork.INSTANCE);
+    readRequest.read(channel, 0, ORecordSerializerNetworkFactory.INSTANCE.current());
     assertTrue(readRequest.isUsingLog());
     assertEquals(readRequest.getOperations().size(), 1);
     assertEquals(readRequest.getTxId(), 0);
@@ -85,7 +79,7 @@ public class ORemoteTransactionMessagesTest {
     channel.close();
 
     OCommit37Request readRequest = new OCommit37Request();
-    readRequest.read(channel, 0, ORecordSerializerNetwork.INSTANCE);
+    readRequest.read(channel, 0, ORecordSerializerNetworkFactory.INSTANCE.current());
     assertTrue(readRequest.isUsingLog());
     assertEquals(readRequest.getOperations().size(), 1);
     assertEquals(readRequest.getTxId(), 0);
@@ -113,7 +107,7 @@ public class ORemoteTransactionMessagesTest {
     channel.close();
 
     OCommit37Request readRequest = new OCommit37Request();
-    readRequest.read(channel, 0, ORecordSerializerNetwork.INSTANCE);
+    readRequest.read(channel, 0, ORecordSerializerNetworkFactory.INSTANCE.current());
     assertTrue(readRequest.isUsingLog());
     assertNull(readRequest.getOperations());
     assertEquals(readRequest.getTxId(), 0);
@@ -137,7 +131,7 @@ public class ORemoteTransactionMessagesTest {
 
     MockChannel channel = new MockChannel();
     OFetchTransactionResponse response = new OFetchTransactionResponse(10, operations, changes);
-    response.write(channel, 0, ORecordSerializerNetwork.INSTANCE);
+    response.write(channel, 0, ORecordSerializerNetworkV37.INSTANCE);
 
     channel.close();
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/sbtree/OSBTreeRidBag.java
@@ -31,7 +31,6 @@ import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.record.*;
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBagDelegate;
-import com.orientechnologies.orient.core.db.record.ridbag.sbtree.OSBTreeRidBag.Change;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.index.sbtree.OTreeInternal;
@@ -941,6 +940,8 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     this.size = -1;
 
     changes.putAll(ChangeSerializationHelper.INSTANCE.deserializeChanges(stream, offset));
+
+    offset += OIntegerSerializer.INT_SIZE + (OLinkSerializer.RID_SIZE + Change.SIZE) * changes.size();
 
     return offset;
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializer.java
@@ -37,4 +37,6 @@ public interface ORecordSerializer {
   String[] getFieldNames(ODocument reference, byte[] iSource);
 
   boolean getSupportBinaryEvaluate();
+
+  String getName();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializerFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializerFactory.java
@@ -19,16 +19,17 @@
   */
 package com.orientechnologies.orient.core.serialization.serializer.record;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.exception.ODatabaseException;
 import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerBinary;
 import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
 import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerJSON;
 import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerSchemaAware2CSV;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Factory of record serialized.
@@ -47,6 +48,8 @@ public class ORecordSerializerFactory {
     register(ORecordSerializerRaw.NAME, new ORecordSerializerRaw());
     register(ORecordSerializerBinary.NAME, ORecordSerializerBinary.INSTANCE);
     register(ORecordSerializerNetwork.NAME, ORecordSerializerNetwork.INSTANCE);
+    register(ORecordSerializerNetworkV37.NAME,ORecordSerializerNetworkV37.INSTANCE);
+
     defaultRecordSerializer = getFormat(OGlobalConfiguration.DB_DOCUMENT_SERIALIZER.getValueAsString());
     if (defaultRecordSerializer == null)
       throw new ODatabaseException(

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializerRaw.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/ORecordSerializerRaw.java
@@ -80,4 +80,9 @@ public class ORecordSerializerRaw implements ORecordSerializer {
   public boolean getSupportBinaryEvaluate() {
     return false;
   }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
@@ -147,4 +147,9 @@ public class ORecordSerializerBinary implements ORecordSerializer {
   public boolean getSupportBinaryEvaluate() {
     return true;
   }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetwork.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetwork.java
@@ -151,4 +151,8 @@ public class ORecordSerializerNetwork implements ORecordSerializer {
     return false;
   }
 
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkFactory.java
@@ -1,0 +1,25 @@
+package com.orientechnologies.orient.core.serialization.serializer.record.binary;
+
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
+
+/**
+ * Created by Enrico Risa on 10/04/17.
+ */
+public class ORecordSerializerNetworkFactory {
+
+  public static ORecordSerializerNetworkFactory INSTANCE = new ORecordSerializerNetworkFactory();
+
+  public ORecordSerializer current() {
+    return forProtocol(OChannelBinaryProtocol.CURRENT_PROTOCOL_VERSION);
+  }
+
+  public ORecordSerializer forProtocol(int protocolNumber) {
+
+    if (protocolNumber >= OChannelBinaryProtocol.PROTOCOL_VERSION_37) {
+      return ORecordSerializerNetworkV37.INSTANCE;
+    } else {
+      return ORecordSerializerNetwork.INSTANCE;
+    }
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
@@ -204,7 +204,7 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
 
   public byte[] serializeValue(Object value, OType type) {
     BytesContainer bytes = new BytesContainer();
-    serializeValue(bytes,value,type,null);
+    serializeValue(bytes, value, type, null);
     return bytes.fitBytes();
   }
 
@@ -379,20 +379,16 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
   private Collection<?> readEmbeddedCollection(final BytesContainer bytes, final Collection<Object> found,
       final ODocument document) {
     final int items = OVarIntSerializer.readAsInteger(bytes);
-    OType type = readOType(bytes);
 
-    if (type == OType.ANY) {
-      for (int i = 0; i < items; i++) {
-        OType itemType = readOType(bytes);
-        if (itemType == OType.ANY)
-          found.add(null);
-        else
-          found.add(deserializeValue(bytes, itemType, document));
-      }
-      return found;
+    for (int i = 0; i < items; i++) {
+      OType itemType = readOType(bytes);
+      if (itemType == OType.ANY)
+        found.add(null);
+      else
+        found.add(deserializeValue(bytes, itemType, document));
     }
-    // TODO: manage case where type is known
-    return null;
+    return found;
+
   }
 
   private OType getLinkedType(ODocument document, OType type, String key) {
@@ -617,7 +613,6 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
   private int writeEmbeddedCollection(final BytesContainer bytes, final Collection<?> value, final OType linkedType) {
     final int pos = OVarIntSerializer.write(bytes, value.size());
     // TODO manage embedded type from schema and auto-determined.
-    writeOType(bytes, bytes.alloc(1), OType.ANY);
     for (Object itemValue : value) {
       // TODO:manage in a better way null entry
       if (itemValue == null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
@@ -51,9 +51,11 @@ import java.util.Map.Entry;
 
 public class ORecordSerializerNetworkV37 implements ORecordSerializer {
 
-  private static final String    CHARSET_UTF_8    = "UTF-8";
-  private static final ORecordId NULL_RECORD_ID   = new ORecordId(-2, ORID.CLUSTER_POS_INVALID);
-  private static final long      MILLISEC_PER_DAY = 86400000;
+  public static final  String                      NAME             = "onet_ser_v37";
+  private static final String                      CHARSET_UTF_8    = "UTF-8";
+  private static final ORecordId                   NULL_RECORD_ID   = new ORecordId(-2, ORID.CLUSTER_POS_INVALID);
+  private static final long                        MILLISEC_PER_DAY = 86400000;
+  public static final  ORecordSerializerNetworkV37 INSTANCE         = new ORecordSerializerNetworkV37();
 
   public ORecordSerializerNetworkV37() {
   }
@@ -77,6 +79,9 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
       } else {
         value = deserializeValue(bytes, type, document);
       }
+      if (ODocumentInternal.rawContainsField(document, fieldName)) {
+        continue;
+      }
       document.setProperty(fieldName, value);
 
       for (String field : iFields) {
@@ -97,21 +102,21 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
 
     String fieldName;
     OType type;
+    Object value;
     int size = OVarIntSerializer.readAsInteger(bytes);
     while ((size--) > 0) {
       // PARSE FIELD NAME
       fieldName = readString(bytes);
       type = readOType(bytes);
+      if (type == null) {
+        value = null;
+      } else {
+        value = deserializeValue(bytes, type, document);
+      }
       if (ODocumentInternal.rawContainsField(document, fieldName)) {
         continue;
       }
-      if (type == null) {
-        document.setProperty(fieldName, null);
-      } else {
-        final Object value = deserializeValue(bytes, type, document);
-        document.setProperty(fieldName, value, type);
-      }
-
+      document.setProperty(fieldName, value, type);
     }
 
     ORecordInternal.clearSource(document);
@@ -127,7 +132,7 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
       return;
     }
     final Set<Entry<String, ODocumentEntry>> fields = ODocumentInternal.rawEntries(document);
-    OVarIntSerializer.write(bytes, fields.size());
+    OVarIntSerializer.write(bytes, document.fields());
     for (Entry<String, ODocumentEntry> entry : fields) {
       ODocumentEntry docEntry = entry.getValue();
       if (!docEntry.exist())
@@ -195,6 +200,17 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
     } else {
       bytes.bytes[pos] = (byte) type.getId();
     }
+  }
+
+  public byte[] serializeValue(Object value, OType type) {
+    BytesContainer bytes = new BytesContainer();
+    serializeValue(bytes,value,type,null);
+    return bytes.fitBytes();
+  }
+
+  public Object deserializeValue(byte[] val, OType type) {
+    BytesContainer bytes = new BytesContainer(val);
+    return deserializeValue(bytes, type, null);
   }
 
   public Object deserializeValue(BytesContainer bytes, OType type, ODocument document) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
@@ -818,4 +818,9 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
   public boolean getSupportBinaryEvaluate() {
     return false;
   }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
@@ -764,4 +764,9 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
     }
     return null;
   }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerSchemaAware2CSV.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerSchemaAware2CSV.java
@@ -547,4 +547,10 @@ public class ORecordSerializerSchemaAware2CSV extends ORecordSerializerCSVAbstra
 
     return linkedClass;
   }
+
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerStringAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerStringAbstract.java
@@ -710,4 +710,5 @@ public abstract class ORecordSerializerStringAbstract implements ORecordSerializ
   public boolean getSupportBinaryEvaluate() {
     return false;
   }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLQuery.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLQuery.java
@@ -33,7 +33,6 @@ import com.orientechnologies.orient.core.query.OQueryAbstract;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.OMemoryStream;
-import com.orientechnologies.orient.core.serialization.OSerializableStream;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
 
 import java.util.ArrayList;
@@ -109,7 +108,7 @@ public abstract class OSQLQuery<T> extends OQueryAbstract<T> implements OCommand
   public OCommandRequestText fromStream(final byte[] iStream, ORecordSerializer serializer) throws OSerializationException {
     final OMemoryStream buffer = new OMemoryStream(iStream);
 
-    queryFromStream(buffer);
+    queryFromStream(buffer,serializer);
 
     return this;
   }
@@ -130,22 +129,23 @@ public abstract class OSQLQuery<T> extends OQueryAbstract<T> implements OCommand
     return buffer;
   }
 
-  protected void queryFromStream(final OMemoryStream buffer) {
+  protected void queryFromStream(final OMemoryStream buffer, ORecordSerializer serializer) {
     text = buffer.getAsString();
     limit = buffer.getAsInteger();
 
     setFetchPlan(buffer.getAsString());
 
     final byte[] paramBuffer = buffer.getAsByteArray();
-    parameters = deserializeQueryParameters(paramBuffer);
+    parameters = deserializeQueryParameters(paramBuffer,serializer);
   }
 
-  protected Map<Object, Object> deserializeQueryParameters(final byte[] paramBuffer) {
+  protected Map<Object, Object> deserializeQueryParameters(final byte[] paramBuffer, ORecordSerializer serializer) {
     if (paramBuffer == null || paramBuffer.length == 0)
       return Collections.emptyMap();
 
     final ODocument param = new ODocument();
-    param.fromStream(paramBuffer);
+
+    serializer.fromStream(paramBuffer,param,null);
     param.setFieldType("params", OType.EMBEDDEDMAP);
     final Map<String, Object> params = param.rawField("params");
 

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLSynchQuery.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/query/OSQLSynchQuery.java
@@ -19,16 +19,17 @@
  */
 package com.orientechnologies.orient.core.sql.query;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.orientechnologies.orient.core.command.OCommandResultListener;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.serialization.OMemoryStream;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * SQL synchronous query. When executed the caller wait for the result.
@@ -146,8 +147,8 @@ public class OSQLSynchQuery<T extends Object> extends OSQLAsynchQuery<T> impleme
   }
 
   @Override
-  protected void queryFromStream(final OMemoryStream buffer) {
-    super.queryFromStream(buffer);
+  protected void queryFromStream(final OMemoryStream buffer, ORecordSerializer serializer) {
+    super.queryFromStream(buffer, serializer);
 
     final String rid = buffer.getAsString();
     if ("".equals(rid))
@@ -156,7 +157,7 @@ public class OSQLSynchQuery<T extends Object> extends OSQLAsynchQuery<T> impleme
       nextPageRID = new ORecordId(rid);
 
     final byte[] serializedPrevParams = buffer.getAsByteArray();
-    previousQueryParams = deserializeQueryParameters(serializedPrevParams);
+    previousQueryParams = deserializeQueryParameters(serializedPrevParams, serializer);
 
   }
 

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSchemalessBinarySerializationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSchemalessBinarySerializationTest.java
@@ -8,6 +8,7 @@ import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.exception.OSerializationException;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.serialization.ODocumentSerializable;
 import com.orientechnologies.orient.core.serialization.OSerializableStream;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
@@ -847,6 +848,50 @@ public class ODocumentSchemalessBinarySerializationTest {
 
   }
 
+  @Test
+  public void testWithRemove() {
+    ODocument document = new ODocument();
+    document.field("name", "name");
+    document.field("age", 20);
+    document.field("youngAge", (short) 20);
+    document.field("oldAge", (long) 20);
+    document.removeField("oldAge");
+
+    byte[] res = serializer.toStream(document, false);
+    ODocument extr = (ODocument) serializer.fromStream(res, new ODocument(), new String[] { });
+
+    assertEquals(document.field("name"), extr.<Object>field("name"));
+    assertEquals(document.<Object>field("age"), extr.field("age"));
+    assertEquals(document.<Object>field("youngAge"), extr.field("youngAge"));
+    assertNull(extr.field("oldAge"));
+
+  }
+
+  @Test
+  public void testPartialCustom() {
+    ODocument document = new ODocument();
+    document.field("name", "name");
+    document.field("age", 20);
+    document.field("youngAge", (short) 20);
+    document.field("oldAge", (long) 20);
+
+    byte[] res = serializer.toStream(document, false);
+
+
+    ODocument extr = new ODocument(res);
+
+    ORecordInternal.setRecordSerializer(extr,serializer);
+
+    assertEquals(document.field("name"), extr.<Object>field("name"));
+    assertEquals(document.<Object>field("age"), extr.field("age"));
+    assertEquals(document.<Object>field("youngAge"), extr.field("youngAge"));
+    assertEquals(document.<Object>field("oldAge"), extr.field("oldAge"));
+
+
+    assertEquals(document.fieldNames().length,extr.fieldNames().length);
+
+
+  }
 
 
   public static class Custom implements OSerializableStream {

--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSerializerNetworkTestV37.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentSerializerNetworkTestV37.java
@@ -36,4 +36,8 @@ public class ODocumentSerializerNetworkTestV37 extends ODocumentSchemalessBinary
     assertEquals(document.<Object>field("oldAge"), extr.field("oldAge"));
 
   }
+
+
+
+
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/OClientConnection.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OClientConnection.java
@@ -19,16 +19,6 @@
  */
 package com.orientechnologies.orient.server;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.exception.OSystemException;
 import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
@@ -40,6 +30,15 @@ import com.orientechnologies.orient.server.config.OServerUserConfiguration;
 import com.orientechnologies.orient.server.network.protocol.ONetworkProtocol;
 import com.orientechnologies.orient.server.network.protocol.ONetworkProtocolData;
 import com.orientechnologies.orient.server.network.protocol.binary.ONetworkProtocolBinary;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class OClientConnection {
   private final int                          id;
@@ -62,7 +61,7 @@ public class OClientConnection {
     this.protocol = protocol;
     this.protocols.add(protocol);
     this.since = System.currentTimeMillis();
-    this.executor = new OConnectionBinaryExecutor(this, protocol.getServer());
+    this.executor = protocol.executor(this);
   }
 
   public void close() {

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -68,14 +68,20 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 
-final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
+public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
 
   private final OClientConnection connection;
   private final OServer           server;
+  private final HandshakeInfo     handshakeInfo;
 
   public OConnectionBinaryExecutor(OClientConnection connection, OServer server) {
+    this(connection, server, null);
+  }
+
+  public OConnectionBinaryExecutor(OClientConnection connection, OServer server, HandshakeInfo handshakeInfo) {
     this.connection = connection;
     this.server = server;
+    this.handshakeInfo = handshakeInfo;
   }
 
   @Override
@@ -842,6 +848,37 @@ final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
   }
 
   @Override
+  public OBinaryResponse executeConnect37(OConnect37Request request) {
+    connection.getData().driverName = handshakeInfo.getDriverName();
+    connection.getData().driverVersion = handshakeInfo.getDriverVersion();
+    connection.getData().protocolVersion = handshakeInfo.getProtocolVersion();
+    connection.getData().clientId = request.getClientId();
+    connection.getData().setSerializationImpl(handshakeInfo.getSerializerImpl());
+
+    connection.setTokenBased(request.isTokenBased());
+    connection.getData().supportsPushMessages = request.isSupportPush();
+    connection.getData().collectStats = request.isCollectStats();
+
+    connection.setServerUser(server.serverLogin(request.getUsername(), request.getPassword(), "server.connect"));
+
+    if (connection.getServerUser() == null)
+      throw new OSecurityAccessException("Wrong user/password to [connect] to the remote OrientDB Server instance");
+
+    byte[] token = null;
+    if (connection.getData().protocolVersion > OChannelBinaryProtocol.PROTOCOL_VERSION_26) {
+      connection.getData().serverUsername = connection.getServerUser().name;
+      connection.getData().serverUser = true;
+
+      if (Boolean.TRUE.equals(connection.getTokenBased())) {
+        token = server.getTokenHandler().getSignedBinaryToken(null, null, connection.getData());
+      } else
+        token = OCommonConst.EMPTY_BYTE_ARRAY;
+    }
+
+    return new OConnectResponse(connection.getId(), token);
+  }
+
+  @Override
   public OBinaryResponse executeDatabaseOpen(OOpenRequest request) {
     connection.getData().driverName = request.getDriverName();
     connection.getData().driverVersion = request.getDriverVersion();
@@ -897,6 +934,62 @@ final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
 
     return new OOpenResponse(connection.getId(), tokenToSend, clusters, distriConf, OConstants.getVersion());
 
+  }
+
+  @Override
+  public OBinaryResponse executeDatabaseOpen37(OOpenRequest37 request) {
+    connection.getData().clientId = request.getClientId();
+    connection.setTokenBased(request.isUseToken());
+    connection.getData().supportsPushMessages = request.isSupportsPush();
+    connection.getData().collectStats = request.isCollectStats();
+    connection.getData().driverName = handshakeInfo.getDriverName();
+    connection.getData().driverVersion = handshakeInfo.getDriverVersion();
+    connection.getData().protocolVersion = handshakeInfo.getProtocolVersion();
+    connection.getData().setSerializationImpl(handshakeInfo.getSerializerImpl());
+    try {
+      connection.setDatabase(
+          server.openDatabase(request.getDatabaseName(), request.getUserName(), request.getUserPassword(), connection.getData()));
+    } catch (OException e) {
+      server.getClientConnectionManager().disconnect(connection);
+      throw e;
+    }
+
+    byte[] token = null;
+
+    if (Boolean.TRUE.equals(connection.getTokenBased())) {
+      token = server.getTokenHandler()
+          .getSignedBinaryToken(connection.getDatabase(), connection.getDatabase().getUser(), connection.getData());
+      // TODO: do not use the parse split getSignedBinaryToken in two methods.
+      server.getClientConnectionManager().connect(connection.getProtocol(), connection, token, server.getTokenHandler());
+    }
+
+    if (connection.getDatabase().getStorage() instanceof OStorageProxy) {
+      connection.getDatabase().getMetadata().getSecurity().authenticate(request.getUserName(), request.getUserPassword());
+    }
+
+    final Collection<? extends OCluster> clusters = connection.getDatabase().getStorage().getClusterInstances();
+    final byte[] tokenToSend;
+    if (Boolean.TRUE.equals(connection.getTokenBased())) {
+      tokenToSend = token;
+    } else
+      tokenToSend = OCommonConst.EMPTY_BYTE_ARRAY;
+
+    final OServerPlugin plugin = server.getPlugin("cluster");
+    byte[] distriConf = null;
+    ODocument distributedCfg = null;
+    if (plugin != null && plugin instanceof ODistributedServerManager) {
+      distributedCfg = ((ODistributedServerManager) plugin).getClusterConfiguration();
+
+      final ODistributedConfiguration dbCfg = ((ODistributedServerManager) plugin)
+          .getDatabaseConfiguration(connection.getDatabase().getName());
+      if (dbCfg != null) {
+        // ENHANCE SERVER CFG WITH DATABASE CFG
+        distributedCfg.field("database", dbCfg.getDocument(), OType.EMBEDDED);
+      }
+      distriConf = getRecordBytes(connection, distributedCfg);
+    }
+
+    return new OOpenResponse(connection.getId(), tokenToSend, clusters, distriConf, OConstants.getVersion());
   }
 
   @Override

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -853,7 +853,7 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
     connection.getData().driverVersion = handshakeInfo.getDriverVersion();
     connection.getData().protocolVersion = handshakeInfo.getProtocolVersion();
     connection.getData().clientId = request.getClientId();
-    connection.getData().setSerializationImpl(handshakeInfo.getSerializerImpl());
+    connection.getData().setSerializer(handshakeInfo.getSerializer());
 
     connection.setTokenBased(request.isTokenBased());
     connection.getData().supportsPushMessages = request.isSupportPush();
@@ -945,7 +945,7 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
     connection.getData().driverName = handshakeInfo.getDriverName();
     connection.getData().driverVersion = handshakeInfo.getDriverVersion();
     connection.getData().protocolVersion = handshakeInfo.getProtocolVersion();
-    connection.getData().setSerializationImpl(handshakeInfo.getSerializerImpl());
+    connection.getData().setSerializer(handshakeInfo.getSerializer());
     try {
       connection.setDatabase(
           server.openDatabase(request.getDatabaseName(), request.getUserName(), request.getUserPassword(), connection.getData()));

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/ONetworkProtocol.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/ONetworkProtocol.java
@@ -19,14 +19,16 @@
  */
 package com.orientechnologies.orient.server.network.protocol;
 
-import java.io.IOException;
-import java.net.Socket;
-
 import com.orientechnologies.common.thread.OSoftThread;
+import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
 import com.orientechnologies.orient.core.config.OContextConfiguration;
 import com.orientechnologies.orient.enterprise.channel.OChannel;
+import com.orientechnologies.orient.server.OClientConnection;
 import com.orientechnologies.orient.server.OServer;
 import com.orientechnologies.orient.server.network.OServerNetworkListener;
+
+import java.io.IOException;
+import java.net.Socket;
 
 public abstract class ONetworkProtocol extends OSoftThread {
   protected OServer server;
@@ -55,4 +57,6 @@ public abstract class ONetworkProtocol extends OSoftThread {
   public OServer getServer() {
     return server;
   }
+
+  public abstract OBinaryRequestExecutor executor(OClientConnection connection);
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/ONetworkProtocolData.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/ONetworkProtocolData.java
@@ -59,6 +59,11 @@ public class ONetworkProtocolData {
     serializer = ORecordSerializerFactory.instance().getFormat(serializationImpl);
   }
 
+  public void setSerializer(ORecordSerializer serializer) {
+    this.serializer = serializer;
+    this.serializationImpl = serializer.getName();
+  }
+
   public ORecordSerializer getSerializer() {
     return serializer;
   }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/HandshakeInfo.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/HandshakeInfo.java
@@ -1,22 +1,23 @@
 package com.orientechnologies.orient.server.network.protocol.binary;
 
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
 
 /**
  * Created by tglman on 29/12/16.
  */
 public class HandshakeInfo {
 
-  private short  protocolVersion;
-  private String driverName;
-  private String driverVersion;
-  private String serializerImpl;
+  private short             protocolVersion;
+  private String            driverName;
+  private String            driverVersion;
+  private ORecordSerializer serializer;
 
   public HandshakeInfo(short protocolVersion, String driverName, String driverVersion) {
     this.protocolVersion = protocolVersion;
     this.driverName = driverName;
     this.driverVersion = driverVersion;
-    this.serializerImpl = ORecordSerializerNetworkV37.NAME;
+    this.serializer = ORecordSerializerNetworkFactory.INSTANCE.forProtocol(protocolVersion);
   }
 
   public short getProtocolVersion() {
@@ -43,7 +44,7 @@ public class HandshakeInfo {
     this.driverVersion = driverVersion;
   }
 
-  public String getSerializerImpl() {
-    return serializerImpl;
+  public ORecordSerializer getSerializer() {
+    return serializer;
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/HandshakeInfo.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/HandshakeInfo.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.server.network.protocol.binary;
 
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
+
 /**
  * Created by tglman on 29/12/16.
  */
@@ -8,11 +10,13 @@ public class HandshakeInfo {
   private short  protocolVersion;
   private String driverName;
   private String driverVersion;
+  private String serializerImpl;
 
   public HandshakeInfo(short protocolVersion, String driverName, String driverVersion) {
     this.protocolVersion = protocolVersion;
     this.driverName = driverName;
     this.driverVersion = driverVersion;
+    this.serializerImpl = ORecordSerializerNetworkV37.NAME;
   }
 
   public short getProtocolVersion() {
@@ -37,5 +41,9 @@ public class HandshakeInfo {
 
   public void setDriverVersion(String driverVersion) {
     this.driverVersion = driverVersion;
+  }
+
+  public String getSerializerImpl() {
+    return serializerImpl;
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkBinaryProtocolFactory.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/binary/ONetworkBinaryProtocolFactory.java
@@ -225,10 +225,10 @@ public class ONetworkBinaryProtocolFactory {
       return new ORollbackTransactionRequest();
 
     case OChannelBinaryProtocol.REQUEST_DB_OPEN:
-      return new OOpenRequest();
+      return new OOpenRequest37();
 
     case OChannelBinaryProtocol.REQUEST_CONNECT:
-      return new OConnectRequest();
+      return new OConnect37Request();
 
     case OChannelBinaryProtocol.REQUEST_DB_REOPEN:
       return new OReopenRequest();

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpDb.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpDb.java
@@ -19,9 +19,11 @@
     */
 package com.orientechnologies.orient.server.network.protocol.http;
 
+import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
 import com.orientechnologies.orient.core.config.OContextConfiguration;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
+import com.orientechnologies.orient.server.OClientConnection;
 import com.orientechnologies.orient.server.OServer;
 import com.orientechnologies.orient.server.network.OServerNetworkListener;
 import com.orientechnologies.orient.server.network.protocol.http.command.post.OServerCommandPostImportDatabase;
@@ -41,8 +43,8 @@ public class ONetworkProtocolHttpDb extends ONetworkProtocolHttpAbstract {
   public void config(final OServerNetworkListener iListener, final OServer iServer, final Socket iSocket,
       final OContextConfiguration iConfiguration) throws IOException {
     server = iServer;
-    setName("OrientDB HTTP Connection " + iSocket.getLocalAddress() + ":" + iSocket.getLocalPort() + "<-"
-        + iSocket.getRemoteSocketAddress());
+    setName("OrientDB HTTP Connection " + iSocket.getLocalAddress() + ":" + iSocket.getLocalPort() + "<-" + iSocket
+        .getRemoteSocketAddress());
 
     super.config(iListener, server, iSocket, iConfiguration);
     cmdManager.registerCommand(new OServerCommandPostImportDatabase());
@@ -63,5 +65,10 @@ public class ONetworkProtocolHttpDb extends ONetworkProtocolHttpAbstract {
   @Override
   protected void afterExecution() throws InterruptedException {
     ODatabaseRecordThreadLocal.INSTANCE.remove();
+  }
+
+  @Override
+  public OBinaryRequestExecutor executor(OClientConnection connection) {
+    return null;
   }
 }

--- a/server/src/test/java/com/orientechnologies/orient/server/OConnetionExecutorTransactionTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/OConnetionExecutorTransactionTest.java
@@ -2,12 +2,15 @@ package com.orientechnologies.orient.server;
 
 import com.orientechnologies.orient.client.remote.OBinaryResponse;
 import com.orientechnologies.orient.client.remote.message.*;
-import com.orientechnologies.orient.core.db.*;
+import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
+import com.orientechnologies.orient.core.db.ODatabaseType;
+import com.orientechnologies.orient.core.db.OrientDB;
+import com.orientechnologies.orient.core.db.OrientDBConfig;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,9 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Created by tglman on 29/12/16.
@@ -201,7 +202,7 @@ public class OConnetionExecutorTransactionTest {
     assertTrue(response instanceof OBeginTransactionResponse);
 
     OQueryRequest query = new OQueryRequest("sql", "update test set name='bla'", new HashMap<>(), true,
-        ORecordSerializerNetwork.INSTANCE, 20);
+        ORecordSerializerNetworkFactory.INSTANCE.current(), 20);
     OQueryResponse queryResponse = (OQueryResponse) query.execute(executor);
 
     assertTrue(queryResponse.isTxChanges());
@@ -225,7 +226,7 @@ public class OConnetionExecutorTransactionTest {
     assertTrue(response instanceof OBeginTransactionResponse);
 
     OQueryRequest query = new OQueryRequest("sql", "update test set name='bla'", new HashMap<>(), true,
-        ORecordSerializerNetwork.INSTANCE, 20);
+        ORecordSerializerNetworkFactory.INSTANCE.current(), 20);
     OQueryResponse queryResponse = (OQueryResponse) query.execute(executor);
 
     assertTrue(queryResponse.isTxChanges());


### PR DESCRIPTION
- Plugged new Serializer ORecordSerializerNetworkV37
- Added executors for Open/Connect 37
- Added ORecordSerializerNetworkFactory for matching the right serializer for the given protocol
- Small fix on OSBTreeRidBag on serialization
- Changed tests from ORecordSerializerNetwork to ORecordSerializerNetworkV37