### PR TITLE
Add "overwrite" record conflict strategy

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/conflict/OOverwriteConflictStrategy.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/conflict/OOverwriteConflictStrategy.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  *  Copyright 2014 Orient Technologies LTD (info(at)orientechnologies.com)
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  * For more information: http://www.orientechnologies.com
+ *  
+ */
+
+package com.orientechnologies.orient.core.conflict;
+
+import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.storage.OStorage;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Auto merges new record with the existent. Collections are also merged, item by item.
+ *
+ * @author Luca Garulli
+ */
+public class OOverwriteConflictStrategy extends OVersionRecordConflictStrategy {
+  public static final String NAME = "overwrite";
+
+  @Override
+  public byte[] onUpdate(OStorage storage, byte iRecordType, final ORecordId rid, final int iRecordVersion,
+      final byte[] iRecordContent, final AtomicInteger iDatabaseVersion) {
+
+    iDatabaseVersion.set(Math.max(iDatabaseVersion.get(), iRecordVersion) + 1);
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/conflict/OOverwriteConflictStrategy.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/conflict/OOverwriteConflictStrategy.java
@@ -26,9 +26,9 @@ import com.orientechnologies.orient.core.storage.OStorage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Auto merges new record with the existent. Collections are also merged, item by item.
+ * Overwrites the record with latest provided value, regardless of the version number
  *
- * @author Luca Garulli
+ * @author Luigi Dell'Aquila
  */
 public class OOverwriteConflictStrategy extends OVersionRecordConflictStrategy {
   public static final String NAME = "overwrite";

--- a/core/src/main/java/com/orientechnologies/orient/core/conflict/ORecordConflictStrategyFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/conflict/ORecordConflictStrategyFactory.java
@@ -29,6 +29,7 @@ public class ORecordConflictStrategyFactory extends OConfigurableStatelessFactor
     registerImplementation(OVersionRecordConflictStrategy.NAME, def);
     registerImplementation(OAutoMergeRecordConflictStrategy.NAME, new OAutoMergeRecordConflictStrategy());
     registerImplementation(OContentRecordConflictStrategy.NAME, new OContentRecordConflictStrategy());
+    registerImplementation(OOverwriteConflictStrategy.NAME, new OOverwriteConflictStrategy());
 
     setDefaultImplementation(def);
   }

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DatabaseConflictStrategyOverwriteTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DatabaseConflictStrategyOverwriteTest.java
@@ -101,13 +101,5 @@ public class DatabaseConflictStrategyOverwriteTest {
       db.shutdown();
     }
   }
-
-  private static void sleep(int i) {
-    try {
-      Thread.sleep(i);
-    } catch (InterruptedException xcpt) {
-      xcpt.printStackTrace();
-    }
-  }
-
+  
 }

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DatabaseConflictStrategyOverwriteTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/DatabaseConflictStrategyOverwriteTest.java
@@ -1,0 +1,113 @@
+package com.orientechnologies.orient.test.database.auto;
+
+import com.orientechnologies.orient.core.conflict.OOverwriteConflictStrategy;
+import com.orientechnologies.orient.core.id.ORID;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import com.tinkerpop.blueprints.impls.orient.OrientGraphFactory;
+import com.tinkerpop.blueprints.impls.orient.OrientGraphNoTx;
+import com.tinkerpop.blueprints.impls.orient.OrientVertex;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class DatabaseConflictStrategyOverwriteTest {
+
+  private static final String CLIENT_ORIENT_URL_MAIN = "memory:DatabaseConflictStrategyOverwriteTest";
+
+  private volatile Throwable exceptionInThread;
+
+  CountDownLatch initLatch = new CountDownLatch(2);
+
+  CountDownLatch firstFinished = new CountDownLatch(1);
+
+  OrientGraphFactory factory;
+
+  @Test
+  public void test() throws Throwable {
+    factory = new OrientGraphFactory(CLIENT_ORIENT_URL_MAIN);
+    OrientBaseGraph graph = factory.getNoTx();
+    graph.setConflictStrategy(OOverwriteConflictStrategy.NAME);
+    graph.createVertexType("vertextype");
+    final ORID rid = graph.addVertex("class:vertextype").getIdentity();
+    graph.shutdown();
+
+    Thread dbClient1 = new Thread() {
+      @Override
+      public void run() {
+        dbClient1(rid);
+      }
+    };
+    dbClient1.start();
+    
+    Thread dbClient2 = new Thread() {
+      @Override
+      public void run() {
+        dbClient2(rid);
+      }
+    };
+    dbClient2.start();
+
+    dbClient1.join();
+    dbClient2.join();
+
+    graph = factory.getNoTx();
+
+    OrientVertex vertex = graph.getVertex(rid);
+    vertex.reload();
+    Assert.assertEquals(vertex.getProperty("foo"), "woo");
+    Assert.assertNull(vertex.getProperty("bar"));
+
+    graph.shutdown();
+    factory.close();
+    if (exceptionInThread != null) {
+      throw exceptionInThread;
+    }
+  }
+
+  private void dbClient1(ORID rid) {
+    OrientGraphNoTx db = factory.getNoTx();
+    try {
+      OrientVertex vertex = db.getVertex(rid);
+      initLatch.countDown();
+      vertex.setProperty("foo", "bar");
+      vertex.setProperty("bar", "baz");
+      vertex.save();
+
+      vertex.setProperty("foo", "baz");
+      vertex.save();
+
+      firstFinished.countDown();
+    } catch (Exception e) {
+      exceptionInThread = e;
+    } finally {
+      db.shutdown();
+    }
+
+  }
+
+  private void dbClient2(ORID rid) {
+    OrientGraphNoTx db = factory.getNoTx();
+    try {
+      OrientVertex vertex = db.getVertex(rid);
+      initLatch.countDown();
+
+      firstFinished.await();
+      vertex.setProperty("foo", "woo");
+      vertex.save();
+    } catch (Exception e) {
+      exceptionInThread = e;
+    } finally {
+      db.shutdown();
+    }
+  }
+
+  private static void sleep(int i) {
+    try {
+      Thread.sleep(i);
+    } catch (InterruptedException xcpt) {
+      xcpt.printStackTrace();
+    }
+  }
+
+}


### PR DESCRIPTION
This conflict strategy just overwrites the record with latest value provided regardless of the version number. The version number is updated at the max value between the newly provided and the existing 

