### PR TITLE
Comments regarding tests problems

### DIFF
--- a/server/src/test/java/com/orientechnologies/orient/core/db/OrientDBRemoteTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/core/db/OrientDBRemoteTest.java
@@ -27,11 +27,16 @@ import static org.junit.Assert.assertTrue;
  */
 public class OrientDBRemoteTest {
 
+  // Leaky. Database name clash.
+
   private static final String SERVER_DIRECTORY = "./target/dbfactory";
   private OServer server;
 
   @Before
   public void before() throws Exception {
+    // That changes the shutdown logic globally, results may vary depending on the tests execution order. Server-related tests
+    // running before/after this test case failing in a strange ways. The case when SERVER_BACKWARD_COMPATIBILITY=true, which is
+    // the default and supposed to be used by the end-users, is "half-tested" due to this global setting.
     OGlobalConfiguration.SERVER_BACKWARD_COMPATIBILITY.setValue(false);
     server = new OServer();
     server.setServerRootDirectory(SERVER_DIRECTORY);

--- a/server/src/test/java/com/orientechnologies/orient/server/HookInstallServerTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/HookInstallServerTest.java
@@ -25,6 +25,8 @@ import com.orientechnologies.orient.server.config.OServerHookConfiguration;
 
 public class HookInstallServerTest {
 
+  // Leaky. Database name clash.
+
   public static class MyHook extends ODocumentHookAbstract {
 
     public MyHook() {

--- a/server/src/test/java/com/orientechnologies/orient/server/network/OLiveQueryRemoteTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/OLiveQueryRemoteTest.java
@@ -26,6 +26,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class OLiveQueryRemoteTest {
 
+  // Leaky.
+
   private static final String SERVER_DIRECTORY = "./target/dbfactory";
   private OServer           server;
   private OrientDB          orientDB;

--- a/server/src/test/java/com/orientechnologies/orient/server/network/ORemoteImportTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/ORemoteImportTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ORemoteImportTest {
 
+  // Leaky.
+
   private static final String SERVER_DIRECTORY = "./target/db";
   private OServer server;
 

--- a/server/src/test/java/com/orientechnologies/orient/server/network/RemoteIndexSupportTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/RemoteIndexSupportTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class RemoteIndexSupportTest {
 
+  // Leaky. Database name clash.
+
   private static final String SERVER_DIRECTORY = "./target/db";
   private OServer server;
 

--- a/server/src/test/java/com/orientechnologies/orient/server/network/RemoteSequenceTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/RemoteSequenceTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertNotEquals;
  */
 public class RemoteSequenceTest {
 
+  // Leaky.
+
   private static final String SERVER_DIRECTORY = "./target/db";
   private OServer server;
 

--- a/server/src/test/java/com/orientechnologies/orient/server/network/TestConcurrentCachedSequenceGenerationIT.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/TestConcurrentCachedSequenceGenerationIT.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.junit.Assert.assertNotNull;
 
 public class TestConcurrentCachedSequenceGenerationIT {
+  // Leaks sometimes (SERVER_BACKWARD_COMPATIBILITY, execution order?).
+
   static final int THREADS = 20;
   static final int RECORDS = 100;
   private static final String SERVER_DIRECTORY = "./target/db";

--- a/server/src/test/java/com/orientechnologies/orient/server/network/TestConcurrentSequenceGenerationIT.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/TestConcurrentSequenceGenerationIT.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import static org.junit.Assert.assertNotNull;
 public class TestConcurrentSequenceGenerationIT {
+
+  // Leaks sometimes (SERVER_BACKWARD_COMPATIBILITY, execution order?).
+
   static final int THREADS = 20;
   static final int RECORDS = 100;
   private static final String SERVER_DIRECTORY = "./target/db";

--- a/server/src/test/java/com/orientechnologies/orient/server/network/TestNetworkSerializerIndipendency.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/network/TestNetworkSerializerIndipendency.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 public class TestNetworkSerializerIndipendency {
+
+  // Leaks sometimes (SERVER_BACKWARD_COMPATIBILITY, execution order?). Database name clash.
+
   private static final String SERVER_DIRECTORY = "./target/db";
   private OServer server;
 

--- a/server/src/test/java/com/orientechnologies/orient/server/tx/RemoteTransactionHookTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/tx/RemoteTransactionHookTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class RemoteTransactionHookTest {
 
+  // Leaky.
+
   private static final String SERVER_DIRECTORY = "./target/hook-transaction";
   private OServer           server;
   private OrientDB          orientDB;

--- a/server/src/test/java/com/orientechnologies/orient/server/tx/RemoteTransactionSupportTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/tx/RemoteTransactionSupportTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.*;
  */
 public class RemoteTransactionSupportTest {
 
+  // Leaky.
+
   private static final String SERVER_DIRECTORY = "./target/transaction";
   private OServer           server;
   private OrientDB          orientDB;


### PR DESCRIPTION
To run individual test with the leak detector enabled from IDE, provide `-Dmemory.directMemory.trackMode=true -Djava.util.logging.manager=com.orientechnologies.common.log.OLogManager$DebugLogManager` options to the JVM.