### PR TITLE
Case sensitive file names

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OWriteCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/OWriteCache.java
@@ -94,7 +94,7 @@ public interface OWriteCache {
 
   void truncateFile(long fileId) throws IOException;
 
-  void renameFile(long fileId, String oldFileName, String newFileName) throws IOException;
+  void renameFile(long fileId, String newFileName) throws IOException;
 
   long[] close() throws IOException;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/OWOWCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/OWOWCache.java
@@ -1270,7 +1270,7 @@ public class OWOWCache extends OAbstractWriteCache implements OWriteCache, OCach
 
     if (nameIdMapHolderFileV2T.exists()) {
       if (!nameIdMapHolderFileV2T.delete()) {
-        throw new OStorageException("Can not deleter temporary version of registry of storage files "
+        throw new OStorageException("Can not delete temporary version of registry of storage files "
             + "during conversion of file registry from v1 binary format to v2 binary format");
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OClusterPositionMap.java
@@ -169,7 +169,7 @@ public class OClusterPositionMap extends ODurableComponent {
       startAtomicOperation(true);
       acquireExclusiveLock();
       try {
-        writeCache.renameFile(fileId, getFullName(), newName + getExtension());
+        writeCache.renameFile(fileId, newName + getExtension());
         setName(newName);
         endAtomicOperation(false, null);
       } catch (IOException ioe) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OLocalPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OLocalPaginatedStorage.java
@@ -505,7 +505,7 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage implements
   }
 
   public static boolean exists(final String path) {
-    return new File(path + "/" + OMetadataDefault.CLUSTER_INTERNAL_NAME + OPaginatedCluster.DEF_EXTENSION).exists();
+    return new File(path + "/database.ocf").exists();
   }
 
   private static class FullCheckpointThreadFactory implements ThreadFactory {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OPaginatedCluster.java
@@ -247,7 +247,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
 
         readCache.deleteFile(fileId, writeCache);
         fileId = newFileId;
-        writeCache.renameFile(fileId, newFileName, getFullName());
+        writeCache.renameFile(fileId, getFullName());
       } finally {
         releaseExclusiveLock();
       }
@@ -1457,7 +1457,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
         releaseExclusiveLock();
       }
 
-      writeCache.renameFile(newFileId, getName() + DEF_EXTENSION + "t", getName() + DEF_EXTENSION);
+      writeCache.renameFile(newFileId, getName() + DEF_EXTENSION);
 
       fileId = newFileId;
       pinnedStateEntryIndex = newStateIndex;
@@ -1904,7 +1904,7 @@ public class OPaginatedCluster extends ODurableComponent implements OCluster {
 
   private void setNameInternal(final String newName) throws IOException {
 
-    writeCache.renameFile(fileId, getFullName(), newName + getExtension());
+    writeCache.renameFile(fileId, newName + getExtension());
     clusterPositionMap.rename(newName);
 
     config.name = newName;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/memory/ODirectMemoryOnlyDiskCache.java
@@ -309,7 +309,7 @@ public class ODirectMemoryOnlyDiskCache extends OAbstractWriteCache implements O
   }
 
   @Override
-  public void renameFile(long fileId, String oldFileName, String newFileName) {
+  public void renameFile(long fileId, String newFileName) {
     int intId = extractFileId(fileId);
 
     metadataLock.lock();
@@ -320,10 +320,8 @@ public class ODirectMemoryOnlyDiskCache extends OAbstractWriteCache implements O
 
       fileNameIdMap.remove(fileName);
 
-      fileName = newFileName + fileName.substring(fileName.lastIndexOf(oldFileName) + fileName.length());
-
-      fileIdNameMap.put(intId, fileName);
-      fileNameIdMap.put(fileName, intId);
+      fileIdNameMap.put(intId, newFileName);
+      fileNameIdMap.put(newFileName, intId);
     } finally {
       metadataLock.unlock();
     }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cache/local/twoq/ReadWriteDiskCacheTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cache/local/twoq/ReadWriteDiskCacheTest.java
@@ -3,7 +3,9 @@ package com.orientechnologies.orient.core.storage.cache.local.twoq;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import java.util.zip.CRC32;
 
@@ -82,6 +84,18 @@ public class ReadWriteDiskCacheTest {
   }
 
   private void closeBufferAndDeleteFile() throws IOException {
+    long fileId = -1;
+
+    if (writeBuffer != null) {
+      fileId = writeBuffer.fileIdByName("readWriteDiskCacheTest.tst");
+    }
+
+    String nativeFileName = null;
+
+    if (fileId >= 0) {
+      nativeFileName = writeBuffer.nativeFileNameById(fileId);
+    }
+
     if (writeBuffer != null) {
       if (readBuffer != null)
         readBuffer.closeStorage(writeBuffer);
@@ -101,7 +115,7 @@ public class ReadWriteDiskCacheTest {
     }
     files.clear();
 
-    File testFile = new File(storageLocal.getConfiguration().getDirectory() + File.separator + "readWriteDiskCacheTest.tst");
+    File testFile = new File(storageLocal.getConfiguration().getDirectory() + File.separator + nativeFileName);
     if (testFile.exists()) {
       Assert.assertTrue(testFile.delete());
     }
@@ -114,6 +128,13 @@ public class ReadWriteDiskCacheTest {
 
   @AfterClass
   public void afterClass() throws IOException {
+    long fileId = writeBuffer.fileIdByName("readWriteDiskCacheTest.tst");
+    String nativeFileName = null;
+
+    if (fileId >= 0) {
+      nativeFileName = writeBuffer.nativeFileNameById(fileId);
+    }
+
     if (writeBuffer != null) {
       if (readBuffer != null)
         readBuffer.deleteStorage(writeBuffer);
@@ -134,10 +155,13 @@ public class ReadWriteDiskCacheTest {
 
     storageLocal.delete();
 
-    File file = new File(storageLocal.getConfiguration().getDirectory() + "/readWriteDiskCacheTest.tst");
-    if (file.exists()) {
-      Assert.assertTrue(file.delete());
-      file.getParentFile().delete();
+    if (nativeFileName != null) {
+      File file = new File(storageLocal.getConfiguration().getDirectory() + "/" + nativeFileName);
+
+      if (file.exists()) {
+        Assert.assertTrue(file.delete());
+        file.getParentFile().delete();
+      }
     }
 
   }
@@ -152,6 +176,7 @@ public class ReadWriteDiskCacheTest {
 
   public void testAddFourItems() throws IOException {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[4];
 
@@ -194,12 +219,109 @@ public class ReadWriteDiskCacheTest {
     writeBuffer.flush();
 
     for (int i = 0; i < 4; i++) {
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(0, 0));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(0, 0), nativeFileName);
+    }
+  }
+
+  private void addFileName(String fileName, List<Long> fileIds, List<String> nativeFileNames) throws IOException {
+    final long fileId = readBuffer.addFile(fileName, writeBuffer);
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
+    fileIds.add(fileId);
+    nativeFileNames.add(nativeFileName);
+  }
+
+  public void testAddFourItemsInFourDifferentFiles() throws IOException {
+    List<Long> fileIds = new ArrayList<Long>();
+    List<String> nativeFileNames = new ArrayList<String>();
+    List<String> fileNames = new ArrayList<String>();
+
+    fileNames.add("readWriteDiskCacheTest.tst");
+    fileNames.add("readwRitedIskCacheTest.tst");
+    fileNames.add("ReadwRitedIskCacheTesT.tst");
+    fileNames.add("readwritediskcachetest.tst");
+
+    addFileName(fileNames.get(0), fileIds, nativeFileNames);
+    addFileName(fileNames.get(1), fileIds, nativeFileNames);
+    addFileName(fileNames.get(2), fileIds, nativeFileNames);
+    addFileName(fileNames.get(3), fileIds, nativeFileNames);
+
+    OCacheEntry[] entries = new OCacheEntry[4];
+
+    for (int i = 0; i < 4; i++) {
+      for (int n = 0; n < 4; n++) {
+        final long fileId = fileIds.get(n);
+
+        entries[i] = readBuffer.load(fileId, i, false, writeBuffer, 1);
+        if (entries[i] == null) {
+          entries[i] = readBuffer.allocateNewPage(fileId, writeBuffer);
+          Assert.assertEquals(entries[i].getPageIndex(), i);
+        }
+
+        entries[i].getCachePointer().acquireExclusiveLock();
+
+        entries[i].markDirty();
+
+        final ByteBuffer buffer = entries[i].getCachePointer().getSharedBuffer();
+
+        buffer.position(systemOffset);
+        buffer.put(new byte[] { (byte) i, 1, 2, (byte) (seed + n), 4, 5, 6, (byte) (i + n) });
+
+        entries[i].getCachePointer().releaseExclusiveLock();
+
+        readBuffer.release(entries[i], writeBuffer);
+      }
+    }
+
+    for (int n = 0; n < 4; n++) {
+      final long fileId = fileIds.get(n);
+      Assert.assertEquals(writeBuffer.getFilledUpTo(fileId), 4);
+    }
+
+    writeBuffer.flush();
+
+    for (int n = 0; n < 4; n++) {
+      final String nativeFileName = nativeFileNames.get(n);
+
+      for (int i = 0; i < 4; i++) {
+        assertFile(i, new byte[] { (byte) i, 1, 2, (byte) (seed + n), 4, 5, 6, (byte) (i + n) }, new OLogSequenceNumber(0, 0),
+            nativeFileName);
+      }
+    }
+
+    for (int n = 3; n >= 0; n--) {
+      for (int i = 3; i >= 0; i--) {
+        final String fileNativeName = nativeFileNames.get(i);
+
+        String path = storageLocal.getConfiguration().getDirectory() + "/" + fileNativeName;
+        final File file = new File(path);
+        if (i > n) {
+          Assert.assertFalse(file.exists());
+        } else {
+          Assert.assertTrue(file.exists());
+        }
+      }
+
+      writeBuffer.deleteFile(fileIds.get(n));
+
+      for (int i = 3; i >= 0; i--) {
+        final String fileNativeName = nativeFileNames.get(i);
+
+        String path = storageLocal.getConfiguration().getDirectory() + "/" + fileNativeName;
+        final File file = new File(path);
+        if (i >= n) {
+          Assert.assertFalse(file.exists());
+        } else {
+          Assert.assertTrue(file.exists());
+        }
+      }
     }
   }
 
   public void testFrequentlyReadItemsAreMovedInAm() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[10];
 
@@ -228,7 +350,7 @@ public class ReadWriteDiskCacheTest {
     readBuffer.clear();
 
     for (int i = 0; i < 10; i++)
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i), nativeFileName);
 
     for (int i = 0; i < 8; i++) {
       entries[i] = readBuffer.load(fileId, i, false, writeBuffer, 1);
@@ -268,9 +390,10 @@ public class ReadWriteDiskCacheTest {
   }
 
   public void testCacheShouldCreateFileIfItIsNotExisted() throws Exception {
-    readBuffer.addFile(fileName, writeBuffer);
+    final long fileId = readBuffer.addFile(fileName, writeBuffer);
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
-    File file = new File(storageLocal.getConfiguration().getDirectory() + "/readWriteDiskCacheTest.tst");
+    File file = new File(storageLocal.getConfiguration().getDirectory() + "/" + nativeFileName);
 
     Assert.assertTrue(file.exists());
     Assert.assertTrue(file.isFile());
@@ -278,6 +401,8 @@ public class ReadWriteDiskCacheTest {
 
   public void testFrequentlyAddItemsAreMovedInAm() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[10];
 
@@ -350,12 +475,14 @@ public class ReadWriteDiskCacheTest {
     writeBuffer.flush();
 
     for (int i = 0; i < 10; i++)
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i), nativeFileName);
 
   }
 
   public void testReadFourItems() throws IOException {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[4];
 
@@ -383,7 +510,7 @@ public class ReadWriteDiskCacheTest {
     writeBuffer.flush();
 
     for (int i = 0; i < 4; i++) {
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(1, i), nativeFileName);
     }
 
     for (int i = 0; i < 4; i++) {
@@ -410,6 +537,8 @@ public class ReadWriteDiskCacheTest {
 
   public void testPrefetchPagesInA1inQueue() throws Exception {
     final long fileId = readBuffer.addFile(fileName, writeBuffer);
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
     for (int i = 0; i < 4; i++) {
       OCacheEntry cacheEntry = readBuffer.allocateNewPage(fileId, writeBuffer);
       cacheEntry.acquireExclusiveLock();
@@ -440,7 +569,7 @@ public class ReadWriteDiskCacheTest {
       for (int n = 0; n < userData.length; n++) {
         userData[n] = (byte) (i + 1);
       }
-      assertFile(i, userData, new OLogSequenceNumber(1, i));
+      assertFile(i, userData, new OLogSequenceNumber(1, i), nativeFileName);
     }
 
     LRUList am = readBuffer.getAm();
@@ -474,6 +603,9 @@ public class ReadWriteDiskCacheTest {
 
   public void testPrefetchPagesInA1inAmQueue() throws Exception {
     final long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
     Assert.assertEquals(readBuffer.getMaxSize(), 4);
 
     //create file with 8 pages, we will push some of them in different queues later
@@ -507,7 +639,7 @@ public class ReadWriteDiskCacheTest {
       for (int n = 0; n < userData.length; n++) {
         userData[n] = (byte) (i + 1);
       }
-      assertFile(i, userData, new OLogSequenceNumber(1, i));
+      assertFile(i, userData, new OLogSequenceNumber(1, i), nativeFileName);
     }
 
     LRUList am = readBuffer.getAm();
@@ -559,6 +691,9 @@ public class ReadWriteDiskCacheTest {
 
   public void testStoreCacheState() throws Exception {
     final long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
     Assert.assertEquals(readBuffer.getMaxSize(), 4);
 
     //create file with 8 pages, we will push some of them in different queues later
@@ -592,7 +727,7 @@ public class ReadWriteDiskCacheTest {
       for (int n = 0; n < userData.length; n++) {
         userData[n] = (byte) (i + 1);
       }
-      assertFile(i, userData, new OLogSequenceNumber(1, i));
+      assertFile(i, userData, new OLogSequenceNumber(1, i), nativeFileName);
     }
 
     LRUList am = readBuffer.getAm();
@@ -664,6 +799,9 @@ public class ReadWriteDiskCacheTest {
 
   public void testPrefetchPagesInPinnedPages() throws Exception {
     final long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
     Assert.assertEquals(readBuffer.getMaxSize(), 4);
 
     //create file with 8 pages, we will push some of them in different queues later
@@ -697,7 +835,7 @@ public class ReadWriteDiskCacheTest {
       for (int n = 0; n < userData.length; n++) {
         userData[n] = (byte) (i + 1);
       }
-      assertFile(i, userData, new OLogSequenceNumber(1, i));
+      assertFile(i, userData, new OLogSequenceNumber(1, i), nativeFileName);
     }
 
     LRUList am = readBuffer.getAm();
@@ -792,6 +930,8 @@ public class ReadWriteDiskCacheTest {
   public void testCloseFileShouldFlushData() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
 
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
+
     OCacheEntry[] entries = new OCacheEntry[4];
 
     for (int i = 0; i < 4; i++) {
@@ -830,7 +970,7 @@ public class ReadWriteDiskCacheTest {
     readBuffer.closeFile(fileId, true, writeBuffer);
 
     for (int i = 0; i < 4; i++) {
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(0, 0));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, (byte) i }, new OLogSequenceNumber(0, 0), nativeFileName);
     }
   }
 
@@ -870,6 +1010,8 @@ public class ReadWriteDiskCacheTest {
 
   public void testFlushData() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[4];
 
@@ -913,13 +1055,15 @@ public class ReadWriteDiskCacheTest {
     writeBuffer.flush(fileId);
 
     for (int i = 0; i < 4; i++) {
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 3, (byte) i }, new OLogSequenceNumber(0, 0));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 3, (byte) i }, new OLogSequenceNumber(0, 0), nativeFileName);
     }
 
   }
 
   public void testIfNotEnoughSpaceOldPagesShouldBeMovedToA1Out() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[6];
 
@@ -964,7 +1108,7 @@ public class ReadWriteDiskCacheTest {
     writeBuffer.flush();
 
     for (int i = 0; i < 6; i++) {
-      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, 7 }, new OLogSequenceNumber(0, 0));
+      assertFile(i, new byte[] { (byte) i, 1, 2, seed, 4, 5, 6, 7 }, new OLogSequenceNumber(0, 0), nativeFileName);
     }
   }
 
@@ -1029,11 +1173,12 @@ public class ReadWriteDiskCacheTest {
       readBuffer.release(entries[i], writeBuffer);
     }
 
-    Assert.assertTrue(writeBuffer.checkStoredPages(null).length == 0);
+    Assert.assertTrue(writeBuffer.checkFileStoredPages(fileName, null).length == 0);
   }
 
   public void testMagicNumberIsBroken() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+    String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[6];
 
@@ -1059,25 +1204,26 @@ public class ReadWriteDiskCacheTest {
     byte[] brokenMagicNumber = new byte[OIntegerSerializer.INT_SIZE];
     OIntegerSerializer.INSTANCE.serializeNative(23, brokenMagicNumber, 0);
 
-    updateFilePage(2, 0, brokenMagicNumber);
-    updateFilePage(4, 0, brokenMagicNumber);
+    updateFilePage(2, 0, brokenMagicNumber, nativeFileName);
+    updateFilePage(4, 0, brokenMagicNumber, nativeFileName);
 
-    OPageDataVerificationError[] pageErrors = writeBuffer.checkStoredPages(null);
+    OPageDataVerificationError[] pageErrors = writeBuffer.checkFileStoredPages(fileName, null);
     Assert.assertEquals(2, pageErrors.length);
 
     Assert.assertTrue(pageErrors[0].incorrectMagicNumber);
     Assert.assertFalse(pageErrors[0].incorrectCheckSum);
     Assert.assertEquals(2, pageErrors[0].pageIndex);
-    Assert.assertEquals("readWriteDiskCacheTest.tst", pageErrors[0].fileName);
+    Assert.assertEquals(fileName, pageErrors[0].fileName);
 
     Assert.assertTrue(pageErrors[1].incorrectMagicNumber);
     Assert.assertFalse(pageErrors[1].incorrectCheckSum);
     Assert.assertEquals(4, pageErrors[1].pageIndex);
-    Assert.assertEquals("readWriteDiskCacheTest.tst", pageErrors[1].fileName);
+    Assert.assertEquals(fileName, pageErrors[1].fileName);
   }
 
   public void testCheckSumIsBroken() throws Exception {
     long fileId = readBuffer.addFile(fileName, writeBuffer);
+    final String nativeFileName = writeBuffer.nativeFileNameById(fileId);
 
     OCacheEntry[] entries = new OCacheEntry[6];
 
@@ -1104,21 +1250,21 @@ public class ReadWriteDiskCacheTest {
     byte[] brokenByte = new byte[1];
     brokenByte[0] = 13;
 
-    updateFilePage(2, systemOffset + 2, brokenByte);
-    updateFilePage(4, systemOffset + 4, brokenByte);
+    updateFilePage(2, systemOffset + 2, brokenByte, nativeFileName);
+    updateFilePage(4, systemOffset + 4, brokenByte, nativeFileName);
 
-    OPageDataVerificationError[] pageErrors = writeBuffer.checkStoredPages(null);
+    OPageDataVerificationError[] pageErrors = writeBuffer.checkFileStoredPages(fileName, null);
     Assert.assertEquals(2, pageErrors.length);
 
     Assert.assertFalse(pageErrors[0].incorrectMagicNumber);
     Assert.assertTrue(pageErrors[0].incorrectCheckSum);
     Assert.assertEquals(2, pageErrors[0].pageIndex);
-    Assert.assertEquals("readWriteDiskCacheTest.tst", pageErrors[0].fileName);
+    Assert.assertEquals(fileName, pageErrors[0].fileName);
 
     Assert.assertFalse(pageErrors[1].incorrectMagicNumber);
     Assert.assertTrue(pageErrors[1].incorrectCheckSum);
     Assert.assertEquals(4, pageErrors[1].pageIndex);
-    Assert.assertEquals("readWriteDiskCacheTest.tst", pageErrors[1].fileName);
+    Assert.assertEquals(fileName, pageErrors[1].fileName);
   }
 
   public void testFlushTillLSN() throws Exception {
@@ -1169,8 +1315,8 @@ public class ReadWriteDiskCacheTest {
     Assert.assertEquals(writeAheadLog.getFlushedLsn(), lsnToFlush);
   }
 
-  private void updateFilePage(long pageIndex, long offset, byte[] value) throws IOException {
-    String path = storageLocal.getConfiguration().getDirectory() + "/readWriteDiskCacheTest.tst";
+  private void updateFilePage(long pageIndex, long offset, byte[] value, String fileName) throws IOException {
+    String path = storageLocal.getConfiguration().getDirectory() + "/" + fileName;
 
     OFileClassic fileClassic = new OFileClassic(path, "rw");
     fileClassic.open();
@@ -1180,8 +1326,8 @@ public class ReadWriteDiskCacheTest {
     fileClassic.close();
   }
 
-  private void assertFile(long pageIndex, byte[] value, OLogSequenceNumber lsn) throws IOException {
-    String path = storageLocal.getConfiguration().getDirectory() + "/readWriteDiskCacheTest.tst";
+  private void assertFile(long pageIndex, byte[] value, OLogSequenceNumber lsn, String fileName) throws IOException {
+    String path = storageLocal.getConfiguration().getDirectory() + "/" + fileName;
 
     OFileClassic fileClassic = new OFileClassic(path, "r");
     fileClassic.open();

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cache/pages/PageCacheTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cache/pages/PageCacheTest.java
@@ -469,7 +469,7 @@ public class PageCacheTest {
     }
 
     @Override
-    public void renameFile(long fileId, String oldFileName, String newFileName) throws IOException {
+    public void renameFile(long fileId, String newFileName) throws IOException {
 
     }
 


### PR DESCRIPTION
A new version of file registry in write cache was implemented.
The main difference is that it contains now two different file names.
The first name is case sensitive and is used to refer files inside of storage second name is a name of the file used by a file system.  Name of the file is used by a file system may be and is different than the name of the file used by storage. 
