### PR TITLE
Optimization browse cluster

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OClusterRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OClusterRemote.java
@@ -25,6 +25,7 @@ import com.orientechnologies.orient.core.config.OStorageClusterConfiguration;
 import com.orientechnologies.orient.core.conflict.ORecordConflictStrategy;
 import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
 import com.orientechnologies.orient.core.storage.*;
+import com.orientechnologies.orient.core.storage.impl.local.OClusterBrowsePage;
 
 /**
  * Remote cluster implementation
@@ -37,7 +38,7 @@ public class OClusterRemote implements OCluster {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.orientechnologies.orient.core.storage.OCluster#configure(com.orientechnologies.orient.core.storage.OStorage, int,
    * java.lang.String, java.lang.String, int, java.lang.Object[])
    */
@@ -48,7 +49,7 @@ public class OClusterRemote implements OCluster {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.orientechnologies.orient.core.storage.OCluster#configure(com.orientechnologies.orient.core.storage.OStorage,
    * com.orientechnologies.orient.core.config.OStorageClusterConfiguration)
    */
@@ -59,7 +60,7 @@ public class OClusterRemote implements OCluster {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.orientechnologies.orient.core.storage.OCluster#create(int)
    */
   public void create(int iStartSize) throws IOException {
@@ -68,7 +69,7 @@ public class OClusterRemote implements OCluster {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see com.orientechnologies.orient.core.storage.OCluster#open()
    */
   public void open() throws IOException {
@@ -253,4 +254,10 @@ public class OClusterRemote implements OCluster {
   public void acquireAtomicExclusiveLock() {
     throw new UnsupportedOperationException("remote cluster doesn't support atomic locking");
   }
+
+  @Override
+  public OClusterBrowsePage nextPage(long lastPosition) {
+    throw new UnsupportedOperationException();
+  }
 }
+

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/OCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/OCluster.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.storage;
 import com.orientechnologies.orient.core.config.OStorageClusterConfiguration;
 import com.orientechnologies.orient.core.conflict.ORecordConflictStrategy;
 import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
+import com.orientechnologies.orient.core.storage.impl.local.OClusterBrowsePage;
 
 import java.io.IOException;
 
@@ -165,4 +166,6 @@ public interface OCluster {
    * Acquires exclusive lock in the active atomic operation running on the current thread for this cluster.
    */
   void acquireAtomicExclusiveLock();
+
+  OClusterBrowsePage nextPage(long lastPosition) throws IOException;
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -1397,18 +1397,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         checkOpenness();
 
         final OCluster cluster = doGetAndCheckCluster(clusterId);
-        OPhysicalPosition[] nextPositions = cluster.higherPositions(new OPhysicalPosition(lastPosition));
-        if (nextPositions.length > 0) {
-          long newLastPosition = nextPositions[nextPositions.length - 1].clusterPosition;
-          List<OClusterBrowseEntry> nexv = new ArrayList<>();
-          for (OPhysicalPosition pos : nextPositions) {
-            final ORawBuffer buff = cluster.readRecord(pos.clusterPosition, false);
-            nexv.add(new OClusterBrowseEntry(pos.clusterPosition, buff));
-          }
-          return new OClusterBrowsePage(nexv, newLastPosition);
-        } else {
-          return null;
-        }
+        return cluster.nextPage(lastPosition);
       } finally {
         stateLock.releaseReadLock();
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OOfflineCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OOfflineCluster.java
@@ -24,6 +24,7 @@ import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.storage.*;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
+import com.orientechnologies.orient.core.storage.impl.local.OClusterBrowsePage;
 
 import java.io.IOException;
 
@@ -275,5 +276,10 @@ public class OOfflineCluster implements OCluster {
   @Override
   public void acquireAtomicExclusiveLock() {
     // do nothing, anyway there is no real data behind to lock it
+  }
+
+  @Override
+  public OClusterBrowsePage nextPage(long lastPosition) {
+    return null;
   }
 }


### PR DESCRIPTION
Hi,

I just did an optimization to move the logic from the storage level to the cluster level, this remove the load of the CPM for each read record, so it should reduce a lot the hit on the cache of the CPM.

Regards