### PR TITLE
OSchemaEmbedded.doCreateClass() - deliver real created cluster ID's

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OSchemaEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OSchemaEmbedded.java
@@ -96,12 +96,19 @@ public class OSchemaEmbedded extends OSchemaShared {
 
         if (clusters == 0)
           cmd.append(" abstract");
-        else {
-          cmd.append(" clusters ");
-          cmd.append(clusters);
-        }
         final int[] clusterIds = createClusters(database, className, clusters);
         createClassInternal(database, className, clusterIds, superClassesList);
+
+        if (clusters > 0) {
+          cmd.append(" cluster ");
+          for (int i = 0; i < clusterIds.length; ++i) {
+            if (i > 0)
+              cmd.append(',');
+            else
+              cmd.append(' ');
+            cmd.append(clusterIds[i]);
+          }
+        }
 
         final OAutoshardedStorage autoshardedStorage = (OAutoshardedStorage) storage;
         OCommandSQL commandSQL = new OCommandSQL(cmd.toString());


### PR DESCRIPTION
Hi,

this is an improvement for a 'follow-up' issue caused by #7950  _Creation of abstract class extending multiple parent classes works only for one node properly_.

Due to the cluster node assignment inconsistencies caused by this issue we initially had the problem that cluster id's assigned for a class are inconsistent between the nodes.

This pull request improved the behaviour of `OSchemaEmbedded.doCreateClass()` that a statement `create class MyTestClass cluster 31,32,33,34` naming the real created clusters is created instead of the original statement `create class MyTestClass clusters 5` allowing all other member nodes picking 'any' nodes.
By specifying fixed cluster id's in the create class statement this will force all other cluster nodes to use the exact same cluster id's for this class or fail if the id's are already occupied (like it was by #7950)

Please also backport to 2.2.x. It sits in OSchemaShared.java here.

Thanks & Bye,
     Chris