### PR TITLE
feat(orientdb-core): make outV(), inV() to support class filter

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/OEdge.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/OEdge.java
@@ -19,12 +19,6 @@
  */
 package com.orientechnologies.orient.core.record;
 
-import com.orientechnologies.orient.core.metadata.schema.OClass;
-
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
 /**
  * @author Luigi Dell'Aquila
  */
@@ -34,43 +28,43 @@ public interface OEdge extends OElement {
 
   public OVertex getFrom();
 
+  /**
+   * returns vertices with specific types
+   * @author Thomas Young (YJJThomasYoung@hotmail.com)
+   * @param labels names of vertex classes
+   * @return
+   */
+  OVertex getFrom(String... labels);
+
   public OVertex getTo();
+
+  /**
+   * returns vertices with specific types
+   * @author Thomas Young (YJJThomasYoung@hotmail.com)
+   * @param labels names of vertex classes
+   * @return
+   */
+  OVertex getTo(String... labels);
 
   public boolean isLightweight();
 
   default OVertex getVertex(ODirection dir) {
-    if (dir == ODirection.IN) {
-      return getTo();
-    } else if (dir == ODirection.OUT) {
-      return getFrom();
-    }
-    return null;
+    return getVertex(dir, (String) null);
   }
 
-  default boolean isLabeled(String[] labels) {
-    if (labels == null) {
-      return true;
+  /**
+   * get vertex with specific types
+   * @author Thomas Young (YJJThomasYoung@hotmail.com)
+   * @param dir direction
+   * @param labels names of vertex classes
+   * @return
+   */
+  default OVertex getVertex(ODirection dir, String... labels) {
+    if (dir == ODirection.IN) {
+      return getTo(labels);
+    } else if (dir == ODirection.OUT) {
+      return getFrom(labels);
     }
-    if (labels.length == 0) {
-      return true;
-    }
-    Set<String> types = new HashSet<>();
-
-    Optional<OClass> typeClass = getSchemaType();
-    if (typeClass.isPresent()) {
-      types.add(typeClass.get().getName());
-      typeClass.get().getAllSuperClasses().stream().map(x -> x.getName()).forEach(name -> types.add(name));
-    } else {
-      types.add("E");
-    }
-    for (String s : labels) {
-      for (String type : types) {
-        if (type.equalsIgnoreCase(s)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
+    return null;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/OElement.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/OElement.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.record;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -94,4 +95,31 @@ public interface OElement extends ORecord{
    * @return the type of current element. An empty optional is returned if current element does not have a schema
    */
   public Optional<OClass> getSchemaType();
+
+  default boolean isLabeled(String[] labels) {
+    if (labels == null) {
+      return true;
+    }
+    if (labels.length == 0) {
+      return true;
+    }
+    Set<String> types = new HashSet<>();
+
+    Optional<OClass> typeClass = getSchemaType();
+    if (typeClass.isPresent()) {
+      types.add(typeClass.get().getName());
+      typeClass.get().getAllSuperClasses().stream().map(OClass::getName).forEach(types::add);
+    } else {
+      types.add("E");
+    }
+    for (String s : labels) {
+      for (String type : types) {
+        if (type.equalsIgnoreCase(s)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeDelegate.java
@@ -61,6 +61,11 @@ public class OEdgeDelegate implements OEdge {
 
   @Override
   public OVertex getFrom() {
+    return getFrom((String) null);
+  }
+
+  @Override
+  public OVertex getFrom(String... labels) {
     if (vOut != null)
       // LIGHTWEIGHT EDGE
       return vOut;
@@ -77,11 +82,20 @@ public class OEdgeDelegate implements OEdge {
     if (!v.isVertex()) {
       return null;//TODO optional...?
     }
-    return v.asVertex().get();
+
+    Optional<OVertex> vOptional = v.asVertex();
+    if(vOptional.isPresent() && vOptional.get().isLabeled(labels))
+      return vOptional.get();
+    return null;
   }
 
   @Override
   public OVertex getTo() {
+    return getTo((String) null);
+  }
+
+  @Override
+  public OVertex getTo(String... labels) {
     if (vIn != null)
       // LIGHTWEIGHT EDGE
       return vIn;
@@ -98,7 +112,11 @@ public class OEdgeDelegate implements OEdge {
     if (!v.isVertex()) {
       return null;//TODO optional...?
     }
-    return v.asVertex().get();
+
+    Optional<OVertex> vOptional = v.asVertex();
+    if(vOptional.isPresent() && vOptional.get().isLabeled(labels))
+      return vOptional.get();
+    return null;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionMove.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionMove.java
@@ -84,11 +84,11 @@ public abstract class OSQLFunctionMove extends OSQLFunctionConfigurableAbstract 
     if (rec.isEdge()) {
       if (iDirection == ODirection.BOTH) {
         List results = new ArrayList();
-        results.add(rec.asEdge().get().getVertex(ODirection.OUT));
-        results.add(rec.asEdge().get().getVertex(ODirection.IN));
+        results.add(rec.asEdge().get().getVertex(ODirection.OUT, iLabels));
+        results.add(rec.asEdge().get().getVertex(ODirection.IN, iLabels));
         return results;
       }
-      return rec.asEdge().get().getVertex(iDirection);
+      return rec.asEdge().get().getVertex(iDirection, iLabels);
     } else {
       return null;
     }


### PR DESCRIPTION
I notice that outE(), inE() suport class filter, but outV(), inV() don't. 
However, there are some business scenarios in which we need vertex filter when traverse.

For example, two vertex classes: Person and Company, one edge class: invest. 
Person can invest company, company can invest company, and now I don't want get Person vertices. 
I know we can get there using other tricks, but I think it's not bad to make them support vertex class filter.