### PR TITLE
custom sql functions server plugin

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OCustomSQLFunctionFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OCustomSQLFunctionFactory.java
@@ -1,0 +1,77 @@
+package com.orientechnologies.orient.core.sql.functions;
+
+import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.orient.core.exception.OCommandExecutionException;
+import com.orientechnologies.orient.core.sql.functions.misc.OSQLStaticReflectiveFunction;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Factory for custom SQL functions.
+ *
+ * @author Fabrizio Fortino
+ */
+public class OCustomSQLFunctionFactory implements OSQLFunctionFactory {
+  private static final Map<String, Object> FUNCTIONS = new HashMap<>();
+
+  public static void register(final String prefix, final Class<?> clazz) {
+    final Map<String, List<Method>> methodsMap = Arrays.stream(clazz.getMethods())
+        .filter(m -> Modifier.isStatic(m.getModifiers()))
+        .collect(Collectors.groupingBy(Method::getName));
+
+    for (Map.Entry<String, List<Method>> entry : methodsMap.entrySet()) {
+      final String name = prefix + entry.getKey();
+      if (FUNCTIONS.containsKey(name)) {
+        OLogManager.instance().warn(null, "Unable to register reflective function with name " + name);
+      } else {
+        List<Method> methodsList = methodsMap.get(entry.getKey());
+        Method[] methods = new Method[methodsList.size()];
+        int i = 0;
+        int minParams = 0;
+        int maxParams = 0;
+        for (Method m : methodsList) {
+          methods[i++] = m;
+          minParams = minParams < m.getParameterTypes().length ? minParams : m.getParameterTypes().length;
+          maxParams = maxParams > m.getParameterTypes().length ? maxParams : m.getParameterTypes().length;
+        }
+        FUNCTIONS.put(name.toLowerCase(), new OSQLStaticReflectiveFunction(name, minParams, maxParams, methods));
+      }
+    }
+
+  }
+
+  @Override
+  public Set<String> getFunctionNames() {
+    return FUNCTIONS.keySet();
+  }
+
+  @Override
+  public boolean hasFunction(final String name) {
+    return FUNCTIONS.containsKey(name);
+  }
+
+  @Override
+  public OSQLFunction createFunction(final String name) {
+    final Object obj = FUNCTIONS.get(name);
+
+    if (obj == null)
+      throw new OCommandExecutionException("Unknown function name :" + name);
+
+    if (obj instanceof OSQLFunction)
+      return (OSQLFunction) obj;
+    else {
+      // it's a class
+      final Class<?> clazz = (Class<?>) obj;
+      try {
+        return (OSQLFunction) clazz.newInstance();
+      } catch (Exception e) {
+        throw OException.wrapException(new OCommandExecutionException("Error in creation of function " + name
+            + "(). Probably there is not an empty constructor or the constructor generates errors"), e);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/ODefaultSQLFunctionFactory.java
@@ -16,7 +16,6 @@
 package com.orientechnologies.orient.core.sql.functions;
 
 import com.orientechnologies.common.exception.OException;
-import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
 import com.orientechnologies.orient.core.sql.functions.coll.*;
 import com.orientechnologies.orient.core.sql.functions.geo.OSQLFunctionDistance;
@@ -28,10 +27,7 @@ import com.orientechnologies.orient.core.sql.functions.stat.*;
 import com.orientechnologies.orient.core.sql.functions.text.OSQLFunctionConcat;
 import com.orientechnologies.orient.core.sql.functions.text.OSQLFunctionFormat;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Default set of SQL function.
@@ -96,38 +92,10 @@ public final class ODefaultSQLFunctionFactory implements OSQLFunctionFactory {
     register(OSQLFunctionShortestPath.NAME, OSQLFunctionShortestPath.class);
     register(OSQLFunctionDijkstra.NAME, OSQLFunctionDijkstra.class);
     register(OSQLFunctionAstar.NAME, OSQLFunctionAstar.class);
-    // auto-register all Math.<method>() automatically with math_ prefix
-    registerStaticReflectiveFunctions("math_", Math.class);
   }
 
   public static void register(final String iName, final Object iImplementation) {
     FUNCTIONS.put(iName.toLowerCase(), iImplementation);
-  }
-
-  private static void registerStaticReflectiveFunctions(final String prefix, final Class<?> clazz) {
-    final Map<String, List<Method>> methodsMap = Arrays.stream(clazz.getMethods())
-        .filter(m -> Modifier.isStatic(m.getModifiers()))
-        .collect(Collectors.groupingBy(Method::getName));
-
-    for (Map.Entry<String, List<Method>> entry : methodsMap.entrySet()) {
-      final String name = prefix + entry.getKey();
-      if (FUNCTIONS.containsKey(name)) {
-        OLogManager.instance().warn(null, "Unable to register reflective function with name " + name);
-      } else {
-        List<Method> methodsList = methodsMap.get(entry.getKey());
-        Method[] methods = new Method[methodsList.size()];
-        int i = 0;
-        int minParams = 0;
-        int maxParams = 0;
-        for (Method m : methodsList) {
-          methods[i++] = m;
-          minParams = minParams < m.getParameterTypes().length ? minParams : m.getParameterTypes().length;
-          maxParams = maxParams > m.getParameterTypes().length ? maxParams : m.getParameterTypes().length;
-        }
-        register(name, new OSQLStaticReflectiveFunction(name, minParams, maxParams, methods));
-      }
-    }
-
   }
 
   @Override

--- a/core/src/main/resources/META-INF/services/com.orientechnologies.orient.core.sql.functions.OSQLFunctionFactory
+++ b/core/src/main/resources/META-INF/services/com.orientechnologies.orient.core.sql.functions.OSQLFunctionFactory
@@ -21,3 +21,4 @@
 com.orientechnologies.orient.core.sql.functions.ODefaultSQLFunctionFactory
 com.orientechnologies.orient.core.sql.ODynamicSQLElementFactory
 com.orientechnologies.orient.core.metadata.function.ODatabaseFunctionFactory
+com.orientechnologies.orient.core.sql.functions.OCustomSQLFunctionFactory

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/sql/OCustomSQLFunctionsTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/sql/OCustomSQLFunctionsTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.exception.OQueryParsingException;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.functions.OCustomSQLFunctionFactory;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -12,13 +13,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class OSQLMathFunctionsTest {
+public class OCustomSQLFunctionsTest {
 
   private static ODatabaseDocumentTx db;
 
   @BeforeClass
   public static void beforeClass() {
-    db = new ODatabaseDocumentTx("memory:" + OSQLMathFunctionsTest.class.getSimpleName());
+    OCustomSQLFunctionFactory.register("math_", Math.class);
+    db = new ODatabaseDocumentTx("memory:" + OCustomSQLFunctionsTest.class.getSimpleName());
     db.create();
   }
 

--- a/distribution/config/custom-sql-functions.json
+++ b/distribution/config/custom-sql-functions.json
@@ -1,0 +1,9 @@
+{
+  "enabled": true,
+  "functions": [
+    {
+      "prefix": "math",
+      "class": "java.lang.Math"
+    }
+  ]
+}

--- a/distribution/config/orientdb-server-config.xml
+++ b/distribution/config/orientdb-server-config.xml
@@ -62,6 +62,13 @@
                 <parameter name="allowedLanguages" value="SQL"/>
             </parameters>
         </handler>
+        <!-- CUSTOM SQL FUNCTIONS -->
+        <handler class="com.orientechnologies.orient.server.handler.OCustomSQLFunctionPlugin">
+            <parameters>
+                <!-- LOCATION OF JSON CONFIGURATION FILE -->
+                <parameter name="config" value="${ORIENTDB_HOME}/config/custom-sql-functions.json"/>
+            </parameters>
+        </handler>
 
     </handlers>
     <network>

--- a/server/src/main/java/com/orientechnologies/orient/server/handler/OCustomSQLFunctionPlugin.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/handler/OCustomSQLFunctionPlugin.java
@@ -1,0 +1,81 @@
+package com.orientechnologies.orient.server.handler;
+
+import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.common.io.OIOUtils;
+import com.orientechnologies.common.parser.OSystemVariableResolver;
+import com.orientechnologies.orient.core.exception.OConfigurationException;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.functions.OCustomSQLFunctionFactory;
+import com.orientechnologies.orient.server.OServer;
+import com.orientechnologies.orient.server.config.OServerParameterConfiguration;
+import com.orientechnologies.orient.server.plugin.OServerPluginAbstract;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Server Plugin to register custom SQL functions.
+ *
+ * @author Fabrizio Fortino
+ */
+public class OCustomSQLFunctionPlugin extends OServerPluginAbstract {
+
+  private static final char PREFIX_NAME_SEPARATOR = '_';
+
+  private ODocument configuration;
+
+  @Override
+  public String getName() {
+    return "custom-sql-functions-manager";
+  }
+
+  @Override
+  public void config(OServer oServer, OServerParameterConfiguration[] iParams) {
+    configuration = new ODocument();
+
+    final File configFile = Arrays.stream(iParams)
+        .filter(p -> p.name.equalsIgnoreCase("config"))
+        .map(p -> p.value.trim())
+        .map(OSystemVariableResolver::resolveSystemVariables)
+        .map(File::new)
+        .filter(File::exists)
+        .findFirst()
+        .orElseThrow(() -> new OConfigurationException("Custom SQL functions configuration file not found"));
+
+    try {
+      final String configurationContent = OIOUtils.readFileAsString(configFile);
+      configuration = new ODocument().fromJSON(configurationContent);
+    } catch (IOException e) {
+      throw OException.wrapException(new OConfigurationException(
+          "Cannot load Custom SQL configuration file '" + configFile + "'. No custom functions will be disabled"), e);
+    }
+  }
+
+  @Override
+  public void startup() {
+    if (configuration.field("enabled")) {
+      List<Map<String, String>> functions = configuration.field("functions");
+      for (Map<String, String> function: functions) {
+        final String prefix = function.get("prefix");
+        final String clazz = function.get("class");
+        if (prefix == null || clazz == null) {
+          throw new OConfigurationException("Unable to load functions without prefix and / or class ");
+        }
+        if (!prefix.matches("^[\\pL]+$")) {
+          throw new OConfigurationException("Unable to load functions with prefix '" + prefix + "'. Prefixes can be letters only");
+        }
+
+        try {
+          Class functionsClass = Class.forName(clazz);
+          OCustomSQLFunctionFactory.register(prefix + PREFIX_NAME_SEPARATOR, functionsClass);
+        } catch (ClassNotFoundException e) {
+          throw new OConfigurationException("Unable to load class " + clazz + " for custom functions with prefix " + prefix);
+        }
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
* server plugin to easily register custom sql functions (configured in an external json file)
* custom ad hoc `OSQLFunctionFactory` to handle custom functions registration
* basic `custom-sql-functions.json` with java.lang.Math registration (not hard coded anymore)
* aligned tests