### PR TITLE
Bump Jackson to 2.9.4

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.0</version>
+            <version>2.9.4</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Jackson needs to be upgraded because a current version which is used in orientdb-tools has serious vulnerabilities.

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15095 - fixed in 2.8.10, 2.9.1
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17485 - fixed in 2.8.10, 2.9.3
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525 - fixed in 2.6.7.1, 2.7.9.1 and 2.8.9

See also: https://github.com/akka/alpakka/issues/793