### PR TITLE
fixing exception thrown from OSoftQueryResultList

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLResultsetAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLResultsetAbstract.java
@@ -715,8 +715,12 @@ public abstract class OCommandExecutorSQLResultsetAbstract extends OCommandExecu
       final String nodeName = entry.getKey();
       final Object nodeResult = entry.getValue();
 
-      if (nodeResult instanceof Collection)
-        mergedResult.addAll((Collection<?>) nodeResult);
+      if (nodeResult instanceof Collection) {
+        // OSoftQueryResultList does not allow .toArray
+        for (Object o : (Collection<?>) nodeResult) {
+          mergedResult.add(o);
+        }
+      }
       else if (nodeResult instanceof Exception)
         // RECEIVED EXCEPTION
         throw (Exception) nodeResult;


### PR DESCRIPTION
In OSoftQueryResultList, the .toArray method is intentionally not implemented (https://github.com/orientechnologies/orientdb/blob/2.2.x/core/src/main/java/com/orientechnologies/orient/core/sql/OSoftQueryResultList.java#L176). However in OCommandExecutorSQLResultsetAbstract:718, java.util.ArrayList.addAll attempts to call .toArray, which results in an exception being thrown. This problem has made the current 2.2.x snapshot unusable for us because some basic select queries refuse to execute. 