### PR TITLE
Bugfix in OCommandExecutorSQLCreateClass.java: handle ` escapings properly

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateClass.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/OCommandExecutorSQLCreateClass.java
@@ -122,6 +122,8 @@ public class OCommandExecutorSQLCreateClass extends OCommandExecutorSQLAbstract 
                 hasNext = true;
               else if (Character.isLetterOrDigit(ch))
                 break;
+              else if (ch == '`')
+                  break;
             }
           } while (hasNext);
           if (newParser) {


### PR DESCRIPTION
This is the Bugfix for Issue #7950 - Creation of abstract class extending multiple parent classes works only for one node properly

Please also backport to 2.2.x