### PR TITLE
Case sensitive schema refactoring

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/config/OStorageConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OStorageConfiguration.java
@@ -69,7 +69,7 @@ public class OStorageConfiguration implements OSerializableStream {
   public static final String DEFAULT_DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   private String charset;
-  public static final int                              CURRENT_VERSION               = 17;
+  public static final int                              CURRENT_VERSION               = 18;
   public static final int                              CURRENT_BINARY_FORMAT_VERSION = 12;
   private final       List<OStorageEntryConfiguration> properties                    = new ArrayList<OStorageEntryConfiguration>();
   protected final transient  OStorage                               storage;
@@ -369,6 +369,12 @@ public class OStorageConfiguration implements OSerializableStream {
 
       for (int i = 0; i < enginesSize; i++) {
         final String name = read(values[index++]);
+        final String fileName;
+        if (version > 17) {
+          fileName = read(values[index++]);
+        } else {
+          fileName = name;
+        }
         final String algorithm = read(values[index++]);
         final String indexType;
 
@@ -414,8 +420,8 @@ public class OStorageConfiguration implements OSerializableStream {
           }
         }
 
-        final IndexEngineData indexEngineData = new IndexEngineData(name, algorithm, indexType, durableInNonTxMode, version,
-            valueSerializerId, keySerializerId, isAutomatic, types, nullValuesSupport, keySize, engineProperties);
+        final IndexEngineData indexEngineData = new IndexEngineData(name, fileName, algorithm, indexType, durableInNonTxMode,
+            version, valueSerializerId, keySerializerId, isAutomatic, types, nullValuesSupport, keySize, engineProperties);
 
         indexEngines.put(name.toLowerCase(getLocaleInstance()), indexEngineData);
       }
@@ -544,6 +550,7 @@ public class OStorageConfiguration implements OSerializableStream {
     write(buffer, indexEngines.size());
     for (IndexEngineData engineData : indexEngines.values()) {
       write(buffer, engineData.name);
+      write(buffer, engineData.fileName);
       write(buffer, engineData.algorithm);
       write(buffer, engineData.indexType == null ? "" : engineData.indexType);
 
@@ -885,6 +892,7 @@ public class OStorageConfiguration implements OSerializableStream {
 
   public static final class IndexEngineData {
     private final String              name;
+    private final String              fileName;
     private final String              algorithm;
     private final String              indexType;
     private final Boolean             durableInNonTxMode;
@@ -897,10 +905,12 @@ public class OStorageConfiguration implements OSerializableStream {
     private final int                 keySize;
     private final Map<String, String> engineProperties;
 
-    public IndexEngineData(final String name, final String algorithm, String indexType, final Boolean durableInNonTxMode,
-        final int version, final byte valueSerializerId, final byte keySerializedId, final boolean isAutomatic,
-        final OType[] keyTypes, final boolean nullValuesSupport, final int keySize, final Map<String, String> engineProperties) {
+    public IndexEngineData(final String name, final String fileName, final String algorithm, String indexType,
+        final Boolean durableInNonTxMode, final int version, final byte valueSerializerId, final byte keySerializedId,
+        final boolean isAutomatic, final OType[] keyTypes, final boolean nullValuesSupport, final int keySize,
+        final Map<String, String> engineProperties) {
       this.name = name;
+      this.fileName = fileName;
       this.algorithm = algorithm;
       this.indexType = indexType;
       this.durableInNonTxMode = durableInNonTxMode;
@@ -966,6 +976,10 @@ public class OStorageConfiguration implements OSerializableStream {
 
     public String getIndexType() {
       return indexType;
+    }
+
+    public String getFileName() {
+      return fileName;
     }
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/config/OStorageConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OStorageConfiguration.java
@@ -423,7 +423,7 @@ public class OStorageConfiguration implements OSerializableStream {
         final IndexEngineData indexEngineData = new IndexEngineData(name, fileName, algorithm, indexType, durableInNonTxMode,
             version, valueSerializerId, keySerializerId, isAutomatic, types, nullValuesSupport, keySize, engineProperties);
 
-        indexEngines.put(name.toLowerCase(getLocaleInstance()), indexEngineData);
+        indexEngines.put(name, indexEngineData);
       }
     }
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
@@ -57,7 +57,6 @@ import com.orientechnologies.orient.core.serialization.serializer.OJSONReader;
 import com.orientechnologies.orient.core.serialization.serializer.OStringSerializerHelper;
 import com.orientechnologies.orient.core.serialization.serializer.binary.impl.OLinkSerializer;
 import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerJSON;
-import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.storage.OPhysicalPosition;
 import com.orientechnologies.orient.core.storage.OStorage;
 
@@ -398,7 +397,7 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
 
       for (OIndex<?> index : database.getMetadata().getIndexManager().getIndexes()) {
         if (index.isAutomatic())
-          indexesToRebuild.add(index.getName().toLowerCase());
+          indexesToRebuild.add(index.getName());
       }
 
       String tag;
@@ -1492,7 +1491,7 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
         listener.onMessage("\n- Index '" + indexName + "'...");
 
         indexManager.dropIndex(indexName);
-        indexesToRebuild.remove(indexName.toLowerCase());
+        indexesToRebuild.remove(indexName);
         List<Integer> clusterIds = new ArrayList<Integer>();
 
         for (final String clusterName : clustersToIndex) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/ODefaultIndexFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/ODefaultIndexFactory.java
@@ -92,7 +92,8 @@ public class ODefaultIndexFactory implements OIndexFactory {
     return ALGORITHMS;
   }
 
-  public OIndexInternal<?> createIndex(String name, OStorage storage, String indexType, String algorithm,
+
+  public OIndexInternal<?> createIndex(String name, String fileName, OStorage storage, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException {
     if (valueContainerAlgorithm == null)
       valueContainerAlgorithm = NONE_VALUE_CONTAINER;
@@ -101,23 +102,23 @@ public class ODefaultIndexFactory implements OIndexFactory {
       version = getLastVersion();
 
     if (SBTREE_ALGORITHM.equals(algorithm))
-      return createSBTreeIndex(name, indexType, valueContainerAlgorithm, metadata,
+      return createSBTreeIndex(name,fileName, indexType, valueContainerAlgorithm, metadata,
           (OAbstractPaginatedStorage) storage.getUnderlying(), version);
 
     throw new OConfigurationException("Unsupported type: " + indexType);
   }
 
-  private OIndexInternal<?> createSBTreeIndex(String name, String indexType, String valueContainerAlgorithm, ODocument metadata,
+  private OIndexInternal<?> createSBTreeIndex(String name, String fileName, String indexType, String valueContainerAlgorithm, ODocument metadata,
       OAbstractPaginatedStorage storage, int version) {
 
     if (OClass.INDEX_TYPE.UNIQUE.toString().equals(indexType)) {
-      return new OIndexUnique(name, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexUnique(name, fileName, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     } else if (OClass.INDEX_TYPE.NOTUNIQUE.toString().equals(indexType)) {
-      return new OIndexNotUnique(name, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexNotUnique(name, fileName,indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     } else if (OClass.INDEX_TYPE.FULLTEXT.toString().equals(indexType)) {
-      return new OIndexFullText(name, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexFullText(name, fileName,indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     } else if (OClass.INDEX_TYPE.DICTIONARY.toString().equals(indexType)) {
-      return new OIndexDictionary(name, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexDictionary(name, fileName, indexType, SBTREE_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     }
 
     throw new OConfigurationException("Unsupported type: " + indexType);
@@ -129,17 +130,17 @@ public class ODefaultIndexFactory implements OIndexFactory {
   }
 
   @Override
-  public OIndexEngine createIndexEngine(String algorithm, String name, Boolean durableInNonTxMode, OStorage storage, int version,
+  public OIndexEngine createIndexEngine(String algorithm, String name, String fileName, Boolean durableInNonTxMode, OStorage storage, int version,
       Map<String, String> engineProperties) {
 
     final OIndexEngine indexEngine;
 
     final String storageType = storage.getType();
     if (storageType.equals("memory") || storageType.equals("plocal"))
-      indexEngine = new OSBTreeIndexEngine(name, durableInNonTxMode, (OAbstractPaginatedStorage) storage, version);
+      indexEngine = new OSBTreeIndexEngine(name, fileName, durableInNonTxMode, (OAbstractPaginatedStorage) storage, version);
     else if (storageType.equals("distributed"))
       // DISTRIBUTED CASE: HANDLE IT AS FOR LOCAL
-      indexEngine = new OSBTreeIndexEngine(name, durableInNonTxMode, (OAbstractPaginatedStorage) storage.getUnderlying(), version);
+      indexEngine = new OSBTreeIndexEngine(name, fileName, durableInNonTxMode, (OAbstractPaginatedStorage) storage.getUnderlying(), version);
     else if (storageType.equals("remote"))
       indexEngine = new ORemoteIndexEngine(name);
     else

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -97,7 +97,7 @@ public abstract class OIndexAbstract<T> implements OIndexInternal<T> {
 
       this.version = version;
       this.name = name;
-      this.fileName = fileName;//TODO!!!
+      this.fileName = fileName;
       this.type = type;
       this.algorithm = algorithm;
       this.metadata = metadata;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexDictionary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexDictionary.java
@@ -34,9 +34,9 @@ import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
  */
 public class OIndexDictionary extends OIndexOneValue {
 
-  public OIndexDictionary(String name, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexDictionary(String name, String fileName, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, ODocument metadata) {
-    super(name, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
+    super(name, fileName, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
   }
 
   public OIndexOneValue put(Object key, final OIdentifiable value) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexEngine.java
@@ -46,8 +46,15 @@ public interface OIndexEngine {
 
   void deleteWithoutLoad(String indexName);
 
-  void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+//  void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+//      OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties);
+
+//  default
+  void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties);
+//  {
+//    load(indexName, valueSerializer, isAutomatic, keySerializer, keyTypes, nullPointerSupport, keySize, engineProperties);
+//  }
 
   boolean contains(Object key);
 
@@ -99,6 +106,10 @@ public interface OIndexEngine {
   int getVersion();
 
   String getName();
+
+  default String getFileName(){
+    return getName();
+  }
 
   /**
    * <p>Acquires exclusive lock in the active atomic operation running on the current thread for this index engine.

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexEngine.java
@@ -46,15 +46,8 @@ public interface OIndexEngine {
 
   void deleteWithoutLoad(String indexName);
 
-//  void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
-//      OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties);
-
-//  default
   void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties);
-//  {
-//    load(indexName, valueSerializer, isAutomatic, keySerializer, keyTypes, nullPointerSupport, keySize, engineProperties);
-//  }
 
   boolean contains(Object key);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFactory.java
@@ -44,6 +44,7 @@ public interface OIndexFactory {
    * Creates an index.
    * 
    * @param name
+   * @param fileName
    * @param storage TODO
    * @param indexType
    *          index type
@@ -53,9 +54,10 @@ public interface OIndexFactory {
    * @throws OConfigurationException
    *           if index creation failed
    */
-  OIndexInternal<?> createIndex(String name, OStorage storage, String indexType, String algorithm,
+  OIndexInternal<?> createIndex(String name, String fileName, OStorage storage, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException;
 
-  OIndexEngine createIndexEngine(String algorithm, String name, Boolean durableInNonTxMode, OStorage storage, int version,
+
+  OIndexEngine createIndexEngine(String algorithm, String name, String fileName, Boolean durableInNonTxMode, OStorage storage, int version,
       Map<String, String> engineProperties);
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFullText.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexFullText.java
@@ -62,9 +62,9 @@ public class OIndexFullText extends OIndexMultiValues {
 
   private Set<String> stopWords;
 
-  public OIndexFullText(String name, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexFullText(String name, String fileName, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, ODocument metadata) {
-    super(name, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
+    super(name, fileName, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
     acquireExclusiveLock();
     try {
       config();
@@ -127,7 +127,7 @@ public class OIndexFullText extends OIndexMultiValues {
                   if (refsc == null) {
                     // WORD NOT EXISTS: CREATE THE KEYWORD CONTAINER THE FIRST TIME THE WORD IS FOUND
                     if (ODefaultIndexFactory.SBTREEBONSAI_VALUE_CONTAINER.equals(valueContainerAlgorithm)) {
-                      result = new OIndexRIDContainer(getName(), durable);
+                      result = new OIndexRIDContainer(getFileName(), durable);
                     } else {
                       throw new IllegalStateException("MBRBTreeContainer is not supported any more");
                     }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexInternal.java
@@ -39,6 +39,7 @@ public interface OIndexInternal<T> extends OIndex<T> {
   String ALGORITHM                 = "algorithm";
   String VALUE_CONTAINER_ALGORITHM = "valueContainerAlgorithm";
   String CONFIG_NAME               = "name";
+  String CONFIG_FILE_NAME          = "fileName";
   String INDEX_DEFINITION          = "indexDefinition";
   String INDEX_DEFINITION_CLASS    = "indexDefinitionClass";
   String INDEX_VERSION             = "indexVersion";
@@ -84,8 +85,8 @@ public interface OIndexInternal<T> extends OIndex<T> {
    * Indicates whether given index can be used to calculate result of
    * {@link com.orientechnologies.orient.core.sql.operator.OQueryOperatorEquality} operators.
    *
-   * @return {@code true} if given index can be used to calculate result of
-   * {@link com.orientechnologies.orient.core.sql.operator.OQueryOperatorEquality} operators.
+   * @return {@code true} if given index can be used to calculate result of {@link com.orientechnologies.orient.core.sql.operator.OQueryOperatorEquality}
+   * operators.
    */
   boolean canBeUsedInEqualityOperators();
 
@@ -93,19 +94,19 @@ public interface OIndexInternal<T> extends OIndex<T> {
 
   /**
    * Applies exclusive lock on keys which prevents read/modification of this keys in following methods:
-   *
+   * <p>
    * <ol>
    * <li>{@link #put(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #checkEntry(com.orientechnologies.orient.core.db.record.OIdentifiable, Object)}</li>
    * <li>{@link #remove(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #remove(Object)}</li>
    * </ol>
-   *
+   * <p>
    * <p>
    * If you want to lock several keys in single thread, you should pass all those keys in single method call. Several calls of this
    * method in single thread are not allowed because it may lead to deadlocks.
    * </p>
-   *
+   * <p>
    * This is internal method and cannot be used by end users.
    *
    * @param key Keys to lock.
@@ -114,19 +115,19 @@ public interface OIndexInternal<T> extends OIndex<T> {
 
   /**
    * Applies exclusive lock on keys which prevents read/modification of this keys in following methods:
-   *
+   * <p>
    * <ol>
    * <li>{@link #put(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #checkEntry(com.orientechnologies.orient.core.db.record.OIdentifiable, Object)}</li>
    * <li>{@link #remove(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #remove(Object)}</li>
    * </ol>
-   *
+   * <p>
    * <p>
    * If you want to lock several keys in single thread, you should pass all those keys in single method call. Several calls of this
    * method in single thread are not allowed because it may lead to deadlocks.
    * </p>
-   *
+   * <p>
    * This is internal method and cannot be used by end users.
    *
    * @param keys Keys to lock.
@@ -137,14 +138,14 @@ public interface OIndexInternal<T> extends OIndex<T> {
 
   /**
    * Release exclusive lock on keys which prevents read/modification of this keys in following methods:
-   *
+   * <p>
    * <ol>
    * <li>{@link #put(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #checkEntry(com.orientechnologies.orient.core.db.record.OIdentifiable, Object)}</li>
    * <li>{@link #remove(Object, com.orientechnologies.orient.core.db.record.OIdentifiable)}</li>
    * <li>{@link #remove(Object)}</li>
    * </ol>
-   *
+   * <p>
    * This is internal method and cannot be used by end users.
    *
    * @param key Keys to unlock.
@@ -181,7 +182,7 @@ public interface OIndexInternal<T> extends OIndex<T> {
   /**
    * <p>
    * Acquires exclusive lock in the active atomic operation running on the current thread for this index.
-   *
+   * <p>
    * <p>
    * If this index supports a more narrow locking, for example key-based sharding, it may use the provided {@code key} to infer a
    * more narrow lock scope, but that is not a requirement.

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerAbstract.java
@@ -195,7 +195,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   public OIndex<?> getIndex(final String iName) {
     final Locale locale = getServerLocale();
 
-    final OIndex<?> index = indexes.get(iName.toLowerCase(locale));
+    final OIndex<?> index = indexes.get(iName);
     if (index == null)
       return null;
     return preProcessBeforeReturn(getDatabase(), index);
@@ -205,7 +205,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   public void addClusterToIndex(final String clusterName, final String indexName) {
     final Locale locale = getServerLocale();
 
-    final OIndex<?> index = indexes.get(indexName.toLowerCase(locale));
+    final OIndex<?> index = indexes.get(indexName);
     if (index == null)
       throw new OIndexException("Index with name " + indexName + " does not exist.");
 
@@ -221,7 +221,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   public void removeClusterFromIndex(final String clusterName, final String indexName) {
     final Locale locale = getServerLocale();
 
-    final OIndex<?> index = indexes.get(indexName.toLowerCase(locale));
+    final OIndex<?> index = indexes.get(indexName);
     if (index == null)
       throw new OIndexException("Index with name " + indexName + " does not exist.");
     index.getInternal().removeCluster(clusterName);
@@ -229,8 +229,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   }
 
   public boolean existsIndex(final String iName) {
-    final Locale locale = getServerLocale();
-    return indexes.containsKey(iName.toLowerCase(locale));
+    return indexes.containsKey(iName);
   }
 
   public String getDefaultClusterName() {
@@ -370,7 +369,6 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   public OIndex<?> getClassIndex(String className, String indexName) {
     final Locale locale = getServerLocale();
     className = className.toLowerCase(locale);
-    indexName = indexName.toLowerCase(locale);
 
     final OIndex<?> index = indexes.get(indexName);
     if (index != null && index.getDefinition() != null && index.getDefinition().getClassName() != null && className
@@ -451,7 +449,7 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
     acquireExclusiveLock();
     try {
       final Locale locale = getServerLocale();
-      indexes.put(index.getName().toLowerCase(locale), index);
+      indexes.put(index.getName(), index);
 
       final OIndexDefinition indexDefinition = index.getDefinition();
       if (indexDefinition == null || indexDefinition.getClassName() == null)
@@ -503,10 +501,8 @@ public abstract class OIndexManagerAbstract extends ODocumentWrapperNoClass impl
   }
 
   protected List<String> normalizeFieldNames(final Collection<String> fieldNames) {
-    final Locale locale = getServerLocale();
     final ArrayList<String> result = new ArrayList<String>(fieldNames.size());
-    for (final String fieldName : fieldNames)
-      result.add(fieldName.toLowerCase(locale));
+    result.addAll(fieldNames);
     return result;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerProxy.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerProxy.java
@@ -121,7 +121,7 @@ public class OIndexManagerProxy extends OProxedResource<OIndexManagerAbstract> i
       reload();
 
       final Locale locale = delegate.getServerLocale();
-      return delegate.preProcessBeforeReturn(getDatabase(), delegate.getIndex(iName.toLowerCase(locale)));
+      return delegate.preProcessBeforeReturn(getDatabase(), delegate.getIndex(iName));
     } finally {
       delegate.releaseExclusiveLock();
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerRemote.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerRemote.java
@@ -22,13 +22,12 @@ package com.orientechnologies.orient.core.index;
 import com.orientechnologies.common.listener.OProgressListener;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandExecutorSQLCreateIndex;
-import com.orientechnologies.orient.core.sql.OCommandSQL;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -70,7 +69,7 @@ public class OIndexManagerRemote extends OIndexManagerAbstract {
       reload();
 
       final Locale locale = getServerLocale();
-      return preProcessBeforeReturn(getDatabase(), indexes.get(iName.toLowerCase(locale)));
+      return preProcessBeforeReturn(getDatabase(), indexes.get(iName));
     } finally {
       releaseExclusiveLock();
     }
@@ -90,7 +89,7 @@ public class OIndexManagerRemote extends OIndexManagerAbstract {
 
       // REMOVE THE INDEX LOCALLY
       final Locale locale = getServerLocale();
-      indexes.remove(iIndexName.toLowerCase(locale));
+      indexes.remove(iIndexName);
       reload();
 
       return this;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
@@ -145,7 +145,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
       }
 
       index = OIndexes
-          .createIndex(getStorage(), iName, iName + System.currentTimeMillis(), type, algorithm, valueContainerAlgorithm, metadata,
+          .createIndex(getStorage(), iName, iName + (System.nanoTime() / 1000), type, algorithm, valueContainerAlgorithm, metadata,
               -1);
       if (progressListener == null)
         // ASSIGN DEFAULT PROGRESS LISTENER
@@ -577,8 +577,8 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
           for (Iterator<OIndexFactory> it = OIndexes.getAllFactories(); it.hasNext(); ) {
             try {
               final OIndexFactory indexFactory = it.next();
-              //TODO!!! check the file name!!!
-              final OIndexEngine engine = indexFactory.createIndexEngine(null, index.getName(), index.getName(), false, storage, 0, null);
+              final OIndexEngine engine = indexFactory.createIndexEngine(null, index.getName(),
+                  indexMetadata.getFileName() == null ? index.getName() : indexMetadata.getFileName(), false, storage, 0, null);
 
               engine.deleteWithoutLoad(index.getName());
             } catch (Exception e2) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
@@ -144,7 +144,9 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
           metadata.field("trackMode", "FULL");
       }
 
-      index = OIndexes.createIndex(getStorage(), iName, type, algorithm, valueContainerAlgorithm, metadata, -1);
+      index = OIndexes
+          .createIndex(getStorage(), iName, iName + System.currentTimeMillis(), type, algorithm, valueContainerAlgorithm, metadata,
+              -1);
       if (progressListener == null)
         // ASSIGN DEFAULT PROGRESS LISTENER
         progressListener = new OIndexRebuildOutputListener(index);
@@ -382,8 +384,9 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
                     d.<String>field(OIndexInternal.VALUE_CONTAINER_ALGORITHM));
 
             index = OIndexes
-                .createIndex(getStorage(), newIndexMetadata.getName(), newIndexMetadata.getType(), newIndexMetadata.getAlgorithm(),
-                    newIndexMetadata.getValueContainerAlgorithm(), (ODocument) d.field(OIndexInternal.METADATA), indexVersion);
+                .createIndex(getStorage(), newIndexMetadata.getName(), newIndexMetadata.getFileName(), newIndexMetadata.getType(),
+                    newIndexMetadata.getAlgorithm(), newIndexMetadata.getValueContainerAlgorithm(),
+                    (ODocument) d.field(OIndexInternal.METADATA), indexVersion);
 
             final String normalizedName = newIndexMetadata.getName().toLowerCase(locale);
 
@@ -574,7 +577,8 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
           for (Iterator<OIndexFactory> it = OIndexes.getAllFactories(); it.hasNext(); ) {
             try {
               final OIndexFactory indexFactory = it.next();
-              final OIndexEngine engine = indexFactory.createIndexEngine(null, index.getName(), false, storage, 0, null);
+              //TODO!!! check the file name!!!
+              final OIndexEngine engine = indexFactory.createIndexEngine(null, index.getName(), index.getName(), false, storage, 0, null);
 
               engine.deleteWithoutLoad(index.getName());
             } catch (Exception e2) {
@@ -635,6 +639,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
 
     private OIndexInternal<?> createIndex(ODocument idx) {
       final String indexName = idx.field(OIndexInternal.CONFIG_NAME);
+      final String indexFileName = idx.field(OIndexInternal.CONFIG_FILE_NAME);
       final String indexType = idx.field(OIndexInternal.CONFIG_TYPE);
       String algorithm = idx.field(OIndexInternal.ALGORITHM);
       String valueContainerAlgorithm = idx.field(OIndexInternal.VALUE_CONTAINER_ALGORITHM);
@@ -645,7 +650,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
         throw new OIndexException("Index type is null, will process other record. Index configuration: " + idx.toString());
       }
 
-      return OIndexes.createIndex(storage, indexName, indexType, algorithm, valueContainerAlgorithm, metadata, -1);
+      return OIndexes.createIndex(storage, indexName, indexFileName, indexType, algorithm, valueContainerAlgorithm, metadata, -1);
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexManagerShared.java
@@ -63,7 +63,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
     acquireSharedLock();
     try {
       final Locale locale = getServerLocale();
-      return indexes.get(name.toLowerCase(locale));
+      return indexes.get(name);
     } finally {
       releaseSharedLock();
     }
@@ -129,8 +129,8 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
     acquireExclusiveLock();
     try {
 
-      if (indexes.containsKey(iName.toLowerCase(locale)))
-        throw new OIndexException("Index with name " + iName.toLowerCase(locale) + " already exists.");
+      if (indexes.containsKey(iName))
+        throw new OIndexException("Index with name " + iName + " already exists.");
 
       // manual indexes are always durable
       if (clusterIdsToIndex == null || clusterIdsToIndex.length == 0) {
@@ -239,7 +239,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
     acquireExclusiveLock();
     try {
       final Locale locale = getServerLocale();
-      final OIndex<?> idx = indexes.remove(iIndexName.toLowerCase(locale));
+      final OIndex<?> idx = indexes.remove(iIndexName);
       if (idx != null) {
         final Set<String> clusters = idx.getClusters();
         if (clusters != null && !clusters.isEmpty()) {
@@ -388,7 +388,7 @@ public class OIndexManagerShared extends OIndexManagerAbstract {
                     newIndexMetadata.getAlgorithm(), newIndexMetadata.getValueContainerAlgorithm(),
                     (ODocument) d.field(OIndexInternal.METADATA), indexVersion);
 
-            final String normalizedName = newIndexMetadata.getName().toLowerCase(locale);
+            final String normalizedName = newIndexMetadata.getName();
 
             OIndex<?> oldIndex = oldIndexes.remove(normalizedName);
             if (oldIndex != null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMetadata.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMetadata.java
@@ -23,21 +23,22 @@ import java.util.Set;
 
 /**
  * Contains the index metadata.
- * 
+ *
  * @author Luca Garulli (l.garulli--(at)--orientdb.com)
- * 
  */
 public class OIndexMetadata {
   private final String           name;
+  private final String           fileName;
   private final OIndexDefinition indexDefinition;
   private final Set<String>      clustersToIndex;
   private final String           type;
   private final String           algorithm;
   private final String           valueContainerAlgorithm;
 
-  public OIndexMetadata(String name, OIndexDefinition indexDefinition, Set<String> clustersToIndex, String type, String algorithm,
+  public OIndexMetadata(String name, String fileName, OIndexDefinition indexDefinition, Set<String> clustersToIndex, String type, String algorithm,
       String valueContainerAlgorithm) {
     this.name = name;
+    this.fileName = fileName;
     this.indexDefinition = indexDefinition;
     this.clustersToIndex = clustersToIndex;
     this.type = type;
@@ -82,6 +83,8 @@ public class OIndexMetadata {
       return false;
     if (!name.equals(that.name))
       return false;
+    if (fileName != null ? !fileName.equals(that.fileName) : that.fileName != null)
+      return false;
     if (!type.equals(that.type))
       return false;
 
@@ -95,10 +98,15 @@ public class OIndexMetadata {
     result = 31 * result + clustersToIndex.hashCode();
     result = 31 * result + type.hashCode();
     result = 31 * result + (algorithm != null ? algorithm.hashCode() : 0);
+    result = 31 * result + (fileName != null ? fileName.hashCode() : 0);
     return result;
   }
 
   String getValueContainerAlgorithm() {
     return valueContainerAlgorithm;
+  }
+
+  public String getFileName() {
+    return fileName;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMultiValues.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexMultiValues.java
@@ -19,16 +19,6 @@
  */
 package com.orientechnologies.orient.core.index;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-
 import com.orientechnologies.common.comparator.ODefaultComparator;
 import com.orientechnologies.common.listener.OProgressListener;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
@@ -43,6 +33,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.stream.OStreamSerializerSBTreeIndexRIDContainer;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 
+import java.util.*;
+import java.util.concurrent.Callable;
+
 /**
  * Abstract index implementation that supports multi-values for the same key.
  * 
@@ -50,9 +43,9 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
  * 
  */
 public abstract class OIndexMultiValues extends OIndexAbstract<Set<OIdentifiable>> {
-  public OIndexMultiValues(String name, final String type, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexMultiValues(String name,String fileName, final String type, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, final ODocument metadata) {
-    super(name, type, algorithm, valueContainerAlgorithm, metadata, version, storage);
+    super(name, fileName, type, algorithm, valueContainerAlgorithm, metadata, version, storage);
   }
 
   public Set<OIdentifiable> get(Object key) {
@@ -175,7 +168,7 @@ public abstract class OIndexMultiValues extends OIndexAbstract<Set<OIdentifiable
 
             if (result == null) {
               if (ODefaultIndexFactory.SBTREEBONSAI_VALUE_CONTAINER.equals(valueContainerAlgorithm)) {
-                result = new OIndexRIDContainer(getName(), durable);
+                result = new OIndexRIDContainer(getFileName(), durable);
               } else {
                 throw new IllegalStateException("MVRBTree is not supported any more");
               }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexNotUnique.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexNotUnique.java
@@ -31,9 +31,9 @@ import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
  */
 public class OIndexNotUnique extends OIndexMultiValues {
 
-  public OIndexNotUnique(String name, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexNotUnique(String name, String fileName, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, ODocument metadata) {
-    super(name, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
+    super(name, fileName, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
   }
 
   public boolean canBeUsedInEqualityOperators() {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexOneValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexOneValue.java
@@ -38,9 +38,9 @@ import java.util.*;
  * @author Luca Garulli
  */
 public abstract class OIndexOneValue extends OIndexAbstract<OIdentifiable> {
-  public OIndexOneValue(String name, final String type, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexOneValue(String name, String fileName, final String type, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, ODocument metadata) {
-    super(name, type, algorithm, valueContainerAlgorithm, metadata, version, storage);
+    super(name, fileName, type, algorithm, valueContainerAlgorithm, metadata, version, storage);
   }
 
   public OIdentifiable get(Object iKey) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexUnique.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexUnique.java
@@ -55,9 +55,9 @@ public class OIndexUnique extends OIndexOneValue {
     }
   };
 
-  public OIndexUnique(String name, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
+  public OIndexUnique(String name, String filename, String typeId, String algorithm, int version, OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm, ODocument metadata) {
-    super(name, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
+    super(name, filename, typeId, algorithm, version, storage, valueContainerAlgorithm, metadata);
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexes.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexes.java
@@ -142,14 +142,14 @@ public final class OIndexes {
    * @throws OIndexException
    *           if index type does not exist
    */
-  public static OIndexInternal<?> createIndex(OStorage storage, String name, String indexType, String algorithm,
+  public static OIndexInternal<?> createIndex(OStorage storage, String name, String fileName, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException, OIndexException {
     if (indexType.equalsIgnoreCase(OClass.INDEX_TYPE.UNIQUE_HASH_INDEX.name())
         || indexType.equalsIgnoreCase(OClass.INDEX_TYPE.NOTUNIQUE_HASH_INDEX.name())
         || indexType.equalsIgnoreCase(OClass.INDEX_TYPE.DICTIONARY_HASH_INDEX.name()))
       algorithm = OHashIndexFactory.HASH_INDEX_ALGORITHM;
 
-    return findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(name, storage, indexType, algorithm,
+    return findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(name,fileName, storage, indexType, algorithm,
         valueContainerAlgorithm, metadata, version);
 
   }
@@ -166,13 +166,13 @@ public final class OIndexes {
         "Index type: " + indexType + " is not supported. Types are " + OCollections.toString(getIndexTypes()));
   }
 
-  public static OIndexEngine createIndexEngine(final String name, final String algorithm, final String type,
+  public static OIndexEngine createIndexEngine(final String name, final String fileName, final String algorithm, final String type,
       final Boolean durableInNonTxMode, final OStorage storage, final int version, final Map<String, String> indexProperties,
       ODocument metadata) {
 
     final OIndexFactory factory = findFactoryByAlgorithmAndType(algorithm, type);
 
-    return factory.createIndexEngine(algorithm, name, durableInNonTxMode, storage, version, indexProperties);
+    return factory.createIndexEngine(algorithm, name, fileName, durableInNonTxMode, storage, version, indexProperties);
   }
 
   public static String chooseDefaultIndexAlgorithm(String type) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/OHashTableIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/OHashTableIndexEngine.java
@@ -54,7 +54,7 @@ public final class OHashTableIndexEngine implements OIndexEngine {
 
   private final String name;
 
-  public OHashTableIndexEngine(String name, Boolean durableInNonTxMode, OAbstractPaginatedStorage storage, int version) {
+  public OHashTableIndexEngine(String name, String fileName, Boolean durableInNonTxMode, OAbstractPaginatedStorage storage, int version) {
     hashFunction = new OMurmurHash3HashFunction<Object>();
 
     boolean durableInNonTx;
@@ -66,10 +66,10 @@ public final class OHashTableIndexEngine implements OIndexEngine {
 
     this.version = version;
     if (version < 2)
-      hashTable = new OLocalHashTable20<Object, Object>(name, METADATA_FILE_EXTENSION, TREE_FILE_EXTENSION, BUCKET_FILE_EXTENSION,
+      hashTable = new OLocalHashTable20<Object, Object>(name, fileName, METADATA_FILE_EXTENSION, TREE_FILE_EXTENSION, BUCKET_FILE_EXTENSION,
           NULL_BUCKET_FILE_EXTENSION, hashFunction, durableInNonTx, storage);
     else
-      hashTable = new OLocalHashTable<Object, Object>(name, METADATA_FILE_EXTENSION, TREE_FILE_EXTENSION, BUCKET_FILE_EXTENSION,
+      hashTable = new OLocalHashTable<Object, Object>(name, fileName, METADATA_FILE_EXTENSION, TREE_FILE_EXTENSION, BUCKET_FILE_EXTENSION,
           NULL_BUCKET_FILE_EXTENSION, hashFunction, storage);
 
     this.name = name;
@@ -112,10 +112,11 @@ public final class OHashTableIndexEngine implements OIndexEngine {
     hashTable.delete();
   }
 
+
   @Override
-  public void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+  public void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties) {
-    hashTable.load(indexName, keyTypes, nullPointerSupport);
+    hashTable.load(indexName, fileName, keyTypes, nullPointerSupport);
     hashFunction.setValueSerializer(hashTable.getKeySerializer());
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/ORemoteIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/ORemoteIndexEngine.java
@@ -45,6 +45,11 @@ public class ORemoteIndexEngine implements OIndexEngine {
   }
 
   @Override
+  public String getFileName() {
+    return null;
+  }
+
+  @Override
   public String getIndexNameByKey(Object key) {
     return name;
   }
@@ -72,7 +77,7 @@ public class ORemoteIndexEngine implements OIndexEngine {
   }
 
   @Override
-  public void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+  public void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties) {
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/OSBTreeIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/OSBTreeIndexEngine.java
@@ -47,9 +47,11 @@ public class OSBTreeIndexEngine implements OIndexEngine {
   private final OSBTree<Object, Object> sbTree;
   private       int                     version;
   private final String                  name;
+  private final String                  fileName;
 
-  public OSBTreeIndexEngine(String name, Boolean durableInNonTxMode, OAbstractPaginatedStorage storage, int version) {
+  public OSBTreeIndexEngine(String name,String fileName, Boolean durableInNonTxMode, OAbstractPaginatedStorage storage, int version) {
     this.name = name;
+    this.fileName = fileName;
     boolean durableInNonTx;
 
     if (durableInNonTxMode == null)
@@ -60,7 +62,7 @@ public class OSBTreeIndexEngine implements OIndexEngine {
 
     this.version = version;
 
-    sbTree = new OSBTree<Object, Object>(name, DATA_FILE_EXTENSION, durableInNonTx, NULL_BUCKET_FILE_EXTENSION, storage);
+    sbTree = new OSBTree<Object, Object>(name, fileName,  DATA_FILE_EXTENSION, durableInNonTx, NULL_BUCKET_FILE_EXTENSION, storage);
   }
 
   @Override
@@ -70,6 +72,11 @@ public class OSBTreeIndexEngine implements OIndexEngine {
   @Override
   public String getName() {
     return name;
+  }
+
+  @Override
+  public String getFileName() {
+    return fileName;
   }
 
   @Override
@@ -93,10 +100,11 @@ public class OSBTreeIndexEngine implements OIndexEngine {
     sbTree.deleteWithoutLoad(indexName);
   }
 
+
   @Override
-  public void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+  public void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties) {
-    sbTree.load(indexName, keySerializer, valueSerializer, keyTypes, keySize, nullPointerSupport);
+    sbTree.load(indexName, fileName, keySerializer, valueSerializer, keyTypes, keySize, nullPointerSupport);
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashIndexFactory.java
@@ -20,15 +20,7 @@
 package com.orientechnologies.orient.core.index.hashindex.local;
 
 import com.orientechnologies.orient.core.exception.OConfigurationException;
-import com.orientechnologies.orient.core.index.ODefaultIndexFactory;
-import com.orientechnologies.orient.core.index.OIndexDictionary;
-import com.orientechnologies.orient.core.index.OIndexEngine;
-import com.orientechnologies.orient.core.index.OIndexException;
-import com.orientechnologies.orient.core.index.OIndexFactory;
-import com.orientechnologies.orient.core.index.OIndexFullText;
-import com.orientechnologies.orient.core.index.OIndexInternal;
-import com.orientechnologies.orient.core.index.OIndexNotUnique;
-import com.orientechnologies.orient.core.index.OIndexUnique;
+import com.orientechnologies.orient.core.index.*;
 import com.orientechnologies.orient.core.index.engine.OHashTableIndexEngine;
 import com.orientechnologies.orient.core.index.engine.ORemoteIndexEngine;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
@@ -42,14 +34,12 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * 
- * 
  * @author Artem Orobets (enisher-at-gmail.com)
  */
 public class OHashIndexFactory implements OIndexFactory {
 
   private static final Set<String> TYPES;
-  public static final String       HASH_INDEX_ALGORITHM = "HASH_INDEX";
+  public static final String HASH_INDEX_ALGORITHM = "HASH_INDEX";
   private static final Set<String> ALGORITHMS;
 
   static {
@@ -85,7 +75,7 @@ public class OHashIndexFactory implements OIndexFactory {
     return ALGORITHMS;
   }
 
-  public OIndexInternal<?> createIndex(String name, OStorage storage, String indexType, String algorithm,
+  public OIndexInternal<?> createIndex(String name, String fileName,  OStorage storage, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException {
 
     if (version < 0)
@@ -95,17 +85,17 @@ public class OHashIndexFactory implements OIndexFactory {
       valueContainerAlgorithm = ODefaultIndexFactory.NONE_VALUE_CONTAINER;
 
     if (OClass.INDEX_TYPE.UNIQUE_HASH_INDEX.toString().equals(indexType))
-      return new OIndexUnique(name, indexType, algorithm, version, (OAbstractPaginatedStorage) storage.getUnderlying(),
-          valueContainerAlgorithm, metadata);
+      return new OIndexUnique(name, fileName, indexType, algorithm, version,
+          (OAbstractPaginatedStorage) storage.getUnderlying(), valueContainerAlgorithm, metadata);
     else if (OClass.INDEX_TYPE.NOTUNIQUE_HASH_INDEX.toString().equals(indexType))
-      return new OIndexNotUnique(name, indexType, algorithm, version, (OAbstractPaginatedStorage) storage.getUnderlying(),
-          valueContainerAlgorithm, metadata);
+      return new OIndexNotUnique(name, fileName, indexType, algorithm, version,
+          (OAbstractPaginatedStorage) storage.getUnderlying(), valueContainerAlgorithm, metadata);
     else if (OClass.INDEX_TYPE.FULLTEXT_HASH_INDEX.toString().equals(indexType))
-      return new OIndexFullText(name, indexType, algorithm, version, (OAbstractPaginatedStorage) storage.getUnderlying(),
-          valueContainerAlgorithm, metadata);
+      return new OIndexFullText(name, fileName, indexType, algorithm, version,
+          (OAbstractPaginatedStorage) storage.getUnderlying(), valueContainerAlgorithm, metadata);
     else if (OClass.INDEX_TYPE.DICTIONARY_HASH_INDEX.toString().equals(indexType))
-      return new OIndexDictionary(name, indexType, algorithm, version, (OAbstractPaginatedStorage) storage.getUnderlying(),
-          valueContainerAlgorithm, metadata);
+      return new OIndexDictionary(name, fileName, indexType, algorithm, version,
+          (OAbstractPaginatedStorage) storage.getUnderlying(), valueContainerAlgorithm, metadata);
 
     throw new OConfigurationException("Unsupported type: " + indexType);
   }
@@ -116,16 +106,16 @@ public class OHashIndexFactory implements OIndexFactory {
   }
 
   @Override
-  public OIndexEngine createIndexEngine(final String algoritm, final String name, final Boolean durableInNonTxMode,
+  public OIndexEngine createIndexEngine(final String algoritm, final String name, String fileName, final Boolean durableInNonTxMode,
       final OStorage storage, final int version, final Map<String, String> engineProperties) {
     OIndexEngine indexEngine;
 
     final String storageType = storage.getType();
     if (storageType.equals("memory") || storageType.equals("plocal"))
-      indexEngine = new OHashTableIndexEngine(name, durableInNonTxMode, (OAbstractPaginatedStorage) storage, version);
+      indexEngine = new OHashTableIndexEngine(name, fileName, durableInNonTxMode, (OAbstractPaginatedStorage) storage, version);
     else if (storageType.equals("distributed"))
       // DISTRIBUTED CASE: HANDLE IT AS FOR LOCAL
-      indexEngine = new OHashTableIndexEngine(name, durableInNonTxMode, (OAbstractPaginatedStorage) storage.getUnderlying(),
+      indexEngine = new OHashTableIndexEngine(name, fileName, durableInNonTxMode, (OAbstractPaginatedStorage) storage.getUnderlying(),
           version);
     else if (storageType.equals("remote"))
       indexEngine = new ORemoteIndexEngine(name);
@@ -134,4 +124,5 @@ public class OHashIndexFactory implements OIndexFactory {
 
     return indexEngine;
   }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTable.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTable.java
@@ -67,7 +67,7 @@ public interface OHashTable<K, V> {
 
   OHashIndexBucket.Entry<K, V>[] higherEntries(K key, int limit);
 
-  void load(String name, OType[] keyTypes, boolean nullKeyIsSupported);
+  void load(String name, String fileName, OType[] keyTypes, boolean nullKeyIsSupported);
 
   void deleteWithoutLoad(String name);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTableDirectory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OHashTableDirectory.java
@@ -46,9 +46,8 @@ public class OHashTableDirectory extends ODurableComponent {
 
   private final long firstEntryIndex;
 
-
   OHashTableDirectory(String defaultExtension, String name, String lockName, OAbstractPaginatedStorage storage) {
-    super(storage, name, defaultExtension, lockName);
+    super(storage, name, name, defaultExtension, lockName);
     this.firstEntryIndex = 0;
   }
 
@@ -677,7 +676,6 @@ public class OHashTableDirectory extends ODurableComponent {
       releasePageFromWrite(atomicOperation, cacheEntry);
     else
       releasePageFromRead(atomicOperation, cacheEntry);
-
 
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable.java
@@ -117,9 +117,9 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
   private OHashTableDirectory directory;
 
 
-  public OLocalHashTable(String name, String metadataConfigurationFileExtension, String treeStateFileExtension,
+  public OLocalHashTable(String name, String fileName, String metadataConfigurationFileExtension, String treeStateFileExtension,
       String bucketFileExtension, String nullBucketFileExtension, OHashFunction<K> keyHashFunction, OAbstractPaginatedStorage abstractPaginatedStorage) {
-    super(abstractPaginatedStorage, name, bucketFileExtension, name + bucketFileExtension);
+    super(abstractPaginatedStorage, name, fileName, bucketFileExtension, fileName + bucketFileExtension);
 
     this.metadataConfigurationFileExtension = metadataConfigurationFileExtension;
     this.treeStateFileExtension = treeStateFileExtension;
@@ -155,7 +155,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
           this.directory = new OHashTableDirectory(treeStateFileExtension, getName(), getFullName(), storage);
 
-          fileStateId = addFile(atomicOperation, getName() + metadataConfigurationFileExtension);
+          fileStateId = addFile(atomicOperation, getFileName() + metadataConfigurationFileExtension);
 
           directory.create();
 
@@ -180,7 +180,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
           initHashTreeState(atomicOperation);
 
           if (nullKeyIsSupported)
-            nullBucketFileId = addFile(atomicOperation, getName() + nullBucketFileExtension);
+            nullBucketFileId = addFile(atomicOperation, this.getFileName() + nullBucketFileExtension);
 
           endAtomicOperation(false, null);
         } catch (IOException e) {
@@ -621,7 +621,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
   }
 
   @Override
-  public void load(String name, OType[] keyTypes, boolean nullKeyIsSupported) {
+  public void load(String name, String fileName, OType[] keyTypes, boolean nullKeyIsSupported) {
     startOperation();
     try {
       acquireExclusiveLock();
@@ -635,7 +635,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
 
         OAtomicOperation atomicOperation = atomicOperationsManager.getCurrentOperation();
 
-        fileStateId = openFile(atomicOperation, name + metadataConfigurationFileExtension);
+        fileStateId = openFile(atomicOperation, fileName + metadataConfigurationFileExtension);
         final OCacheEntry hashStateEntry = loadPageForRead(atomicOperation, fileStateId, 0, true);
         hashStateEntryIndex = hashStateEntry.getPageIndex();
 
@@ -659,7 +659,7 @@ public class OLocalHashTable<K, V> extends ODurableComponent implements OHashTab
         }
 
         if (nullKeyIsSupported)
-          nullBucketFileId = openFile(atomicOperation, name + nullBucketFileExtension);
+          nullBucketFileId = openFile(atomicOperation, fileName + nullBucketFileExtension);
 
         fileId = openFile(atomicOperation, getFullName());
       } catch (IOException e) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable20.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTable20.java
@@ -130,10 +130,10 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
   private final boolean durableInNonTxMode;
 
-  public OLocalHashTable20(String name, String metadataConfigurationFileExtension, String treeStateFileExtension,
+  public OLocalHashTable20(String name, String fileName, String metadataConfigurationFileExtension, String treeStateFileExtension,
       String bucketFileExtension, String nullBucketFileExtension, OHashFunction<K> keyHashFunction, boolean durableInNonTxMode,
       OAbstractPaginatedStorage abstractPaginatedStorage) {
-    super(abstractPaginatedStorage, name, bucketFileExtension, name + bucketFileExtension);
+    super(abstractPaginatedStorage, name, fileName, bucketFileExtension, fileName + bucketFileExtension);
 
     this.metadataConfigurationFileExtension = metadataConfigurationFileExtension;
     this.treeStateFileExtension = treeStateFileExtension;
@@ -618,7 +618,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
   }
 
   @Override
-  public void load(String name, OType[] keyTypes, boolean nullKeyIsSupported) {
+  public void load(String name, String fileName, OType[] keyTypes, boolean nullKeyIsSupported) {
     acquireExclusiveLock();
     try {
       if (keyTypes != null)
@@ -630,7 +630,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
 
       OAtomicOperation atomicOperation = atomicOperationsManager.getCurrentOperation();
 
-      fileStateId = openFile(atomicOperation, name + metadataConfigurationFileExtension);
+      fileStateId = openFile(atomicOperation, fileName + metadataConfigurationFileExtension);
       final OCacheEntry hashStateEntry = loadPageForRead(atomicOperation, fileStateId, 0, true);
       hashStateEntryIndex = hashStateEntry.getPageIndex();
 
@@ -649,7 +649,7 @@ public class OLocalHashTable20<K, V> extends ODurableComponent implements OHashT
       }
 
       if (nullKeyIsSupported)
-        nullBucketFileId = openFile(atomicOperation, name + nullBucketFileExtension);
+        nullBucketFileId = openFile(atomicOperation, fileName + nullBucketFileExtension);
     } catch (IOException e) {
       throw OException.wrapException(new OIndexException("Exception during hash table loading"), e);
     } finally {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTree.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtree/local/OSBTree.java
@@ -93,9 +93,9 @@ public class OSBTree<K, V> extends ODurableComponent {
   private OBinarySerializer<V> valueSerializer;
   private boolean              nullPointerSupport;
 
-  public OSBTree(String name, String dataFileExtension, boolean durableInNonTxMode, String nullFileExtension,
+  public OSBTree(String name, String fileName, String dataFileExtension, boolean durableInNonTxMode, String nullFileExtension,
       OAbstractPaginatedStorage storage) {
-    super(storage, name, dataFileExtension, name + dataFileExtension);
+    super(storage, name, fileName, dataFileExtension, fileName + dataFileExtension);
     acquireExclusiveLock();
     try {
       this.nullFileExtension = nullFileExtension;
@@ -134,7 +134,7 @@ public class OSBTree<K, V> extends ODurableComponent {
         fileId = addFile(atomicOperation, getFullName());
 
         if (nullPointerSupport)
-          nullBucketFileId = addFile(atomicOperation, getName() + nullFileExtension);
+          nullBucketFileId = addFile(atomicOperation, getFileName() + nullFileExtension);
 
         OCacheEntry rootCacheEntry = addPage(atomicOperation, fileId);
         try {
@@ -550,15 +550,15 @@ public class OSBTree<K, V> extends ODurableComponent {
           deleteFile(atomicOperation, fileId);
         }
 
-        if (isFileExists(atomicOperation, getName() + nullFileExtension)) {
-          final long nullFileId = openFile(atomicOperation, getName() + nullFileExtension);
+        if (isFileExists(atomicOperation, getFileName() + nullFileExtension)) {
+          final long nullFileId = openFile(atomicOperation, getFileName() + nullFileExtension);
           deleteFile(atomicOperation, nullFileId);
         }
 
         endAtomicOperation(false, null);
       } catch (IOException ioe) {
         rollback(ioe);
-        throw OException.wrapException(new OSBTreeException("Exception during deletion of sbtree " + getName(), this), ioe);
+        throw OException.wrapException(new OSBTreeException("Exception during deletion of sbtree " + getName()+" "+getFileName(), this), ioe);
       } catch (Exception e) {
         rollback(e);
         throw OException.wrapException(new OSBTreeException("Exception during deletion of sbtree " + getName(), this), e);
@@ -570,7 +570,7 @@ public class OSBTree<K, V> extends ODurableComponent {
     }
   }
 
-  public void load(String name, OBinarySerializer<K> keySerializer, OBinarySerializer<V> valueSerializer, OType[] keyTypes,
+  public void load(String name, String fileName, OBinarySerializer<K> keySerializer, OBinarySerializer<V> valueSerializer, OType[] keyTypes,
       int keySize, boolean nullPointerSupport) {
     startOperation();
     try {
@@ -588,12 +588,12 @@ public class OSBTree<K, V> extends ODurableComponent {
 
         fileId = openFile(atomicOperation, getFullName());
         if (nullPointerSupport)
-          nullBucketFileId = openFile(atomicOperation, name + nullFileExtension);
+          nullBucketFileId = openFile(atomicOperation, fileName + nullFileExtension);
 
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
       } catch (IOException e) {
-        throw OException.wrapException(new OSBTreeException("Exception during loading of sbtree " + name, this), e);
+        throw OException.wrapException(new OSBTreeException("Exception during loading of sbtree " + fileName, this), e);
       } finally {
         releaseExclusiveLock();
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
@@ -75,7 +75,7 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
   private OBinarySerializer<V> valueSerializer;
 
   public OSBTreeBonsaiLocal(String name, String dataFileExtension, OAbstractPaginatedStorage storage) {
-    super(storage, name, dataFileExtension, name + dataFileExtension);
+    super(storage, name, name, dataFileExtension, name + dataFileExtension);
   }
 
   public void create(OBinarySerializer<K> keySerializer, OBinarySerializer<V> valueSerializer) {

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -744,23 +744,21 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     acquireSchemaReadLock();
     try {
       final Map<String, OProperty> props = new HashMap<String, OProperty>(20);
-      propertiesMap(props, true);
+      propertiesMap(props);
       return props;
     } finally {
       releaseSchemaReadLock();
     }
   }
 
-  private void propertiesMap(Map<String, OProperty> propertiesMap, boolean keepCase) {
+  private void propertiesMap(Map<String, OProperty> propertiesMap) {
     for (OProperty p : properties.values()) {
       String propName = p.getName();
-      if (!keepCase)
-        propName = propName.toLowerCase();
       if (!propertiesMap.containsKey(propName))
         propertiesMap.put(propName, p);
     }
     for (OClassImpl superClass : superClasses) {
-      superClass.propertiesMap(propertiesMap, keepCase);
+      superClass.propertiesMap(propertiesMap);
     }
   }
 
@@ -810,8 +808,6 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   public OProperty getProperty(String propertyName) {
     acquireSchemaReadLock();
     try {
-      propertyName = propertyName.toLowerCase();
-
       OProperty p = properties.get(propertyName);
       if (p != null)
         return p;
@@ -848,7 +844,6 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   public boolean existsProperty(String propertyName) {
     acquireSchemaReadLock();
     try {
-      propertyName = propertyName.toLowerCase();
       boolean result = properties.containsKey(propertyName);
       if (result)
         return true;
@@ -869,11 +864,9 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
 
     getDatabase().checkSecurity(ORule.ResourceGeneric.SCHEMA, ORole.PERMISSION_DELETE);
 
-    final String lowerName = propertyName.toLowerCase();
-
     acquireSchemaWriteLock();
     try {
-      if (!properties.containsKey(lowerName))
+      if (!properties.containsKey(propertyName))
         throw new OSchemaException("Property '" + propertyName + "' not found in class " + name + "'");
 
       final ODatabaseDocumentInternal database = getDatabase();
@@ -966,11 +959,11 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
         prop.fromStream();
 
         if (properties.containsKey(prop.getName())) {
-          prop = (OPropertyImpl) properties.get(prop.getName().toLowerCase());
+          prop = (OPropertyImpl) properties.get(prop.getName());
           prop.fromStream(p);
         }
 
-        newProperties.put(prop.getName().toLowerCase(), prop);
+        newProperties.put(prop.getName(), prop);
       }
 
     properties.clear();
@@ -1084,9 +1077,9 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
   }
 
   public void renameProperty(final String iOldName, final String iNewName) {
-    final OProperty p = properties.remove(iOldName.toLowerCase());
+    final OProperty p = properties.remove(iOldName);
     if (p != null)
-      properties.put(iNewName.toLowerCase(), p);
+      properties.put(iNewName, p);
   }
 
   public OClass addClusterId(final int clusterId) {
@@ -1803,8 +1796,6 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     if (!unsafe)
       checkPersistentPropertyType(getDatabase(), name, type);
 
-    final String lowerName = name.toLowerCase();
-
     final OPropertyImpl prop;
 
     // This check are doubled because used by sql commands
@@ -1818,14 +1809,14 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     try {
       checkEmbedded();
 
-      if (properties.containsKey(lowerName))
+      if (properties.containsKey(name))
         throw new OSchemaException("Class '" + this.name + "' already has property '" + name + "'");
 
       OGlobalProperty global = owner.findOrCreateGlobalProperty(name, type);
 
       prop = new OPropertyImpl(this, global);
 
-      properties.put(lowerName, prop);
+      properties.put(name, prop);
 
       if (linkedType != null)
         prop.setLinkedTypeInternal(linkedType);
@@ -2345,7 +2336,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
     try {
       checkEmbedded();
 
-      final OProperty prop = properties.remove(iPropertyName.toLowerCase());
+      final OProperty prop = properties.remove(iPropertyName);
 
       if (prop == null)
         throw new OSchemaException("Property '" + iPropertyName + "' not found in class " + name + "'");
@@ -2673,7 +2664,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
         impl = (OClassImpl) ((OClassAbstractDelegate) superClass).delegate;
       else
         impl = (OClassImpl) superClass;
-      impl.propertiesMap(properties, false);
+      impl.propertiesMap(properties);
       for (Map.Entry<String, OProperty> entry : properties.entrySet()) {
         if (comulative.containsKey(entry.getKey())) {
           final String property = entry.getKey();
@@ -2781,7 +2772,7 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
 
     for (String fieldName : fieldNames) {
       if (!fieldName.equals("@rid"))
-        types.add(getProperty(decodeClassName(OIndexDefinitionFactory.extractFieldName(fieldName)).toLowerCase()).getType());
+        types.add(getProperty(decodeClassName(OIndexDefinitionFactory.extractFieldName(fieldName))).getType());
       else
         types.add(OType.LINK);
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OImmutableClass.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OImmutableClass.java
@@ -113,7 +113,7 @@ public class OImmutableClass implements OClass {
 
     properties = new HashMap<String, OProperty>();
     for (OProperty p : oClass.declaredProperties())
-      properties.put(p.getName().toLowerCase(), new OImmutableProperty(p, this));
+      properties.put(p.getName(), new OImmutableProperty(p, this));
 
     Map<String, String> customFields = new HashMap<String, String>();
     for (String key : oClass.getCustomKeys())
@@ -275,8 +275,6 @@ public class OImmutableClass implements OClass {
   public OProperty getProperty(String propertyName) {
     initSuperClasses();
 
-    propertyName = propertyName.toLowerCase();
-
     OProperty p = properties.get(propertyName);
     if (p != null)
       return p;
@@ -318,7 +316,6 @@ public class OImmutableClass implements OClass {
 
   @Override
   public boolean existsProperty(String propertyName) {
-    propertyName = propertyName.toLowerCase();
     boolean result = properties.containsKey(propertyName);
     if (result)
       return true;

--- a/core/src/main/java/com/orientechnologies/orient/core/sharding/auto/OAutoShardingIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sharding/auto/OAutoShardingIndexEngine.java
@@ -80,6 +80,11 @@ public final class OAutoShardingIndexEngine implements OIndexEngine {
     return name;
   }
 
+  @Override
+  public String getFileName() {
+    return getName();
+  }
+
   public OAutoShardingStrategy getStrategy() {
     return strategy;
   }
@@ -105,7 +110,7 @@ public final class OAutoShardingIndexEngine implements OIndexEngine {
   }
 
   @Override
-  public void load(final String indexName, final OBinarySerializer valueSerializer, final boolean isAutomatic,
+  public void load(final String indexName, String fileName, final OBinarySerializer valueSerializer, final boolean isAutomatic,
       final OBinarySerializer keySerializer, final OType[] keyTypes, final boolean nullPointerSupport, final int keySize,
       final Map<String, String> engineProperties) {
 
@@ -122,7 +127,7 @@ public final class OAutoShardingIndexEngine implements OIndexEngine {
 
       int i = 0;
       for (OHashTable<Object, Object> p : partitions)
-        p.load(indexName + "_" + (i++), keyTypes, nullPointerSupport);
+        p.load(indexName + "_" + (i), fileName + (i++), keyTypes, nullPointerSupport);
     }
 
     hashFunction.setValueSerializer(keySerializer);
@@ -160,9 +165,9 @@ public final class OAutoShardingIndexEngine implements OIndexEngine {
 
     partitions = new ArrayList<OHashTable<Object, Object>>(partitionSize);
     for (int i = 0; i < partitionSize; ++i) {
-      partitions.add(
-          new OLocalHashTable<Object, Object>(name + "_" + i, SUBINDEX_METADATA_FILE_EXTENSION, SUBINDEX_TREE_FILE_EXTENSION,
-              SUBINDEX_BUCKET_FILE_EXTENSION, SUBINDEX_NULL_BUCKET_FILE_EXTENSION, hashFunction, storage));
+      partitions.add(new OLocalHashTable<Object, Object>(name + "_" + i, getFileName() + "_" + i, SUBINDEX_METADATA_FILE_EXTENSION,
+          SUBINDEX_TREE_FILE_EXTENSION, SUBINDEX_BUCKET_FILE_EXTENSION, SUBINDEX_NULL_BUCKET_FILE_EXTENSION, hashFunction,
+          storage));
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/sharding/auto/OAutoShardingIndexFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sharding/auto/OAutoShardingIndexFactory.java
@@ -15,11 +15,6 @@
  */
 package com.orientechnologies.orient.core.sharding.auto;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import com.orientechnologies.orient.core.exception.OConfigurationException;
 import com.orientechnologies.orient.core.index.*;
 import com.orientechnologies.orient.core.index.engine.ORemoteIndexEngine;
@@ -28,6 +23,11 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Auto-sharding index factory.<br>
  * Supports index types:
@@ -35,13 +35,13 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
  * <li>UNIQUE</li>
  * <li>NOTUNIQUE</li>
  * </ul>
- * 
+ *
  * @since 3.0
  */
 public class OAutoShardingIndexFactory implements OIndexFactory {
 
-  public static final String       AUTOSHARDING_ALGORITHM = "AUTOSHARDING";
-  public static final String       NONE_VALUE_CONTAINER   = "NONE";
+  public static final String AUTOSHARDING_ALGORITHM = "AUTOSHARDING";
+  public static final String NONE_VALUE_CONTAINER   = "NONE";
 
   private static final Set<String> TYPES;
   private static final Set<String> ALGORITHMS;
@@ -86,7 +86,7 @@ public class OAutoShardingIndexFactory implements OIndexFactory {
     return ALGORITHMS;
   }
 
-  public OIndexInternal<?> createIndex(String name, OStorage storage, String indexType, String algorithm,
+  public OIndexInternal<?> createIndex(String name, String fileName, OStorage storage, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException {
     if (valueContainerAlgorithm == null)
       valueContainerAlgorithm = NONE_VALUE_CONTAINER;
@@ -105,9 +105,9 @@ public class OAutoShardingIndexFactory implements OIndexFactory {
       final ODocument metadata, final OAbstractPaginatedStorage storage, final int version) {
 
     if (OClass.INDEX_TYPE.UNIQUE.toString().equals(indexType)) {
-      return new OIndexUnique(name, indexType, AUTOSHARDING_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexUnique(name, name, indexType, AUTOSHARDING_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     } else if (OClass.INDEX_TYPE.NOTUNIQUE.toString().equals(indexType)) {
-      return new OIndexNotUnique(name, indexType, AUTOSHARDING_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
+      return new OIndexNotUnique(name, name, indexType, AUTOSHARDING_ALGORITHM, version, storage, valueContainerAlgorithm, metadata);
     }
 
     throw new OConfigurationException("Unsupported type: " + indexType);
@@ -119,7 +119,7 @@ public class OAutoShardingIndexFactory implements OIndexFactory {
   }
 
   @Override
-  public OIndexEngine createIndexEngine(final String algorithm, final String name, final Boolean durableInNonTxMode,
+  public OIndexEngine createIndexEngine(final String algorithm, final String name, String fileName, final Boolean durableInNonTxMode,
       final OStorage storage, final int version, final Map<String, String> engineProperties) {
 
     final OIndexEngine indexEngine;
@@ -139,4 +139,6 @@ public class OAutoShardingIndexFactory implements OIndexFactory {
 
     return indexEngine;
   }
+
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLInsert.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLInsert.java
@@ -93,14 +93,15 @@ public class OCommandExecutorSQLInsert extends OCommandExecutorSQLSetAware imple
       parserRequiredKeyword("INSERT");
       parserRequiredKeyword("INTO");
 
-      String subjectName = parserRequiredWord(true, "Invalid subject name. Expected cluster, class or index");
+      String subjectNameOriginal = parserRequiredWord(false, "Invalid subject name. Expected cluster, class or index");
+      String subjectName = subjectNameOriginal.toUpperCase();
       if (subjectName.startsWith(OCommandExecutorSQLAbstract.CLUSTER_PREFIX))
         // CLUSTER
         clusterName = subjectName.substring(OCommandExecutorSQLAbstract.CLUSTER_PREFIX.length());
 
       else if (subjectName.startsWith(OCommandExecutorSQLAbstract.INDEX_PREFIX))
         // INDEX
-        indexName = subjectName.substring(OCommandExecutorSQLAbstract.INDEX_PREFIX.length());
+        indexName = subjectNameOriginal.substring(OCommandExecutorSQLAbstract.INDEX_PREFIX.length());
 
       else {
         // CLASS

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OOrderByOptimizer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OOrderByOptimizer.java
@@ -82,8 +82,8 @@ public class OOrderByOptimizer {
 
     //check that all the "equals" clauses are a prefix for the index
     for (int i = 0; i < endIndex; i++) {
-      final String equalsFieldName = equalsFilterFields.get(i).toLowerCase();
-      final String indexFieldName = indexFields.get(i).toLowerCase();
+      final String equalsFieldName = equalsFilterFields.get(i);
+      final String indexFieldName = indexFields.get(i);
       if (!equalsFieldName.equals(indexFieldName))
         return false;
     }
@@ -101,8 +101,8 @@ public class OOrderByOptimizer {
       if (!firstOrder.equals(pair.getValue()))
         return false;
 
-      final String orderFieldName = pair.getKey().toLowerCase();
-      final String indexFieldName = indexFields.get(i).toLowerCase();
+      final String orderFieldName = pair.getKey();
+      final String indexFieldName = indexFields.get(i);
 
       if (!orderFieldName.equals(indexFieldName))
         return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
@@ -1298,8 +1298,8 @@ public class OSelectExecutionPlanner {
     }
 
     for (int i = 0; i < orderedFields.size(); i++) {
-      final String orderFieldName = orderedFields.get(i).toLowerCase();//toLowerCase...? remove this?
-      final String indexFieldName = fields.get(i).toLowerCase();//toLowerCase...?
+      final String orderFieldName = orderedFields.get(i);
+      final String indexFieldName = fields.get(i);
       if (!orderFieldName.equals(indexFieldName)) {
         return false;
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLTarget.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/filter/OSQLTarget.java
@@ -208,7 +208,7 @@ public class OSQLTarget extends OBaseParser {
         if (subjectName.equals("AS"))
           alias = parserRequiredWord(true, "Alias not found");
         else
-          alias = subjectName;
+          alias = originalSubjectName;
 
         final String subjectToMatch = subjectName;
         if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.CLUSTER_PREFIX)) {
@@ -227,7 +227,7 @@ public class OSQLTarget extends OBaseParser {
 
         } else if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.INDEX_PREFIX)) {
           // REGISTER AS INDEX
-          targetIndex = subjectName.substring(OCommandExecutorSQLAbstract.INDEX_PREFIX.length());
+          targetIndex = originalSubjectName.substring(OCommandExecutorSQLAbstract.INDEX_PREFIX.length());
         } else if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.METADATA_PREFIX)) {
           // METADATA
           final String metadataTarget = subjectName.substring(OCommandExecutorSQLAbstract.METADATA_PREFIX.length());
@@ -252,13 +252,13 @@ public class OSQLTarget extends OBaseParser {
             ((List<OIdentifiable>) targetRecords).add(value);
 
         } else if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.INDEX_VALUES_PREFIX)) {
-          targetIndexValues = subjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_PREFIX.length());
+          targetIndexValues = originalSubjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_PREFIX.length());
           targetIndexValuesAsc = true;
         } else if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.INDEX_VALUES_ASC_PREFIX)) {
-          targetIndexValues = subjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_ASC_PREFIX.length());
+          targetIndexValues = originalSubjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_ASC_PREFIX.length());
           targetIndexValuesAsc = true;
         } else if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.INDEX_VALUES_DESC_PREFIX)) {
-          targetIndexValues = subjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_DESC_PREFIX.length());
+          targetIndexValues = originalSubjectName.substring(OCommandExecutorSQLAbstract.INDEX_VALUES_DESC_PREFIX.length());
           targetIndexValuesAsc = false;
         } else {
           if (subjectToMatch.startsWith(OCommandExecutorSQLAbstract.CLASS_PREFIX))

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -271,13 +271,14 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     for (String indexName : indexNames) {
       final OStorageConfiguration.IndexEngineData engineData = configuration.getIndexEngine(indexName);
       final OIndexEngine engine = OIndexes
-          .createIndexEngine(engineData.getName(), engineData.getAlgorithm(), engineData.getIndexType(),
+          .createIndexEngine(engineData.getName(), engineData.getFileName(), engineData.getAlgorithm(), engineData.getIndexType(),
               engineData.getDurableInNonTxMode(), this, engineData.getVersion(), engineData.getEngineProperties(), null);
 
       try {
-        engine.load(engineData.getName(), cf.binarySerializerFactory.getObjectSerializer(engineData.getValueSerializerId()),
-            engineData.isAutomatic(), cf.binarySerializerFactory.getObjectSerializer(engineData.getKeySerializedId()),
-            engineData.getKeyTypes(), engineData.isNullValuesSupport(), engineData.getKeySize(), engineData.getEngineProperties());
+        engine.load(engineData.getName(), engineData.getFileName(),
+            cf.binarySerializerFactory.getObjectSerializer(engineData.getValueSerializerId()), engineData.isAutomatic(),
+            cf.binarySerializerFactory.getObjectSerializer(engineData.getKeySerializedId()), engineData.getKeyTypes(),
+            engineData.isNullValuesSupport(), engineData.getKeySize(), engineData.getEngineProperties());
 
         indexEngineNameMap.put(engineData.getName().toLowerCase(configuration.getLocaleInstance()), engine);
         indexEngines.add(engine);
@@ -1364,9 +1365,9 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     }
   }
 
-  public int loadExternalIndexEngine(String engineName, String algorithm, String indexType, OIndexDefinition indexDefinition,
-      OBinarySerializer valueSerializer, boolean isAutomatic, Boolean durableInNonTxMode, int version,
-      Map<String, String> engineProperties) {
+  public int loadExternalIndexEngine(String engineName, String fileName, String algorithm, String indexType,
+      OIndexDefinition indexDefinition, OBinarySerializer valueSerializer, boolean isAutomatic, Boolean durableInNonTxMode,
+      int version, Map<String, String> engineProperties) {
     checkOpenness();
 
     stateLock.acquireWriteLock();
@@ -1392,13 +1393,14 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       final OType[] keyTypes = indexDefinition != null ? indexDefinition.getTypes() : null;
       final boolean nullValuesSupport = indexDefinition != null && !indexDefinition.isNullValuesIgnored();
 
-      final OStorageConfiguration.IndexEngineData engineData = new OStorageConfiguration.IndexEngineData(originalName, algorithm,
-          indexType, durableInNonTxMode, version, valueSerializer.getId(), keySerializer.getId(), isAutomatic, keyTypes,
+      final OStorageConfiguration.IndexEngineData engineData = new OStorageConfiguration.IndexEngineData(originalName, fileName,
+          algorithm, indexType, durableInNonTxMode, version, valueSerializer.getId(), keySerializer.getId(), isAutomatic, keyTypes,
           nullValuesSupport, keySize, engineProperties);
 
       final OIndexEngine engine = OIndexes
-          .createIndexEngine(originalName, algorithm, indexType, durableInNonTxMode, this, version, engineProperties, null);
-      engine.load(originalName, valueSerializer, isAutomatic, keySerializer, keyTypes, nullValuesSupport, keySize,
+          .createIndexEngine(originalName, fileName, algorithm, indexType, durableInNonTxMode, this, version, engineProperties,
+              null);
+      engine.load(originalName, fileName, valueSerializer, isAutomatic, keySerializer, keyTypes, nullValuesSupport, keySize,
           engineData.getEngineProperties());
 
       indexEngineNameMap.put(engineName, engine);
@@ -1413,7 +1415,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     }
   }
 
-  public int addIndexEngine(String engineName, final String algorithm, final String indexType,
+  public int addIndexEngine(String engineName,String fileName, final String algorithm, final String indexType,
       final OIndexDefinition indexDefinition, final OBinarySerializer valueSerializer, final boolean isAutomatic,
       final Boolean durableInNonTxMode, final int version, final Map<String, String> engineProperties,
       final Set<String> clustersToIndex, final ODocument metadata) {
@@ -1427,6 +1429,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
       final String originalName = engineName;
       engineName = engineName.toLowerCase(configuration.getLocaleInstance());
+
 
       if (indexEngineNameMap.containsKey(engineName)) {
         // OLD INDEX FILE ARE PRESENT: THIS IS THE CASE OF PARTIAL/BROKEN INDEX
@@ -1453,7 +1456,8 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         serializerId = -1;
 
       final OIndexEngine engine = OIndexes
-          .createIndexEngine(originalName, algorithm, indexType, durableInNonTxMode, this, version, engineProperties, metadata);
+          .createIndexEngine(originalName, fileName, algorithm, indexType, durableInNonTxMode, this, version, engineProperties,
+              metadata);
 
       engine.create(valueSerializer, isAutomatic, keyTypes, nullValuesSupport, keySerializer, keySize, clustersToIndex,
           engineProperties, metadata);
@@ -1462,7 +1466,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
       indexEngines.add(engine);
 
-      final OStorageConfiguration.IndexEngineData engineData = new OStorageConfiguration.IndexEngineData(originalName, algorithm,
+      final OStorageConfiguration.IndexEngineData engineData = new OStorageConfiguration.IndexEngineData(originalName, fileName, algorithm,
           indexType, durableInNonTxMode, version, serializerId, keySerializer.getId(), isAutomatic, keyTypes, nullValuesSupport,
           keySize, engineProperties);
 
@@ -3066,7 +3070,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         OLogManager.instance().error(this, "Error on recycling record " + rid + " (cluster: " + cluster + ")", e);
 
         throw OException
-          .wrapException(new OStorageException("Error on recycling record " + rid + " (cluster: " + cluster + ")"), e);      
+            .wrapException(new OStorageException("Error on recycling record " + rid + " (cluster: " + cluster + ")"), e);
       }
 
       if (OLogManager.instance().isDebugEnabled())
@@ -3078,7 +3082,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       OLogManager.instance().error(this, "Error on recycling record " + rid + " (cluster: " + cluster + ")", ioe);
 
       throw OException
-        .wrapException(new OStorageException("Error on recycling record " + rid + " (cluster: " + cluster + ")"), ioe);    
+          .wrapException(new OStorageException("Error on recycling record " + rid + " (cluster: " + cluster + ")"), ioe);
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -280,7 +280,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             cf.binarySerializerFactory.getObjectSerializer(engineData.getKeySerializedId()), engineData.getKeyTypes(),
             engineData.isNullValuesSupport(), engineData.getKeySize(), engineData.getEngineProperties());
 
-        indexEngineNameMap.put(engineData.getName().toLowerCase(configuration.getLocaleInstance()), engine);
+        indexEngineNameMap.put(engineData.getName(), engine);
         indexEngines.add(engine);
       } catch (RuntimeException e) {
         OLogManager.instance()
@@ -1352,7 +1352,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     try {
       checkOpenness();
 
-      final OIndexEngine engine = indexEngineNameMap.get(name.toLowerCase(configuration.getLocaleInstance()));
+      final OIndexEngine engine = indexEngineNameMap.get(name);
       if (engine == null)
         return -1;
 
@@ -1381,7 +1381,6 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         return -1;
 
       final String originalName = engineName;
-      engineName = engineName.toLowerCase(configuration.getLocaleInstance());
 
       if (indexEngineNameMap.containsKey(engineName))
         throw new OIndexException("Index with name " + engineName + " already exists");
@@ -1428,8 +1427,6 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       checkLowDiskSpaceRequestsAndBackgroundDataFlushExceptions();
 
       final String originalName = engineName;
-      engineName = engineName.toLowerCase(configuration.getLocaleInstance());
-
 
       if (indexEngineNameMap.containsKey(engineName)) {
         // OLD INDEX FILE ARE PRESENT: THIS IS THE CASE OF PARTIAL/BROKEN INDEX
@@ -1528,7 +1525,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
       engine.delete();
 
-      final String engineName = engine.getName().toLowerCase(configuration.getLocaleInstance());
+      final String engineName = engine.getName();
       indexEngineNameMap.remove(engineName);
       configuration.deleteIndexEngine(engineName);
     } catch (IOException e) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
@@ -41,7 +41,7 @@ public class OClusterPositionMap extends ODurableComponent {
   private long fileId;
 
   public OClusterPositionMap(OAbstractPaginatedStorage storage, String name, String lockName) {
-    super(storage, name, DEF_EXTENSION, lockName);
+    super(storage, name, name, DEF_EXTENSION, lockName);
   }
 
   public void open() throws IOException {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
@@ -15,15 +15,6 @@
  */
 package com.orientechnologies.orient.core.storage.impl.local.paginated;
 
-import static com.orientechnologies.orient.core.config.OGlobalConfiguration.DISK_CACHE_PAGE_SIZE;
-import static com.orientechnologies.orient.core.config.OGlobalConfiguration.PAGINATED_STORAGE_LOWEST_FREELIST_BOUNDARY;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OFileUtils;
 import com.orientechnologies.common.log.OLogManager;
@@ -52,8 +43,16 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperation;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurableComponent;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OSessionStoragePerformanceStatistic;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.orientechnologies.orient.core.config.OGlobalConfiguration.DISK_CACHE_PAGE_SIZE;
+import static com.orientechnologies.orient.core.config.OGlobalConfiguration.PAGINATED_STORAGE_LOWEST_FREELIST_BOUNDARY;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
@@ -112,7 +111,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
   }
 
   public OPaginatedCluster(final String name, final OAbstractPaginatedStorage storage) {
-    super(storage, name, ".pcl", name + ".pcl");
+    super(storage, name, name, ".pcl", name + ".pcl");
 
     systemCluster = OMetadataInternal.SYSTEM_CLUSTER.contains(name);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
@@ -27,7 +27,6 @@ import com.orientechnologies.orient.core.storage.cache.OWriteCache;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperation;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationsManager;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OPerformanceStatisticManager;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OSessionStoragePerformanceStatistic;
 
@@ -65,19 +64,22 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
   protected final OPerformanceStatisticManager performanceStatisticManager;
 
   private volatile String name;
+  private volatile String fileName;
   private volatile String fullName;
 
   protected final String extension;
 
   private volatile String lockName;
 
-  public ODurableComponent(OAbstractPaginatedStorage storage, String name, String extension, String lockName) {
+  public ODurableComponent(OAbstractPaginatedStorage storage, String name, String fileName, String extension, String lockName) {
     super(true);
 
     assert name != null;
+    assert fileName != null;
     this.extension = extension;
     this.storage = storage;
-    this.fullName = name + extension;
+    this.fileName = fileName;
+    this.fullName = fileName + extension;
     this.name = name;
     this.atomicOperationsManager = storage.getAtomicOperationsManager();
     this.readCache = storage.getReadCache();
@@ -96,7 +98,16 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
 
   public void setName(String name) {
     this.name = name;
-    this.fullName = name + extension;
+//    this.fullName = name + extension;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+    this.fullName = fileName + extension;
   }
 
   public String getFullName() {
@@ -117,7 +128,7 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
   }
 
   /**
-   * @see OAtomicOperationsManager#startAtomicOperation(com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurableComponent, boolean)
+   * @see OAtomicOperationsManager#startAtomicOperation(com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurableComponent, * boolean)
    */
   protected OAtomicOperation startAtomicOperation(boolean trackNonTxOperations) throws IOException {
     return atomicOperationsManager.startAtomicOperation(this, trackNonTxOperations);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurableComponent.java
@@ -98,7 +98,6 @@ public abstract class ODurableComponent extends OSharedResourceAdaptive {
 
   public void setName(String name) {
     this.name = name;
-//    this.fullName = name + extension;
   }
 
   public String getFileName() {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
@@ -364,7 +364,7 @@ public class ODirectMemoryOnlyDiskCache extends OAbstractWriteCache implements O
 
       fileNameIdMap.remove(fileName);
 
-      fileName = newFileName + fileName.substring(fileName.lastIndexOf(oldFileName) + fileName.length());
+      fileName = newFileName;
 
       fileIdNameMap.put(intId, fileName);
       fileNameIdMap.put(fileName, intId);

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/LocalHashTableIterationTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/LocalHashTableIterationTestIT.java
@@ -41,7 +41,7 @@ public class LocalHashTableIterationTestIT {
       }
     };
 
-    localHashTable = new OLocalHashTable<Integer, String>("localHashTableIterationTest", ".imc", ".tsc", ".obf", ".nbh",
+    localHashTable = new OLocalHashTable<Integer, String>("localHashTableIterationTest", "localHashTableIterationTest",".imc", ".tsc", ".obf", ".nbh",
         hashFunction, (OAbstractPaginatedStorage) databaseDocumentTx.getStorage());
 
     localHashTable

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableTestIT.java
@@ -32,7 +32,7 @@ public class OLocalHashTableTestIT extends OLocalHashTableBase {
     OMurmurHash3HashFunction<Integer> murmurHash3HashFunction = new OMurmurHash3HashFunction<Integer>();
     murmurHash3HashFunction.setValueSerializer(OIntegerSerializer.INSTANCE);
 
-    localHashTable = new OLocalHashTable<Integer, String>("localHashTableTest", ".imc", ".tsc", ".obf", ".nbh",
+    localHashTable = new OLocalHashTable<Integer, String>("localHashTableTest","localHashTableTest", ".imc", ".tsc", ".obf", ".nbh",
         murmurHash3HashFunction, (OAbstractPaginatedStorage) databaseDocumentTx.getStorage());
 
     localHashTable

--- a/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableWALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/hashindex/local/OLocalHashTableWALTestIT.java
@@ -104,7 +104,7 @@ public class OLocalHashTableWALTestIT extends OLocalHashTableBase {
     OMurmurHash3HashFunction<Integer> murmurHash3HashFunction = new OMurmurHash3HashFunction<Integer>();
     murmurHash3HashFunction.setValueSerializer(OIntegerSerializer.INSTANCE);
 
-    localHashTable = new OLocalHashTable<Integer, String>("actualLocalHashTable", ".imc", ".tsc", ".obf", ".nbh",
+    localHashTable = new OLocalHashTable<Integer, String>("actualLocalHashTable", "actualLocalHashTable",".imc", ".tsc", ".obf", ".nbh",
         murmurHash3HashFunction, (OAbstractPaginatedStorage) databaseDocumentTx.getStorage());
     localHashTable
         .create(OIntegerSerializer.INSTANCE, OBinarySerializerFactory.getInstance().<String>getObjectSerializer(OType.STRING), null,

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeCompositeKeyTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeCompositeKeyTest.java
@@ -31,7 +31,7 @@ public class SBTreeCompositeKeyTest extends DatabaseAbstractTest {
 
   @Before
   public void beforeMethod() {
-    localSBTree = new OSBTree<OCompositeKey, OIdentifiable>("localSBTreeCompositeKeyTest", ".sbt", false, ".nbt",
+    localSBTree = new OSBTree<OCompositeKey, OIdentifiable>("localSBTreeCompositeKeyTest", "localSBTreeCompositeKeyTest", ".sbt", false, ".nbt",
         (OAbstractPaginatedStorage) database.getStorage().getUnderlying());
     localSBTree.create(OCompositeKeySerializer.INSTANCE, OLinkSerializer.INSTANCE, null, 2, false);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeTestIT.java
@@ -36,7 +36,7 @@ public class SBTreeTestIT {
 
     databaseDocumentTx.create();
 
-    sbTree = new OSBTree<Integer, OIdentifiable>("sbTree", ".sbt", false, ".nbt",
+    sbTree = new OSBTree<Integer, OIdentifiable>("sbTree", "sbTree",".sbt", false, ".nbt",
         (OAbstractPaginatedStorage) databaseDocumentTx.getStorage());
     sbTree.create(OIntegerSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, 1, false);
   }
@@ -477,7 +477,7 @@ public class SBTreeTestIT {
 
   @Test
   public void testNullKeysInSBTree() {
-    final OSBTree<Integer, OIdentifiable> nullSBTree = new OSBTree<Integer, OIdentifiable>("nullSBTree", ".sbt", false, ".nbt",
+    final OSBTree<Integer, OIdentifiable> nullSBTree = new OSBTree<Integer, OIdentifiable>("nullSBTree","nullSBTree", ".sbt", false, ".nbt",
         (OAbstractPaginatedStorage) databaseDocumentTx.getStorage());
     nullSBTree.create(OIntegerSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, 1, true);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeWALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/sbtree/local/SBTreeWALTestIT.java
@@ -111,7 +111,7 @@ public class SBTreeWALTestIT extends SBTreeTestIT {
 
     actualReadCache = ((OAbstractPaginatedStorage) databaseDocumentTx.getStorage()).getReadCache();
 
-    sbTree = new OSBTree<>("actualSBTree", ".sbt", true, ".nbt", actualStorage);
+    sbTree = new OSBTree<>("actualSBTree","actualSBTree", ".sbt", true, ".nbt", actualStorage);
     sbTree.create(OIntegerSerializer.INSTANCE, OLinkSerializer.INSTANCE, null, 1, false);
   }
 

--- a/lucene/src/main/java/com/orientechnologies/lucene/OLuceneIndexFactory.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/OLuceneIndexFactory.java
@@ -83,7 +83,7 @@ public class OLuceneIndexFactory implements OIndexFactory, ODatabaseLifecycleLis
   }
 
   @Override
-  public OIndexInternal<?> createIndex(String name, OStorage storage, String indexType, String algorithm,
+  public OIndexInternal<?> createIndex(String name, String fileName, OStorage storage, String indexType, String algorithm,
       String valueContainerAlgorithm, ODocument metadata, int version) throws OConfigurationException {
 
     OAbstractPaginatedStorage pagStorage = (OAbstractPaginatedStorage) storage.getUnderlying();
@@ -102,7 +102,7 @@ public class OLuceneIndexFactory implements OIndexFactory, ODatabaseLifecycleLis
   }
 
   @Override
-  public OIndexEngine createIndexEngine(String algorithm, String indexName, Boolean durableInNonTxMode, OStorage storage,
+  public OIndexEngine createIndexEngine(String algorithm, String indexName, String fileName, Boolean durableInNonTxMode, OStorage storage,
       int version, Map<String, String> engineProperties) {
 
     return new OLuceneFullTextIndexEngine(storage, indexName);

--- a/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineAbstract.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineAbstract.java
@@ -423,7 +423,7 @@ public abstract class OLuceneIndexEngineAbstract<V> extends OSharedResourceAdapt
   }
 
   @Override
-  public void load(String indexName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
+  public void load(String indexName, String fileName, OBinarySerializer valueSerializer, boolean isAutomatic, OBinarySerializer keySerializer,
       OType[] keyTypes, boolean nullPointerSupport, int keySize, Map<String, String> engineProperties) {
     // initIndex(indexName, indexDefinition, isAutomatic, metadata);
   }

--- a/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
@@ -52,7 +52,7 @@ public class OLuceneIndexNotUnique extends OIndexAbstract<Set<OIdentifiable>> im
       OAbstractPaginatedStorage storage,
       String valueContainerAlgorithm,
       ODocument metadata) {
-    super(name, typeId, algorithm, valueContainerAlgorithm, metadata, version, storage);
+    super(name, name, typeId, algorithm, valueContainerAlgorithm, metadata, version, storage);
   }
 
   @Override

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexManagerTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexManagerTest.java
@@ -1,13 +1,7 @@
 package com.orientechnologies.orient.test.database.auto;
 
 import com.orientechnologies.common.listener.OProgressListener;
-import com.orientechnologies.orient.core.index.OCompositeIndexDefinition;
-import com.orientechnologies.orient.core.index.OIndex;
-import com.orientechnologies.orient.core.index.OIndexDefinition;
-import com.orientechnologies.orient.core.index.OIndexManager;
-import com.orientechnologies.orient.core.index.OIndexManagerProxy;
-import com.orientechnologies.orient.core.index.OPropertyIndexDefinition;
-import com.orientechnologies.orient.core.index.OSimpleKeyIndexDefinition;
+import com.orientechnologies.orient.core.index.*;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OType;
@@ -23,12 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 @Test
 public class IndexManagerTest extends DocumentDBBaseTest {
@@ -207,7 +196,7 @@ public class IndexManagerTest extends DocumentDBBaseTest {
 
     final boolean result = indexManager.areIndexed(CLASS_NAME, Arrays.asList("ftwO", "Fone", "fThrEE"));
 
-    assertTrue(result);
+    assertFalse(result);
   }
 
   @Test(dependsOnMethods = { "createCompositeIndexTestWithListener", "createCompositeIndexTestWithoutListener",
@@ -435,8 +424,7 @@ public class IndexManagerTest extends DocumentDBBaseTest {
 
     final Set<OIndex<?>> result = indexManager.getClassInvolvedIndexes(CLASS_NAME, Arrays.asList("ftwO", "foNe", "fThrEE"));
 
-    assertEquals(result.size(), 1);
-    assertEquals(result.iterator().next().getName(), "compositetwo");
+    assertEquals(result.size(), 0);
   }
 
   @Test(dependsOnMethods = { "createCompositeIndexTestWithListener", "createCompositeIndexTestWithoutListener",

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexTest.java
@@ -188,7 +188,7 @@ public class IndexTest extends ObjectDBBaseTest {
 
   @Test(dependsOnMethods = "testDuplicatedIndexOnNotUnique")
   public void testQueryIndex() {
-    List<?> result = database.query(new OSQLSynchQuery<Object>("select from index:profile.nick where key = 'Jay'"));
+    List<?> result = database.query(new OSQLSynchQuery<Object>("select from index:Profile.nick where key = 'Jay'"));
     Assert.assertTrue(result.size() > 0);
   }
 
@@ -200,10 +200,10 @@ public class IndexTest extends ObjectDBBaseTest {
 
     final List<Long> positions = getValidPositions(3);
 
-    database.command(new OCommandSQL("insert into index:IDX (key,rid) values (10,#3:" + positions.get(0) + ')')).execute();
-    database.command(new OCommandSQL("insert into index:IDX (key,rid) values (20,#3:" + positions.get(1) + ')')).execute();
+    database.command(new OCommandSQL("insert into index:idx (key,rid) values (10,#3:" + positions.get(0) + ')')).execute();
+    database.command(new OCommandSQL("insert into index:idx (key,rid) values (20,#3:" + positions.get(1) + ')')).execute();
 
-    List<ODocument> result = database.command(new OCommandSQL("select from index:IDX")).execute();
+    List<ODocument> result = database.command(new OCommandSQL("select from index:idx")).execute();
     Assert.assertNotNull(result);
     Assert.assertEquals(result.size(), 2);
     for (ODocument d : result) {
@@ -218,7 +218,7 @@ public class IndexTest extends ObjectDBBaseTest {
         Assert.assertTrue(false);
     }
 
-    result = database.command(new OCommandSQL("select key, rid from index:IDX")).execute();
+    result = database.command(new OCommandSQL("select key, rid from index:idx")).execute();
     Assert.assertNotNull(result);
     Assert.assertEquals(result.size(), 2);
     for (ODocument d : result) {
@@ -233,7 +233,7 @@ public class IndexTest extends ObjectDBBaseTest {
         Assert.assertTrue(false);
     }
 
-    result = database.command(new OCommandSQL("select key from index:IDX")).execute();
+    result = database.command(new OCommandSQL("select key from index:idx")).execute();
     Assert.assertNotNull(result);
     Assert.assertEquals(result.size(), 2);
     for (ODocument d : result) {
@@ -241,7 +241,7 @@ public class IndexTest extends ObjectDBBaseTest {
       Assert.assertFalse(d.containsField("rid"));
     }
 
-    result = database.command(new OCommandSQL("select rid from index:IDX")).execute();
+    result = database.command(new OCommandSQL("select rid from index:idx")).execute();
     Assert.assertNotNull(result);
     Assert.assertEquals(result.size(), 2);
     for (ODocument d : result) {
@@ -249,7 +249,7 @@ public class IndexTest extends ObjectDBBaseTest {
       Assert.assertTrue(d.containsField("rid"));
     }
 
-    result = database.command(new OCommandSQL("select rid from index:IDX where key = 10")).execute();
+    result = database.command(new OCommandSQL("select rid from index:idx where key = 10")).execute();
     Assert.assertNotNull(result);
     Assert.assertEquals(result.size(), 1);
     for (ODocument d : result) {

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/IndexTest.java
@@ -1658,9 +1658,18 @@ public class IndexTest extends ObjectDBBaseTest {
     final OAbstractPaginatedStorage storageLocalAbstract = (OAbstractPaginatedStorage) database.getStorage();
 
     final OWriteCache writeCache = storageLocalAbstract.getWriteCache();
-    Assert.assertTrue(writeCache.exists("ValuesContainerIsRemovedIfIndexIsRemovedIndex.irs"));
+    Assert.assertTrue(existsFile(writeCache.files().keySet(), "ValuesContainerIsRemovedIfIndexIsRemovedIndex", ".irs"));
     database.command(new OCommandSQL("drop index ValuesContainerIsRemovedIfIndexIsRemovedIndex")).execute();
-    Assert.assertTrue(!writeCache.exists("ValuesContainerIsRemovedIfIndexIsRemovedIndex.irs"));
+    Assert.assertFalse(existsFile(writeCache.files().keySet(), "ValuesContainerIsRemovedIfIndexIsRemovedIndex", ".irs"));
+  }
+
+  private boolean existsFile(Set<String> strings, String prefix, String suffix) {
+    for (String s : strings) {
+      if (s.startsWith(prefix) && s.endsWith(suffix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public void testPreservingIdentityInIndexTx() {

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/PropertyIndexTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/PropertyIndexTest.java
@@ -181,7 +181,7 @@ public class PropertyIndexTest extends DocumentDBBaseTest {
     final OClass oClass = schema.getClass("PropertyIndexTestClass");
 
     oClass.createIndex("PropertyIndexFirstIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{ "prop4"});
-    oClass.createIndex("PropertyIndexSecondIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{ "pROp4"});
+    oClass.createIndex("PropertyIndexSecondIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{ "prop4"});
 
     oClass.getProperty("prop4").dropIndexes();
 
@@ -194,7 +194,7 @@ public class PropertyIndexTest extends DocumentDBBaseTest {
     final OSchema schema = database.getMetadata().getSchema();
     final OClass oClass = schema.getClass("PropertyIndexTestClass");
 
-    oClass.createIndex("PropertyIndexFirstIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{"pROp4"});
+    oClass.createIndex("PropertyIndexFirstIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{"prop4"});
     oClass.createIndex("PropertyIndexSecondIndex", OClass.INDEX_TYPE.UNIQUE.toString(), null, new ODocument().fields("ignoreNullValues", true), new String[]{"prop4", "prop5"});
 
     try {

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLDropPropertyIndexTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLDropPropertyIndexTest.java
@@ -15,12 +15,6 @@
  */
 package com.orientechnologies.orient.test.database.auto;
 
-import java.util.Arrays;
-
-import org.testng.Assert;
-import org.testng.annotations.*;
-
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
 import com.orientechnologies.orient.core.index.OCompositeIndexDefinition;
 import com.orientechnologies.orient.core.index.OIndex;
@@ -29,7 +23,10 @@ import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import com.orientechnologies.orient.enterprise.channel.binary.OResponseProcessingException;
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+import java.util.Arrays;
 
 @Test(groups = { "index" })
 public class SQLDropPropertyIndexTest extends DocumentDBBaseTest {
@@ -91,7 +88,7 @@ public class SQLDropPropertyIndexTest extends DocumentDBBaseTest {
         .getClassIndex("DropPropertyIndexCompositeIndex");
     Assert.assertNotNull(index);
 
-    database.command(new OCommandSQL("DROP PROPERTY DropPropertyIndextestclasS.pRoP1 FORCE")).execute();
+    database.command(new OCommandSQL("DROP PROPERTY DropPropertyIndextestclasS.prop1 FORCE")).execute();
     database.getMetadata().getIndexManager().reload();
 
     index = database.getMetadata().getSchema().getClass("DropPropertyIndexTestClass")
@@ -142,7 +139,7 @@ public class SQLDropPropertyIndexTest extends DocumentDBBaseTest {
         .execute();
 
     try {
-      database.command(new OCommandSQL("DROP PROPERTY DropPropertyIndextestclaSS.proP1")).execute();
+      database.command(new OCommandSQL("DROP PROPERTY DropPropertyIndextestclaSS.prop1")).execute();
       Assert.fail();
     } catch (OCommandExecutionException e) {
       Assert.assertTrue(e.getMessage().contains(


### PR DESCRIPTION
**Goal**: 
- fix an old problem regarding case sensitivity of properties in schema. Until now, properties where case sensitive while schemaless. When you declared schema for a property, it became case insensitive. 

**Side effects**:
- Index names are now CASE SENSITIVE!

**Challenges**: 
- when creating an index from Property API, its name is assigned as `ClassName.propertyName`. Index file names are the same as the index name. Defining two properties with colliding case insensitive names (eg. `Person.firstname` and `Person.firstName`) would lead to two index file names that collide on case insensitive file systems (Windows systems and the vast majority of OSX instances), so we had to refactor index file name generation to avoid such a collision

**Code Changes**:
- a big change to low level index API to explicitly pass file name when creating an index 
- a change to ODurableComponent and to index metadata to store the file name
- removal of some (well, more than fourty...) `toLowerCase()` in the Schema implementation to make properties case sensitive
- increase OStorageConfiguration.CURRENT_VERSION number

**Open/Critical Points**:
- please check that I didn't miss anything in the refactoring ( @laa )
- I had to do a fix on ODirectMemoryOnlyDiskCache to make tests pass (line 367). Please check it, because it's quite obscure...  ( @lvca @laa )
- Please double check autosharding index behavior ( @lvca )
- Is there anything specific to do for distributed? ( @lvca )
- Geospatial indexes will likely need a little fix ( @maggiolo00 )
