### PR TITLE
Unification transaction api

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -60,9 +60,7 @@ import com.orientechnologies.orient.core.serialization.serializer.record.ORecord
 import com.orientechnologies.orient.core.sql.query.OLiveQuery;
 import com.orientechnologies.orient.core.storage.*;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.ORecordSerializationContext;
-import com.orientechnologies.orient.core.tx.OTransaction;
-import com.orientechnologies.orient.core.tx.OTransactionAbstract;
-import com.orientechnologies.orient.core.tx.OTransactionOptimistic;
+import com.orientechnologies.orient.core.tx.*;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinary;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryProtocol;
 import com.orientechnologies.orient.enterprise.channel.binary.ODistributedRedirectException;
@@ -901,11 +899,11 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
     rs.fetched(response.getResult(), response.isHasNextPage(), response.getExecutionPlan(), response.getQueryStats());
   }
 
-  public List<ORecordOperation> commit(final OTransaction iTx, final Runnable callback) {
+  public List<ORecordOperation> commit(final OTransactionInternal iTx, final Runnable callback) {
     OCommit37Request request;
     if (((OTransactionOptimistic) iTx).isChanged()) {
-      request = new OCommit37Request(iTx.getId(), true, iTx.isUsingLog(), (Iterable<ORecordOperation>) iTx.getAllRecordEntries(),
-          ((OTransactionOptimistic) iTx).getIndexEntries());
+      request = new OCommit37Request(iTx.getId(), true, iTx.isUsingLog(), (Iterable<ORecordOperation>) iTx.getRecordOperations(),
+          ((OTransactionOptimistic) iTx).getIndexOperations());
     } else {
       request = new OCommit37Request(iTx.getId(), false, iTx.isUsingLog(), null, null);
     }
@@ -933,15 +931,15 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
     updateCollectionsFromChanges(((OTransactionOptimistic) iTx).getDatabase().getSbTreeCollectionManager(),
         response.getCollectionChanges());
     // SET ALL THE RECORDS AS UNDIRTY
-    for (ORecordOperation txEntry : iTx.getAllRecordEntries())
+    for (ORecordOperation txEntry : iTx.getRecordOperations())
       ORecordInternal.unsetDirty(txEntry.getRecord());
 
     // UPDATE THE CACHE ONLY IF THE ITERATOR ALLOWS IT. 
-    OTransactionAbstract.updateCacheFromEntries(iTx, iTx.getAllRecordEntries(), true);
+    OTransactionAbstract.updateCacheFromEntries(iTx.getDatabase(), iTx.getRecordOperations(), true);
     return null;
   }
 
-  public void rollback(OTransaction iTx) {
+  public void rollback(OTransactionInternal iTx) {
     if (((OTransactionOptimistic) iTx).isAlreadyCleared()) {
       ORollbackTransactionRequest request = new ORollbackTransactionRequest(iTx.getId());
       ORollbackTransactionResponse response = networkOperation(request, "Error on fetching next page for statment: " + request);
@@ -1824,7 +1822,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
 
   public void beginTransaction(ODatabaseDocumentRemote database, OTransactionOptimistic transaction) {
     OBeginTransactionRequest request = new OBeginTransactionRequest(transaction.getId(), true, transaction.isUsingLog(),
-        transaction.getAllRecordEntries(), transaction.getIndexEntries());
+        transaction.getRecordOperations(), transaction.getIndexOperations());
     OBeginTransactionResponse response = networkOperationNoRetry(request, "Error on remote treansaction begin");
     for (Map.Entry<ORID, ORID> entry : response.getUpdatedIds().entrySet()) {
       transaction.updateIdentityAfterCommit(entry.getKey(), entry.getValue());
@@ -1833,7 +1831,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
 
   public void reBeginTransaction(ODatabaseDocumentRemote database, OTransactionOptimistic transaction) {
     ORebeginTransactionRequest request = new ORebeginTransactionRequest(transaction.getId(), transaction.isUsingLog(),
-        transaction.getAllRecordEntries(), transaction.getIndexEntries());
+        transaction.getRecordOperations(), transaction.getIndexOperations());
     OBeginTransactionResponse response = networkOperationNoRetry(request, "Error on remote treansaction begin");
     for (Map.Entry<ORID, ORID> entry : response.getUpdatedIds().entrySet()) {
       transaction.updateIdentityAfterCommit(entry.getKey(), entry.getValue());

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
@@ -56,7 +56,6 @@ import com.orientechnologies.orient.core.iterator.ORecordIteratorCluster;
 import com.orientechnologies.orient.core.metadata.OMetadata;
 import com.orientechnologies.orient.core.metadata.OMetadataDefault;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
-import com.orientechnologies.orient.core.metadata.schema.OImmutableClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OSchemaProxy;
 import com.orientechnologies.orient.core.metadata.security.*;
@@ -69,9 +68,7 @@ import com.orientechnologies.orient.core.serialization.serializer.record.ORecord
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializerFactory;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
-import com.orientechnologies.orient.core.sql.parser.OLocalResultSetLifecycleDecorator;
 import com.orientechnologies.orient.core.storage.*;
-import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.OFreezableStorageComponent;
 import com.orientechnologies.orient.core.storage.impl.local.OMicroTransaction;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OOfflineClusterException;
@@ -2496,7 +2493,7 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
     long deletedInTx = 0;
     long addedInTx = 0;
     if (getTransaction().isActive())
-      for (ORecordOperation op : getTransaction().getAllRecordEntries()) {
+      for (ORecordOperation op : getTransaction().getRecordOperations()) {
         if (op.type == ORecordOperation.DELETED) {
           final ORecord rec = op.getRecord();
           if (rec != null && rec instanceof ODocument) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareMultiValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareMultiValue.java
@@ -306,7 +306,7 @@ public class OIndexTxAwareMultiValue extends OIndexTxAware<Set<OIdentifiable>> {
     if (indexChanges == null) {
       Set<OIdentifiable> res = super.get(key);
       //In case of active transaction we use to return null instead of empty list, make check to be backward compatible
-      if (database.getTransaction().isActive() && ((OTransactionOptimistic) database.getTransaction()).getIndexEntries().size() != 0
+      if (database.getTransaction().isActive() && ((OTransactionOptimistic) database.getTransaction()).getIndexOperations().size() != 0
           && res.isEmpty())
         return null;
       return res;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/FetchTemporaryFromTxStep.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/FetchTemporaryFromTxStep.java
@@ -98,7 +98,7 @@ public class FetchTemporaryFromTxStep extends AbstractExecutionStep {
     long begin = profilingEnabled ? System.nanoTime() : 0;
     try {
       if (this.txEntries == null) {
-        Iterable<? extends ORecordOperation> iterable = ctx.getDatabase().getTransaction().getAllRecordEntries();
+        Iterable<? extends ORecordOperation> iterable = ctx.getDatabase().getTransaction().getRecordOperations();
 
         List<ORecord> records = new ArrayList<>();
         if (iterable != null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/OBasicTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/OBasicTransaction.java
@@ -136,4 +136,13 @@ public interface OBasicTransaction {
    */
   void setCustomData(String name, Object value);
 
+  /**
+   * @return this transaction ID as seen by the client of this transaction.
+   */
+  default int getClientTransactionId() {
+    return getId();
+  }
+
+  int getId();
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/OStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/OStorage.java
@@ -30,7 +30,7 @@ import com.orientechnologies.orient.core.db.record.ridbag.sbtree.OSBTreeCollecti
 import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import com.orientechnologies.orient.core.util.OBackupable;
 
 import java.io.IOException;
@@ -102,10 +102,10 @@ public interface OStorage extends OBackupable, OSharedContainer {
   boolean cleanOutRecord(ORecordId recordId, int recordVersion, int iMode, ORecordCallback<Boolean> callback);
 
   // TX OPERATIONS
-  List<ORecordOperation> commit(OTransaction iTx, Runnable callback);
+  List<ORecordOperation> commit(OTransactionInternal iTx, Runnable callback);
 
   // TX OPERATIONS
-  void rollback(OTransaction iTx);
+  void rollback(OTransactionInternal iTx);
 
   // MISC
   OStorageConfiguration getConfiguration();

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -80,10 +80,7 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODura
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.*;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OPerformanceStatisticManager;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OSessionStoragePerformanceStatistic;
-import com.orientechnologies.orient.core.tx.OTransaction;
-import com.orientechnologies.orient.core.tx.OTransactionAbstract;
-import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
-import com.orientechnologies.orient.core.tx.OTransactionOptimistic;
+import com.orientechnologies.orient.core.tx.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.*;
@@ -1472,7 +1469,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       checkLowDiskSpaceRequestsAndBackgroundDataFlushExceptionsAndBrokenPages();
 
       @SuppressWarnings("unchecked")
-      final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getAllRecordEntries();
+      final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getRecordOperations();
       final TreeMap<Integer, OCluster> clustersToLock = new TreeMap<>();
 
       final Set<ORecordOperation> newRecords = new TreeSet<>(COMMIT_RECORD_OPERATION_COMPARATOR);
@@ -1547,7 +1544,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
    * @return The list of operations applied by the transaction
    */
   @Override
-  public List<ORecordOperation> commit(final OTransaction clientTx, Runnable callback) {
+  public List<ORecordOperation> commit(final OTransactionInternal clientTx, Runnable callback) {
     return commit(clientTx, false);
   }
 
@@ -1559,7 +1556,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
    * @return The list of operations applied by the transaction
    */
   @SuppressWarnings("UnusedReturnValue")
-  public List<ORecordOperation> commitPreAllocated(final OTransaction clientTx) {
+  public List<ORecordOperation> commitPreAllocated(final OTransactionInternal clientTx) {
     return commit(clientTx, true);
   }
 
@@ -1580,7 +1577,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
    *
    * @return The list of operations applied by the transaction
    */
-  private List<ORecordOperation> commit(final OTransaction clientTx, boolean allocated) {
+  private List<ORecordOperation> commit(final OTransactionInternal clientTx, boolean allocated) {
     // XXX: At this moment, there are two implementations of the commit method. One for regular client transactions and one for
     // implicit micro-transactions. The implementations are quite identical, but operate on slightly different data. If you change
     // this method don't forget to change its counterpart:
@@ -1600,7 +1597,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       databaseRecord.getMetadata().makeThreadLocalSchemaSnapshot();
 
       @SuppressWarnings("unchecked")
-      final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getAllRecordEntries();
+      final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getRecordOperations();
       final TreeMap<Integer, OCluster> clustersToLock = new TreeMap<>();
       final Map<ORecordOperation, Integer> clusterOverrides = new IdentityHashMap<>();
 
@@ -1722,7 +1719,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
                 });
             }
 
-            OTransactionAbstract.updateCacheFromEntries(clientTx, entries, true);
+            OTransactionAbstract.updateCacheFromEntries(clientTx.getDatabase(), entries, true);
 
             txCommit.incrementAndGet();
 
@@ -1857,7 +1854,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
                 rid.setClusterPosition(physicalPosition.clusterPosition);
 
-                microTransaction.updateIdentityAfterRecordCommit(oldRID, rid);
+                microTransaction.updateIdentityAfterCommit(oldRID, rid);
               }
             }
 
@@ -1872,7 +1869,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
             endStorageTx();
 
-            microTransaction.updateRecordCacheAfterCommit();
+            OTransactionAbstract.updateCacheFromEntries(microTransaction.getDatabase(), microTransaction.getRecordOperations(), true);
 
             txCommit.incrementAndGet();
 
@@ -1931,13 +1928,8 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     }
   }
 
-  private TreeMap<String, OTransactionIndexChanges> getSortedIndexOperations(OTransaction clientTx) {
-    assert clientTx instanceof OTransactionOptimistic;
-    return new TreeMap<>(((OTransactionOptimistic) clientTx).getIndexEntries());
-  }
-
-  private TreeMap<String, OTransactionIndexChanges> getSortedIndexOperations(OMicroTransaction microTransaction) {
-    return new TreeMap<>(microTransaction.getIndexOperations());
+  private TreeMap<String, OTransactionIndexChanges> getSortedIndexOperations(OTransactionInternal clientTx) {
+    return new TreeMap<>(clientTx.getIndexOperations());
   }
 
   public int loadIndexEngine(String name) {
@@ -2899,7 +2891,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return engine.hasRangeQuerySupport();
   }
 
-  private void makeRollback(OTransaction clientTx, Exception e) {
+  private void makeRollback(OTransactionInternal clientTx, Exception e) {
     // WE NEED TO CALL ROLLBACK HERE, IN THE LOCK
     OLogManager.instance()
         .debug(this, "Error during transaction commit, transaction will be rolled back (tx-id=%d)", e, clientTx.getId());
@@ -2924,7 +2916,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
   }
 
   @Override
-  public void rollback(final OTransaction clientTx) {
+  public void rollback(final OTransactionInternal clientTx) {
     try {
       checkOpenness();
       stateLock.acquireReadLock();
@@ -2945,7 +2937,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
           makeStorageDirty();
           rollbackStorageTx();
 
-          OTransactionAbstract.updateCacheFromEntries(clientTx, clientTx.getAllRecordEntries(), false);
+          OTransactionAbstract.updateCacheFromEntries(clientTx.getDatabase(), clientTx.getRecordOperations(), false);
 
           txRollback.incrementAndGet();
 
@@ -3896,7 +3888,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return lsn;
   }
 
-  private void startStorageTx(OTransaction clientTx) throws IOException {
+  private void startStorageTx(OTransactionInternal clientTx) throws IOException {
     final OStorageTransaction storageTx = transaction.get();
     if (storageTx != null && storageTx.getClientTx().getId() != clientTx.getId())
       rollback(clientTx);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -1572,12 +1572,12 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
    * <bold>other node commit</bold> is the commit that happen when a node execute a transaction of another node where all the rids
    * are already allocated in the other node.
    *
-   * @param clientTx  the transaction to commit
+   * @param transaction  the transaction to commit
    * @param allocated true if the operation is pre-allocated commit
    *
    * @return The list of operations applied by the transaction
    */
-  private List<ORecordOperation> commit(final OTransactionInternal clientTx, boolean allocated) {
+  private List<ORecordOperation> commit(final OTransactionInternal transaction, boolean allocated) {
     // XXX: At this moment, there are two implementations of the commit method. One for regular client transactions and one for
     // implicit micro-transactions. The implementations are quite identical, but operate on slightly different data. If you change
     // this method don't forget to change its counterpart:
@@ -1590,33 +1590,32 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
       txBegun.incrementAndGet();
 
-      final ODatabaseDocumentInternal databaseRecord = (ODatabaseDocumentInternal) clientTx.getDatabase();
-      final OIndexManager indexManager = databaseRecord.getMetadata().getIndexManager();
-      final TreeMap<String, OTransactionIndexChanges> indexesToCommit = getSortedIndexOperations(clientTx);
+      final ODatabaseDocumentInternal database = transaction.getDatabase();
+      final OIndexManager indexManager = database.getMetadata().getIndexManager();
+      final TreeMap<String, OTransactionIndexChanges> indexOperations = getSortedIndexOperations(transaction);
 
-      databaseRecord.getMetadata().makeThreadLocalSchemaSnapshot();
+      database.getMetadata().makeThreadLocalSchemaSnapshot();
 
-      @SuppressWarnings("unchecked")
-      final Iterable<ORecordOperation> entries = (Iterable<ORecordOperation>) clientTx.getRecordOperations();
+      final Collection<ORecordOperation> recordOperations = transaction.getRecordOperations();
       final TreeMap<Integer, OCluster> clustersToLock = new TreeMap<>();
       final Map<ORecordOperation, Integer> clusterOverrides = new IdentityHashMap<>();
 
       final Set<ORecordOperation> newRecords = new TreeSet<>(COMMIT_RECORD_OPERATION_COMPARATOR);
 
-      for (ORecordOperation txEntry : entries) {
-        if (txEntry.type == ORecordOperation.CREATED || txEntry.type == ORecordOperation.UPDATED) {
-          final ORecord record = txEntry.getRecord();
+      for (ORecordOperation recordOperation : recordOperations) {
+        if (recordOperation.type == ORecordOperation.CREATED || recordOperation.type == ORecordOperation.UPDATED) {
+          final ORecord record = recordOperation.getRecord();
           if (record instanceof ODocument)
             ((ODocument) record).validate();
         }
 
-        if (txEntry.type == ORecordOperation.UPDATED || txEntry.type == ORecordOperation.DELETED) {
-          final int clusterId = txEntry.getRecord().getIdentity().getClusterId();
+        if (recordOperation.type == ORecordOperation.UPDATED || recordOperation.type == ORecordOperation.DELETED) {
+          final int clusterId = recordOperation.getRecord().getIdentity().getClusterId();
           clustersToLock.put(clusterId, getClusterById(clusterId));
-        } else if (txEntry.type == ORecordOperation.CREATED) {
-          newRecords.add(txEntry);
+        } else if (recordOperation.type == ORecordOperation.CREATED) {
+          newRecords.add(recordOperation);
 
-          final ORecord record = txEntry.getRecord();
+          final ORecord record = recordOperation.getRecord();
           final ORID rid = record.getIdentity();
 
           int clusterId = rid.getClusterId();
@@ -1627,7 +1626,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             final OImmutableClass class_ = ODocumentInternal.getImmutableSchemaClass(((ODocument) record));
             if (class_ != null) {
               clusterId = class_.getClusterForNewInstance((ODocument) record);
-              clusterOverrides.put(txEntry, clusterId);
+              clusterOverrides.put(recordOperation, clusterId);
             }
           }
 
@@ -1644,17 +1643,17 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             checkOpenness();
 
             makeStorageDirty();
-            startStorageTx(clientTx);
+            startStorageTx(transaction);
 
             lockClusters(clustersToLock);
 
             Map<ORecordOperation, OPhysicalPosition> positions = new IdentityHashMap<>();
-            for (ORecordOperation txEntry : newRecords) {
-              ORecord rec = txEntry.getRecord();
+            for (ORecordOperation recordOperation : newRecords) {
+              ORecord rec = recordOperation.getRecord();
 
               if (allocated) {
                 if (rec.getIdentity().isPersistent()) {
-                  positions.put(txEntry, new OPhysicalPosition(rec.getIdentity().getClusterPosition()));
+                  positions.put(recordOperation, new OPhysicalPosition(rec.getIdentity().getClusterPosition()));
                 } else {
                   throw new OStorageException("Impossible to commit a transaction with not valid rid in pre-allocated commit");
                 }
@@ -1662,47 +1661,47 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
                 ORecordId rid = (ORecordId) rec.getIdentity().copy();
                 ORecordId oldRID = rid.copy();
 
-                final Integer clusterOverride = clusterOverrides.get(txEntry);
+                final Integer clusterOverride = clusterOverrides.get(recordOperation);
                 final int clusterId = clusterOverride == null ? rid.getClusterId() : clusterOverride;
 
                 final OCluster cluster = getClusterById(clusterId);
-                OPhysicalPosition ppos = cluster.allocatePosition(ORecordInternal.getRecordType(rec));
+                OPhysicalPosition physicalPosition = cluster.allocatePosition(ORecordInternal.getRecordType(rec));
                 rid.setClusterId(cluster.getId());
 
                 if (rid.getClusterPosition() > -1) {
                   // CREATE EMPTY RECORDS UNTIL THE POSITION IS REACHED. THIS IS THE CASE WHEN A SERVER IS OUT OF SYNC
                   // BECAUSE A TRANSACTION HAS BEEN ROLLED BACK BEFORE TO SEND THE REMOTE CREATES. SO THE OWNER NODE DELETED
                   // RECORD HAVING A HIGHER CLUSTER POSITION
-                  while (rid.getClusterPosition() > ppos.clusterPosition) {
-                    ppos = cluster.allocatePosition(ORecordInternal.getRecordType(rec));
+                  while (rid.getClusterPosition() > physicalPosition.clusterPosition) {
+                    physicalPosition = cluster.allocatePosition(ORecordInternal.getRecordType(rec));
                   }
 
-                  if (rid.getClusterPosition() != ppos.clusterPosition)
-                    throw new OConcurrentCreateException(rid, new ORecordId(rid.getClusterId(), ppos.clusterPosition));
+                  if (rid.getClusterPosition() != physicalPosition.clusterPosition)
+                    throw new OConcurrentCreateException(rid, new ORecordId(rid.getClusterId(), physicalPosition.clusterPosition));
                 }
-                positions.put(txEntry, ppos);
+                positions.put(recordOperation, physicalPosition);
 
-                rid.setClusterPosition(ppos.clusterPosition);
+                rid.setClusterPosition(physicalPosition.clusterPosition);
 
-                clientTx.updateIdentityAfterCommit(oldRID, rid);
+                transaction.updateIdentityAfterCommit(oldRID, rid);
               }
             }
 
-            lockRidBags(clustersToLock, indexesToCommit, indexManager);
+            lockRidBags(clustersToLock, indexOperations, indexManager);
 
-            for (ORecordOperation txEntry : entries) {
-              commitEntry(txEntry, positions.get(txEntry), databaseRecord.getSerializer());
-              result.add(txEntry);
+            for (ORecordOperation recordOperation : recordOperations) {
+              commitEntry(recordOperation, positions.get(recordOperation), database.getSerializer());
+              result.add(recordOperation);
             }
 
-            lockIndexes(indexesToCommit);
+            lockIndexes(indexOperations);
 
-            commitIndexes(indexesToCommit);
+            commitIndexes(indexOperations);
 
             final OLogSequenceNumber lsn = endStorageTx();
             final DataOutputStream journaledStream = OAbstractPaginatedStorage.journaledStream;
             if (journaledStream != null) { // send event to journaled tx stream if the streaming is on
-              final int txId = clientTx.getClientTransactionId();
+              final int txId = transaction.getClientTransactionId();
               if (lsn == null || writeAheadLog == null) // if tx is not journaled
                 try {
                   journaledStream.writeInt(txId);
@@ -1719,17 +1718,17 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
                 });
             }
 
-            OTransactionAbstract.updateCacheFromEntries(clientTx.getDatabase(), entries, true);
+            OTransactionAbstract.updateCacheFromEntries(transaction.getDatabase(), recordOperations, true);
 
             txCommit.incrementAndGet();
 
-          } catch (IOException | RuntimeException ioe) {
-            makeRollback(clientTx, ioe);
+          } catch (IOException | RuntimeException e) {
+            makeRollback(transaction, e);
           } finally {
-            transaction.set(null);
+            this.transaction.set(null);
           }
         } finally {
-          databaseRecord.getMetadata().clearThreadLocalSchemaSnapshot();
+          database.getMetadata().clearThreadLocalSchemaSnapshot();
         }
       } finally {
         stateLock.releaseReadLock();
@@ -1738,7 +1737,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       if (OLogManager.instance().isDebugEnabled())
         OLogManager.instance()
             .debug(this, "%d Committed transaction %d on database '%s' (result=%s)", Thread.currentThread().getId(),
-                clientTx.getId(), databaseRecord.getName(), result);
+                transaction.getId(), database.getName(), result);
 
       return result;
     } catch (RuntimeException ee) {
@@ -1753,9 +1752,9 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
   /**
    * Commits the given micro-transaction.
    *
-   * @param microTransaction the micro-transaction to commit.
+   * @param transaction the micro-transaction to commit.
    */
-  public void commit(OMicroTransaction microTransaction) {
+  public void commit(OMicroTransaction transaction) {
     // XXX: At this moment, there are two implementations of the commit method. One for regular client transactions and one for
     // implicit micro-transactions. The implementations are quite identical, but operate on slightly different data. If you change
     // this method don't forget to change its counterpart:
@@ -1768,13 +1767,13 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
       txBegun.incrementAndGet();
 
-      final ODatabaseDocumentInternal database = microTransaction.getDatabase();
+      final ODatabaseDocumentInternal database = transaction.getDatabase();
       final OIndexManager indexManager = database.getMetadata().getIndexManager();
-      final TreeMap<String, OTransactionIndexChanges> indexOperations = getSortedIndexOperations(microTransaction);
+      final TreeMap<String, OTransactionIndexChanges> indexOperations = getSortedIndexOperations(transaction);
 
       database.getMetadata().makeThreadLocalSchemaSnapshot();
 
-      final Iterable<ORecordOperation> recordOperations = microTransaction.getRecordOperations();
+      final Collection<ORecordOperation> recordOperations = transaction.getRecordOperations();
       final TreeMap<Integer, OCluster> clustersToLock = new TreeMap<>();
       final Map<ORecordOperation, Integer> clusterOverrides = new IdentityHashMap<>();
 
@@ -1820,7 +1819,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
             checkOpenness();
 
             makeStorageDirty();
-            startStorageTx(microTransaction);
+            startStorageTx(transaction);
 
             lockClusters(clustersToLock);
 
@@ -1854,14 +1853,15 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
                 rid.setClusterPosition(physicalPosition.clusterPosition);
 
-                microTransaction.updateIdentityAfterCommit(oldRID, rid);
+                transaction.updateIdentityAfterCommit(oldRID, rid);
               }
             }
 
             lockRidBags(clustersToLock, indexOperations, indexManager);
 
-            for (ORecordOperation recordOperation : recordOperations)
+            for (ORecordOperation recordOperation : recordOperations) {
               commitEntry(recordOperation, positions.get(recordOperation), database.getSerializer());
+            }
 
             lockIndexes(indexOperations);
 
@@ -1869,14 +1869,14 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
             endStorageTx();
 
-            OTransactionAbstract.updateCacheFromEntries(microTransaction.getDatabase(), microTransaction.getRecordOperations(), true);
+            OTransactionAbstract.updateCacheFromEntries(transaction.getDatabase(), recordOperations, true);
 
             txCommit.incrementAndGet();
 
           } catch (IOException | RuntimeException e) {
-            makeRollback(microTransaction, e);
+            makeRollback(transaction, e);
           } finally {
-            transaction.set(null);
+            this.transaction.set(null);
           }
         } finally {
           database.getMetadata().clearThreadLocalSchemaSnapshot();

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OStorageTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OStorageTransaction.java
@@ -16,17 +16,17 @@
 package com.orientechnologies.orient.core.storage.impl.local.paginated;
 
 import com.orientechnologies.orient.core.storage.impl.local.OMicroTransaction;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
  * @since 12.06.13
  */
 public class OStorageTransaction {
-  private final OTransaction      clientTx;
-  private final OMicroTransaction microTransaction;
+  private final OTransactionInternal clientTx;
+  private final OMicroTransaction    microTransaction;
 
-  public OStorageTransaction(OTransaction clientTx) {
+  public OStorageTransaction(OTransactionInternal clientTx) {
     this.clientTx = clientTx;
     this.microTransaction = null;
   }
@@ -41,7 +41,7 @@ public class OStorageTransaction {
     this.clientTx = null;
   }
 
-  public OTransaction getClientTx() {
+  public OTransactionInternal getClientTx() {
     return clientTx;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationsManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationsManager.java
@@ -39,7 +39,7 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.ONonTx
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOperationUnitId;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWriteAheadLog;
 import com.orientechnologies.orient.core.storage.impl.local.statistic.OPerformanceStatisticManager;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 
 import javax.management.*;
 import java.io.IOException;
@@ -553,7 +553,7 @@ public class OAtomicOperationsManager implements OAtomicOperationsMangerMXBean {
     if (storageTransaction == null)
       return true;
 
-    final OTransaction clientTx = storageTransaction.getClientTx();
+    final OTransactionInternal clientTx = storageTransaction.getClientTx();
     return clientTx == null || clientTx.isUsingLog();
 
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
@@ -93,21 +93,12 @@ public interface OTransaction extends OBasicTransaction {
   ORecord loadRecordIfVersionIsNotLatest(ORID rid, int recordVersion, String fetchPlan, boolean ignoreCache)
       throws ORecordNotFoundException;
 
-  int getId();
-
-  /**
-   * @return this transaction ID as seen by the client of this transaction.
-   */
-  default int getClientTransactionId() {
-    return getId();
-  }
-
   TXSTATUS getStatus();
 
   @Deprecated
   Iterable<? extends ORecordOperation> getCurrentRecordEntries();
 
-  Iterable<? extends ORecordOperation> getAllRecordEntries();
+  Iterable<? extends ORecordOperation> getRecordOperations();
 
   List<ORecordOperation> getNewRecordEntriesByClass(OClass iClass, boolean iPolymorphic);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -24,7 +24,6 @@ import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.exception.OSchemaException;
@@ -60,9 +59,9 @@ public abstract class OTransactionAbstract implements OTransaction {
     database = iDatabase;
   }
 
-  public static void updateCacheFromEntries(final OTransaction tx, final Iterable<? extends ORecordOperation> entries,
+  public static void updateCacheFromEntries(final ODatabaseDocumentInternal database, final Iterable<? extends ORecordOperation> entries,
       final boolean updateStrategy) {
-    final OLocalRecordCache dbCache = tx.getDatabase().getLocalCache();
+    final OLocalRecordCache dbCache = database.getLocalCache();
 
     for (ORecordOperation txEntry : entries) {
       if (!updateStrategy)

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
@@ -1,30 +1,27 @@
-/*
- *
- *  *  Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *  * For more information: http://orientdb.com
- *
- */
 package com.orientechnologies.orient.core.tx;
 
-/**
- * Internal class to manage Transactions.
- */
-public class OTransactionInternal {
-  public static void setStatus(final OTransactionAbstract iTx, final OTransaction.TXSTATUS iStatus) {
-    iTx.status = iStatus;
-  }
+import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
+import com.orientechnologies.orient.core.db.record.ORecordOperation;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.storage.OBasicTransaction;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface OTransactionInternal extends OBasicTransaction {
+
+  Collection<ORecordOperation> getRecordOperations();
+
+  Map<String, OTransactionIndexChanges> getIndexOperations();
+
+  void setStatus(final OTransaction.TXSTATUS iStatus);
+
+  ODatabaseDocumentInternal getDatabase();
+
+  void updateIdentityAfterCommit(ORID oldRID, ORID rid);
+
+  boolean isUsingLog();
+
+  ORecordOperation getRecordEntry(ORID currentRid);
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
@@ -291,7 +291,7 @@ public class OTransactionNoTx extends OTransactionAbstract {
     return null;
   }
 
-  public Collection<ORecordOperation> getAllRecordEntries() {
+  public Collection<ORecordOperation> getRecordOperations() {
     return null;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -42,7 +42,7 @@ import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey.OTran
 import java.util.*;
 import java.util.Map.Entry;
 
-public abstract class OTransactionRealAbstract extends OTransactionAbstract {
+public abstract class OTransactionRealAbstract extends OTransactionAbstract implements OTransactionInternal {
   protected Map<ORID, ORID>                                   updatedRids           = new HashMap<ORID, ORID>();
   protected Map<ORID, ORecordOperation>                       allEntries            = new LinkedHashMap<ORID, ORecordOperation>();
   protected Map<String, OTransactionIndexChanges>             indexEntries          = new LinkedHashMap<String, OTransactionIndexChanges>();
@@ -81,7 +81,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract {
   public void close() {
     super.close();
 
-    for (final ORecordOperation recordOperation : getAllRecordEntries()) {
+    for (final ORecordOperation recordOperation : getRecordOperations()) {
       final ORecord record = recordOperation.getRecord();
       if (record instanceof ODocument) {
         final ODocument document = (ODocument) record;
@@ -130,7 +130,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract {
     return allEntries.values();
   }
 
-  public Collection<ORecordOperation> getAllRecordEntries() {
+  public Collection<ORecordOperation> getRecordOperations() {
     return allEntries.values();
   }
 
@@ -256,7 +256,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract {
     return result;
   }
 
-  public Map<String, OTransactionIndexChanges> getIndexEntries() {
+  public Map<String, OTransactionIndexChanges> getIndexOperations() {
     return indexEntries;
   }
 

--- a/core/src/test/java/com/orientechnologies/orient/core/PostponedEngineStartTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/PostponedEngineStartTest.java
@@ -34,7 +34,7 @@ import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.storage.*;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -323,12 +323,12 @@ public class PostponedEngineStartTest {
         }
 
         @Override
-        public List<ORecordOperation> commit(OTransaction iTx, Runnable callback) {
+        public List<ORecordOperation> commit(OTransactionInternal iTx, Runnable callback) {
           return null;
         }
 
         @Override
-        public void rollback(OTransaction iTx) {
+        public void rollback(OTransactionInternal iTx) {
 
         }
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/StorageNamingTests.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/StorageNamingTests.java
@@ -28,13 +28,12 @@ import com.orientechnologies.orient.core.db.record.ridbag.sbtree.OSBTreeCollecti
 import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.IllegalCharsetNameException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -148,12 +147,12 @@ public class StorageNamingTests {
     }
 
     @Override
-    public List<ORecordOperation> commit(OTransaction iTx, Runnable callback) {
+    public List<ORecordOperation> commit(OTransactionInternal iTx, Runnable callback) {
       return null;
     }
 
     @Override
-    public void rollback(OTransaction iTx) {
+    public void rollback(OTransactionInternal iTx) {
 
     }
 

--- a/core/src/test/java/com/orientechnologies/orient/core/tx/TransactionRidAllocationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/tx/TransactionRidAllocationTest.java
@@ -121,12 +121,12 @@ public class TransactionRidAllocationTest {
     OVertex v = db.newVertex("V");
     db.save(v);
 
-    ((OAbstractPaginatedStorage) db.getStorage()).preallocateRids(db.getTransaction());
+    ((OAbstractPaginatedStorage) db.getStorage()).preallocateRids((OTransactionOptimistic) db.getTransaction());
     OTransaction transaction = db.getTransaction();
     second.activateOnCurrentThread();
     second.begin();
     OTransactionOptimistic transactionOptimistic = (OTransactionOptimistic) second.getTransaction();
-    for (ORecordOperation operation : transaction.getAllRecordEntries()) {
+    for (ORecordOperation operation : transaction.getRecordOperations()) {
       transactionOptimistic.addRecord(operation.getRecord().copy(), operation.getType(), null);
     }
     ((OAbstractPaginatedStorage) second.getStorage()).preallocateRids(transactionOptimistic);

--- a/core/src/test/java/com/orientechnologies/orient/core/tx/TransactionRidAllocationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/tx/TransactionRidAllocationTest.java
@@ -13,7 +13,6 @@ import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.OVertex;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,7 +61,7 @@ public class TransactionRidAllocationTest {
 
     ((OAbstractPaginatedStorage) db.getStorage()).preallocateRids(db.getTransaction());
     ORID generated = v.getIdentity();
-    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated(db.getTransaction());
+    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated((OTransactionInternal) db.getTransaction());
 
     ODatabaseDocument db1 = orientDB.open("test", "admin", "admin");
     assertNotNull(db1.load(generated));
@@ -87,19 +86,19 @@ public class TransactionRidAllocationTest {
     second.activateOnCurrentThread();
     second.begin();
     OTransactionOptimistic transactionOptimistic = (OTransactionOptimistic) second.getTransaction();
-    for (ORecordOperation operation : transaction.getAllRecordEntries()) {
+    for (ORecordOperation operation : transaction.getRecordOperations()) {
       transactionOptimistic.addRecord(operation.getRecord().copy(), operation.getType(), null);
     }
     ((OAbstractPaginatedStorage) second.getStorage()).preallocateRids(transactionOptimistic);
     db.activateOnCurrentThread();
-    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated(db.getTransaction());
+    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated((OTransactionInternal) db.getTransaction());
 
     ODatabaseDocument db1 = orientDB.open("test", "admin", "admin");
     assertNotNull(db1.load(generated));
 
     db1.close();
     second.activateOnCurrentThread();
-    ((OAbstractPaginatedStorage) second.getStorage()).commitPreAllocated(second.getTransaction());
+    ((OAbstractPaginatedStorage) second.getStorage()).commitPreAllocated((OTransactionInternal) second.getTransaction());
     second.close();
     ODatabaseDocument db2 = orientDB.open("secondTest", "admin", "admin");
     assertNotNull(db2.load(generated));
@@ -152,7 +151,7 @@ public class TransactionRidAllocationTest {
     for (ORecord rec : orecords) {
       allocated.add(rec.getIdentity());
     }
-    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated(db.getTransaction());
+    ((OAbstractPaginatedStorage) db.getStorage()).commitPreAllocated((OTransactionInternal) db.getTransaction());
 
     ODatabaseDocument db1 = orientDB.open("test", "admin", "admin");
     for (ORID id : allocated) {

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedStorage.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedStorage.java
@@ -59,7 +59,7 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
 import com.orientechnologies.orient.core.storage.impl.local.OFreezableStorageComponent;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OLocalPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
-import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import com.orientechnologies.orient.enterprise.channel.binary.ODistributedRedirectException;
 import com.orientechnologies.orient.server.OServer;
 import com.orientechnologies.orient.server.distributed.*;
@@ -1389,7 +1389,7 @@ public class ODistributedStorage implements OStorage, OFreezableStorageComponent
   }
 
   @Override
-  public List<ORecordOperation> commit(final OTransaction iTx, final Runnable callback) {
+  public List<ORecordOperation> commit(final OTransactionInternal iTx, final Runnable callback) {
     resetLastValidBackup();
 
     if (isLocalEnv()) {
@@ -1534,7 +1534,7 @@ public class ODistributedStorage implements OStorage, OFreezableStorageComponent
   }
 
   @Override
-  public void rollback(final OTransaction iTx) {
+  public void rollback(final OTransactionInternal iTx) {
     wrapped.rollback(iTx);
   }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedTransactionManager.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedTransactionManager.java
@@ -30,7 +30,6 @@ import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.OExecutionThreadLocal;
 import com.orientechnologies.orient.core.db.OScenarioThreadLocal;
-import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.record.OPlaceholder;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.exception.*;
@@ -43,9 +42,9 @@ import com.orientechnologies.orient.core.replication.OAsyncReplicationOk;
 import com.orientechnologies.orient.core.storage.ORawBuffer;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OLocalPaginatedStorage;
+import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import com.orientechnologies.orient.core.tx.OTransaction;
 import com.orientechnologies.orient.core.tx.OTransactionAbstract;
-import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import com.orientechnologies.orient.server.distributed.*;
 import com.orientechnologies.orient.server.distributed.ODistributedRequest.EXECUTION_MODE;
 import com.orientechnologies.orient.server.distributed.impl.task.*;
@@ -76,12 +75,12 @@ public class ODistributedTransactionManager {
     this.localDistributedDatabase = iDDatabase;
   }
 
-  public List<ORecordOperation> commit(final ODatabaseDocumentInternal database, final OTransaction iTx, final Runnable callback,
+  public List<ORecordOperation> commit(final ODatabaseDocumentInternal database, final OTransactionInternal iTx, final Runnable callback,
       final ODistributedStorageEventListener eventListener) {
     final String localNodeName = dManager.getLocalNodeName();
 
     try {
-      OTransactionInternal.setStatus((OTransactionAbstract) iTx, OTransaction.TXSTATUS.BEGUN);
+      iTx.setStatus(OTransaction.TXSTATUS.BEGUN);
 
       final ODistributedConfiguration dbCfg = dManager.getDatabaseConfiguration(storage.getName());
 
@@ -136,7 +135,7 @@ public class ODistributedTransactionManager {
         database.setDefaultTransactionMode();
 
         // After commit force the clean of dirty managers due to possible copy and miss clean.
-        for (ORecordOperation ent : iTx.getAllRecordEntries())
+        for (ORecordOperation ent : iTx.getRecordOperations())
           ORecordInternal.getDirtyManager(ent.getRecord()).clear();
 
         if (nodes.isEmpty()) {
@@ -154,7 +153,7 @@ public class ODistributedTransactionManager {
         try {
           txTask.setLastLSN(((OAbstractPaginatedStorage) storage.getUnderlying()).getLSN());
 
-          OTransactionInternal.setStatus((OTransactionAbstract) iTx, OTransaction.TXSTATUS.COMMITTING);
+          iTx.setStatus(OTransaction.TXSTATUS.COMMITTING);
 
           if (executionModeSynch) {
             // SYNCHRONOUS CALL: REPLICATE IT
@@ -263,7 +262,7 @@ public class ODistributedTransactionManager {
 
     } catch (Exception e) {
 
-      for (ORecordOperation op : iTx.getAllRecordEntries()) {
+      for (ORecordOperation op : iTx.getRecordOperations()) {
         if (op.type == ORecordOperation.CREATED) {
           final ORecordId lockEntireCluster = (ORecordId) op.getRID().copy();
           localDistributedDatabase.getDatabaseRepairer().enqueueRepairCluster(lockEntireCluster.getClusterId());
@@ -277,8 +276,8 @@ public class ODistributedTransactionManager {
     return null;
   }
 
-  protected void checkForClusterIds(final OTransaction iTx, final String localNodeName, final ODistributedConfiguration dbCfg) {
-    for (ORecordOperation op : iTx.getAllRecordEntries()) {
+  protected void checkForClusterIds(final OTransactionInternal iTx, final String localNodeName, final ODistributedConfiguration dbCfg) {
+    for (ORecordOperation op : iTx.getRecordOperations()) {
       final ORecordId rid = (ORecordId) op.getRecord().getIdentity();
       switch (op.type) {
       case ORecordOperation.CREATED:
@@ -517,10 +516,10 @@ public class ODistributedTransactionManager {
    *
    * @throws InterruptedException
    */
-  protected void acquireMultipleRecordLocks(final OTransaction iTx, final ODistributedStorageEventListener eventListener,
+  protected void acquireMultipleRecordLocks(final OTransactionInternal iTx, final ODistributedStorageEventListener eventListener,
       final ODistributedTxContext reqContext) throws InterruptedException {
     final List<ORecordId> recordsToLock = new ArrayList<ORecordId>();
-    for (ORecordOperation op : iTx.getAllRecordEntries()) {
+    for (ORecordOperation op : iTx.getRecordOperations()) {
       recordsToLock.add((ORecordId) op.record.getIdentity());
     }
 
@@ -600,10 +599,10 @@ public class ODistributedTransactionManager {
    *
    * @return List of remote undo tasks
    */
-  protected List<OAbstractRemoteTask> createUndoTasksFromTx(final OTransaction iTx, final ODistributedDatabase database,
+  protected List<OAbstractRemoteTask> createUndoTasksFromTx(final OTransactionInternal iTx, final ODistributedDatabase database,
       final ODistributedRequestId requestId) {
     final List<OAbstractRemoteTask> undoTasks = new ArrayList<OAbstractRemoteTask>();
-    for (final ORecordOperation op : iTx.getAllRecordEntries()) {
+    for (final ORecordOperation op : iTx.getRecordOperations()) {
       OAbstractRemoteTask undoTask = null;
 
       final ORecord record = op.getRecord();
@@ -672,7 +671,7 @@ public class ODistributedTransactionManager {
 
   }
 
-  protected void processCommitResult(final String localNodeName, final OTransaction iTx, final OTxTask txTask,
+  protected void processCommitResult(final String localNodeName, final OTransactionInternal iTx, final OTxTask txTask,
       final Set<String> involvedClusters, final Iterable<ORecordOperation> tmpEntries, final Collection<String> nodes,
       final ODistributedRequestId reqId, final ODistributedResponse dResponse) throws InterruptedException {
     final Object result = dResponse.getPayload();

--- a/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
+++ b/object/src/main/java/com/orientechnologies/orient/object/db/OObjectDatabaseTx.java
@@ -49,14 +49,12 @@ import com.orientechnologies.orient.core.hook.ORecordHook;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.OMetadataInternal;
-import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.metadata.security.*;
 import com.orientechnologies.orient.core.query.OQuery;
 import com.orientechnologies.orient.core.record.*;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.record.OSerializationThreadLocal;
-import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.storage.ORecordCallback;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.tx.OTransaction;
@@ -632,10 +630,10 @@ public class OObjectDatabaseTx extends ODatabaseWrapperAbstract<ODatabaseDocumen
     if (getTransaction().isActive())
       return this;
 
-    if (getTransaction().getAllRecordEntries() != null) {
+    if (getTransaction().getRecordOperations() != null) {
       // UPDATE ID & VERSION FOR ALL THE RECORDS
       Object pojo = null;
-      for (ORecordOperation entry : getTransaction().getAllRecordEntries()) {
+      for (ORecordOperation entry : getTransaction().getRecordOperations()) {
         switch (entry.type) {
         case ORecordOperation.CREATED:
         case ORecordOperation.UPDATED:
@@ -666,9 +664,9 @@ public class OObjectDatabaseTx extends ODatabaseWrapperAbstract<ODatabaseDocumen
     if (!underlying.getTransaction().isActive()) {
       // COPY ALL TX ENTRIES
       final List<ORecordOperation> newEntries;
-      if (getTransaction().getAllRecordEntries() != null) {
+      if (getTransaction().getRecordOperations() != null) {
         newEntries = new ArrayList<ORecordOperation>();
-        for (ORecordOperation entry : getTransaction().getAllRecordEntries())
+        for (ORecordOperation entry : getTransaction().getRecordOperations())
           if (entry.type == ORecordOperation.CREATED)
             newEntries.add(entry);
       } else

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -53,7 +53,6 @@ import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
 import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializerFactory;
 import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkV37;
-import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultInternal;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.sql.parser.OLocalResultSetLifecycleDecorator;
@@ -1278,7 +1277,7 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
     if (!database.getTransaction().isActive())
       throw new ODatabaseException("No Transaction Active");
     OTransactionOptimistic tx = (OTransactionOptimistic) database.getTransaction();
-    return new OFetchTransactionResponse(tx.getId(), tx.getAllRecordEntries(), tx.getIndexEntries(), tx.getUpdatedRids());
+    return new OFetchTransactionResponse(tx.getId(), tx.getRecordOperations(), tx.getIndexOperations(), tx.getUpdatedRids());
   }
 
   @Override


### PR DESCRIPTION
Introduced new OTransactionInternal interface to be used by the commit operations with all methods need by it, made both OptimisticTransaction and MicroTransaction inplement the interface, the commit methods are still two different implementation but can easily be merged due to the same behaviour, the merge will come in a not too far future.