### PR TITLE
Remove usages of org.mockito.internal

### DIFF
--- a/client/src/test/java/com/orientechnologies/orient/client/remote/ORemoteConnectionPushListenerTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/ORemoteConnectionPushListenerTest.java
@@ -5,7 +5,8 @@ import com.orientechnologies.orient.enterprise.channel.binary.OChannelListener;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.internal.verification.VerificationModeFactory;
+
+import static org.mockito.Mockito.only;
 
 /**
  * Created by tglman on 22/10/15.
@@ -22,7 +23,7 @@ public class ORemoteConnectionPushListenerTest {
     poolListener.addListener(pool, chann, listener);
     poolListener.onRequest((byte) 10, null);
 
-    Mockito.verify(listener, VerificationModeFactory.only()).onRequest(Mockito.anyByte(), Mockito.anyObject());
+    Mockito.verify(listener, only()).onRequest(Mockito.anyByte(), Mockito.anyObject());
   }
 
   @Test
@@ -35,7 +36,7 @@ public class ORemoteConnectionPushListenerTest {
     poolListener.addListener(pool, chann, listener);
     poolListener.onRequest((byte) 10, null);
 
-    Mockito.verify(listener, VerificationModeFactory.only()).onRequest(Mockito.anyByte(), Mockito.anyObject());
+    Mockito.verify(listener, only()).onRequest(Mockito.anyByte(), Mockito.anyObject());
 
   }
 
@@ -52,7 +53,7 @@ public class ORemoteConnectionPushListenerTest {
     poolListener.addListener(pool, chann, listener);
     captor.getValue().onChannelClose(chann);
 
-    Mockito.verify(listener, VerificationModeFactory.only()).onEndUsedConnections(pool);
+    Mockito.verify(listener, only()).onEndUsedConnections(pool);
 
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/server/OLiveCommandResultListenerTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/OLiveCommandResultListenerTest.java
@@ -3,14 +3,11 @@ package com.orientechnologies.orient.server;
 import com.orientechnologies.orient.core.command.OCommandResultListener;
 import com.orientechnologies.orient.core.config.OContextConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
-import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.query.live.OLiveQueryHook;
 import com.orientechnologies.orient.core.query.live.OLiveQueryListener;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerBinary;
 import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetwork;
 import com.orientechnologies.orient.enterprise.channel.binary.OChannelBinaryServer;
 import com.orientechnologies.orient.server.network.protocol.binary.OLiveCommandResultListener;
@@ -22,12 +19,12 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
 
 /**
  * Created by tglman on 07/06/16.
@@ -88,7 +85,7 @@ public class OLiveCommandResultListenerTest {
     OLiveCommandResultListener listener = new OLiveCommandResultListener(server, connection, new TestResultListener());
     ORecordOperation op = new ORecordOperation(new ODocument(), ORecordOperation.CREATED);
     listener.onLiveResult(10, op);
-    Mockito.verify(channelBinary, VerificationModeFactory.atLeastOnce()).writeBytes(Mockito.any(byte[].class));
+    Mockito.verify(channelBinary, atLeastOnce()).writeBytes(Mockito.any(byte[].class));
   }
 
   @Test

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpImportTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpImportTest.java
@@ -2,9 +2,13 @@ package com.orientechnologies.orient.test.server.network.http;
 
 import org.apache.http.HttpResponse;
 import org.junit.Test;
-import org.mockito.internal.util.io.IOUtil;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -21,8 +25,20 @@ public class HttpImportTest extends BaseHttpDatabaseTest {
     HttpResponse response = getResponse();
     assertEquals(200, response.getStatusLine().getStatusCode());
 
-    System.out.println(IOUtil.readLines(response.getEntity().getContent()));
+    InputStream is = response.getEntity().getContent();
+    List<String> out = new LinkedList<>();
+    BufferedReader r = new BufferedReader(new InputStreamReader(is));
 
+    try {
+      String line;
+      while((line = r.readLine()) != null) {
+          out.add(line);
+      }
+
+      System.out.println(out);
+    } catch (IOException var5) {
+      throw new IllegalArgumentException("Problems reading from: " + is, var5);
+    }
   }
 
   @Override


### PR DESCRIPTION
Hey! I saw you were depending on several `org.mockito.internal` classes. As we (the Mockito core developers) do not guarantee backwards compatibility on these classes, I converted them for you to the equivalent public API. Probably your IDE was suggesting the wrong import upon autocompletion.