### PR TITLE
Optimize ridbags serialization

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
@@ -471,7 +471,7 @@ public class ORidBag implements OStringBuilderSerializable, Iterable<OIdentifiab
     }
   }
 
-  protected ORidBagDelegate getDelegate() {
+  public ORidBagDelegate getDelegate() {
     return delegate;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
@@ -243,8 +243,7 @@ public class ORidBag implements OStringBuilderSerializable, Iterable<OIdentifiab
     delegate.serialize(stream, offset, oldUuid);
     return pointer;
   }
-
-  //vazno
+  
   public void checkAndConvert() {
     ODatabaseInternal database = ODatabaseRecordThreadLocal.instance().getIfDefined();
     if (database != null && !database.getStorage().isRemote()) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
@@ -244,6 +244,7 @@ public class ORidBag implements OStringBuilderSerializable, Iterable<OIdentifiab
     return pointer;
   }
 
+  //vazno
   public void checkAndConvert() {
     ODatabaseInternal database = ODatabaseRecordThreadLocal.instance().getIfDefined();
     if (database != null && !database.getStorage().isRemote()) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
@@ -83,4 +83,6 @@ public interface ORidBagDelegate extends Iterable<OIdentifiable>, ORecordLazyMul
   public List<OMultiValueChangeListener<OIdentifiable, OIdentifiable>> getChangeListeners();
 
   NavigableMap<OIdentifiable,Change> getChanges();
+  
+  void setSize(int size);
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
@@ -84,7 +84,5 @@ public interface ORidBagDelegate extends Iterable<OIdentifiable>, ORecordLazyMul
 
   NavigableMap<OIdentifiable,Change> getChanges();
   
-  void setSize(int size);
-  
-  int getSize();
+  void setSize(int size);    
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBagDelegate.java
@@ -85,4 +85,6 @@ public interface ORidBagDelegate extends Iterable<OIdentifiable>, ORecordLazyMul
   NavigableMap<OIdentifiable,Change> getChanges();
   
   void setSize(int size);
+  
+  int getSize();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -58,11 +58,6 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     this.size = size;
   }
 
-  @Override
-  public int getSize() {
-    return size;
-  }
-
   private static enum Tombstone {
     TOMBSTONE
   }
@@ -228,10 +223,6 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
       add(value);
   }
 
-  public void add(final OIdentifiable identifiable, boolean fireChangeEvent){
-    
-  }
-  
   @Override
   public void add(final OIdentifiable identifiable) {
     if (identifiable == null)

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -53,6 +53,11 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
 
   private List<OMultiValueChangeListener<OIdentifiable, OIdentifiable>> changeListeners;
 
+  @Override
+  public void setSize(int size) {
+    this.size = size;
+  }
+
   private static enum Tombstone {
     TOMBSTONE
   }
@@ -84,8 +89,8 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     @Override
     public OIdentifiable next() {
       currentRemoved = false;
-
-      currentIndex = nextIndex;
+ 
+     currentIndex = nextIndex;
       if (currentIndex == -1)
         throw new NoSuchElementException();
 
@@ -214,6 +219,10 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
       add(value);
   }
 
+  public void add(final OIdentifiable identifiable, boolean fireChangeEvent){
+    
+  }
+  
   @Override
   public void add(final OIdentifiable identifiable) {
     if (identifiable == null)
@@ -355,12 +364,14 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
       return "[size=" + size + "]";
   }
 
+  @Override
   public void addChangeListener(final OMultiValueChangeListener<OIdentifiable, OIdentifiable> changeListener) {
     if (changeListeners == null)
       changeListeners = new LinkedList<OMultiValueChangeListener<OIdentifiable, OIdentifiable>>();
     changeListeners.add(changeListener);
   }
 
+  @Override
   public void removeRecordChangeListener(final OMultiValueChangeListener<OIdentifiable, OIdentifiable> changeListener) {
     if (changeListeners != null)
       changeListeners.remove(changeListener);
@@ -479,6 +490,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     return Collections.unmodifiableList(changeListeners);
   }
 
+  @Override
   public void fireCollectionChangedEvent(final OMultiValueChangeEvent<OIdentifiable, OIdentifiable> event) {
     if (changeListeners != null) {
       for (final OMultiValueChangeListener<OIdentifiable, OIdentifiable> changeListener : changeListeners) {
@@ -488,7 +500,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     }
   }
 
-  private void addEntry(final OIdentifiable identifiable) {
+  public void addEntry(final OIdentifiable identifiable) {
     if (entries.length == entriesLength) {
       if (entriesLength == 0) {
         final int cfgValue = OGlobalConfiguration.RID_BAG_EMBEDDED_TO_SBTREEBONSAI_THRESHOLD.getValueAsInteger();

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -58,8 +58,17 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     this.size = size;
   }
 
+  @Override
+  public int getSize() {
+    return size;
+  }
+
   private static enum Tombstone {
     TOMBSTONE
+  }
+  
+  public Object[] getEntries(){
+    return entries;
   }
 
   private final class EntriesIterator implements Iterator<OIdentifiable>, OResettable, OSizeable {

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -1136,6 +1136,7 @@ public class ODocument extends ORecordAbstract
    *
    * @return field value if defined, otherwise null
    */
+  @Override
   public <RET> RET field(final String iFieldName) {
     RET value = this.rawField(iFieldName);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
@@ -33,7 +33,7 @@ public class ORecordSerializerBinary implements ORecordSerializer {
 
   public static final  String                  NAME                   = "ORecordSerializerBinary";
   public static final  ORecordSerializerBinary INSTANCE               = new ORecordSerializerBinary();
-  private static final byte                    CURRENT_RECORD_VERSION = 0;
+  private static final byte                    CURRENT_RECORD_VERSION = 1;
 
   private ODocumentSerializer[] serializerByVersion;
   private final byte currentSerializerVersion;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinary.java
@@ -33,7 +33,7 @@ public class ORecordSerializerBinary implements ORecordSerializer {
 
   public static final  String                  NAME                   = "ORecordSerializerBinary";
   public static final  ORecordSerializerBinary INSTANCE               = new ORecordSerializerBinary();
-  private static final byte                    CURRENT_RECORD_VERSION = 1;
+  private static final byte                    CURRENT_RECORD_VERSION = 0;
 
   private ODocumentSerializer[] serializerByVersion;
   private final byte currentSerializerVersion;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV0.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV0.java
@@ -410,7 +410,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return deserializeValue(bytes, type, ownerDocument, true, -1, -1, false);
   }
   
-  private Object deserializeEmbeddedAsDocument(final BytesContainer bytes, final ODocument ownerDocument){
+  protected Object deserializeEmbeddedAsDocument(final BytesContainer bytes, final ODocument ownerDocument){
     Object value = new ODocument();
     deserializeWithClassName((ODocument) value, bytes);
     if (((ODocument) value).containsField(ODocumentSerializable.CLASS_NAME)) {
@@ -615,7 +615,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return new OResultBinary(bytes.bytes, startOffset, valueLength, serializerVersion);
   }  
     
-  private Object deserializeValue(final BytesContainer bytes, final OType type, final ODocument ownerDocument, boolean embeddedAsDocument, 
+  protected Object deserializeValue(final BytesContainer bytes, final OType type, final ODocument ownerDocument, boolean embeddedAsDocument, 
           int valueLengthInBytes, int serializerVersion, boolean justRunThrough) {
     Object value = null;
     switch (type) {
@@ -776,7 +776,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return ODocumentInternal.getGlobalPropertyById(document, id);    
   }  
 
-  private Map<Object, OIdentifiable> readLinkMap(final BytesContainer bytes, final ODocument document) {
+  protected Map<Object, OIdentifiable> readLinkMap(final BytesContainer bytes, final ODocument document) {
     int size = OVarIntSerializer.readAsInteger(bytes);
     final ORecordLazyMap result = new ORecordLazyMap(document);
 
@@ -799,7 +799,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     }
   }
 
-  private Object readEmbeddedMap(final BytesContainer bytes, final ODocument document) {
+  protected Object readEmbeddedMap(final BytesContainer bytes, final ODocument document) {
     int size = OVarIntSerializer.readAsInteger(bytes);
     final OTrackedMap<Object> result = new OTrackedMap<>(document);
 
@@ -832,7 +832,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     }
   }
 
-  private Collection<OIdentifiable> readLinkCollection(final BytesContainer bytes, final Collection<OIdentifiable> found) {
+  protected Collection<OIdentifiable> readLinkCollection(final BytesContainer bytes, final Collection<OIdentifiable> found) {
     final int items = OVarIntSerializer.readAsInteger(bytes);
     for (int i = 0; i < items; i++) {
       ORecordId id = readOptimizedLink(bytes);
@@ -844,7 +844,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return found;
   }  
 
-  private Collection<?> readEmbeddedSet(final BytesContainer bytes, final ODocument ownerDocument) {
+  protected Collection<?> readEmbeddedSet(final BytesContainer bytes, final ODocument ownerDocument) {
 
     final int items = OVarIntSerializer.readAsInteger(bytes);
     OType type = readOType(bytes);
@@ -872,7 +872,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return null;
   }
 
-  private Collection<?> readEmbeddedList(final BytesContainer bytes, final ODocument ownerDocument) {
+  protected Collection<?> readEmbeddedList(final BytesContainer bytes, final ODocument ownerDocument) {
 
     final int items = OVarIntSerializer.readAsInteger(bytes);
     OType type = readOType(bytes);
@@ -1018,14 +1018,14 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return pointer;
   }
 
-  private int writeBinary(final BytesContainer bytes, final byte[] valueBytes) {
+  protected int writeBinary(final BytesContainer bytes, final byte[] valueBytes) {
     final int pointer = OVarIntSerializer.write(bytes, valueBytes.length);
     final int start = bytes.alloc(valueBytes.length);
     System.arraycopy(valueBytes, 0, bytes.bytes, start, valueBytes.length);
     return pointer;
   }
 
-  private int writeLinkMap(final BytesContainer bytes, final Map<Object, OIdentifiable> map) {
+  protected int writeLinkMap(final BytesContainer bytes, final Map<Object, OIdentifiable> map) {
     final boolean disabledAutoConversion = map instanceof ORecordLazyMultiValue
         && ((ORecordLazyMultiValue) map).isAutoConvertToRecord();
 
@@ -1055,7 +1055,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
   }
 
   @SuppressWarnings("unchecked")
-  private int writeEmbeddedMap(BytesContainer bytes, Map<Object, Object> map) {
+  protected int writeEmbeddedMap(BytesContainer bytes, Map<Object, Object> map) {
     final int[] pos = new int[map.size()];
     int i = 0;
     Entry<Object, Object> values[] = new Entry[map.size()];
@@ -1088,14 +1088,14 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return fullPos;
   }
 
-  private int writeNullLink(final BytesContainer bytes) {
+  protected static int writeNullLink(final BytesContainer bytes) {
     final int pos = OVarIntSerializer.write(bytes, NULL_RECORD_ID.getIdentity().getClusterId());
     OVarIntSerializer.write(bytes, NULL_RECORD_ID.getIdentity().getClusterPosition());
     return pos;
 
   }
 
-  private int writeOptimizedLink(final BytesContainer bytes, OIdentifiable link) {
+  protected static int writeOptimizedLink(final BytesContainer bytes, OIdentifiable link) {
     if (!link.getIdentity().isPersistent()) {
       try {
         final ORecord real = link.getRecord();
@@ -1113,7 +1113,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return pos;
   }
 
-  private int writeLinkCollection(final BytesContainer bytes, final Collection<OIdentifiable> value) {
+  protected int writeLinkCollection(final BytesContainer bytes, final Collection<OIdentifiable> value) {
     final int pos = OVarIntSerializer.write(bytes, value.size());
 
     final boolean disabledAutoConversion = value instanceof ORecordLazyMultiValue
@@ -1140,7 +1140,7 @@ public class ORecordSerializerBinaryV0 implements ODocumentSerializer {
     return pos;
   }
 
-  private int writeEmbeddedCollection(final BytesContainer bytes, final Collection<?> value, final OType linkedType) {
+  protected int writeEmbeddedCollection(final BytesContainer bytes, final Collection<?> value, final OType linkedType) {
     final int pos = OVarIntSerializer.write(bytes, value.size());
     // TODO manage embedded type from schema and auto-determined.
     writeOType(bytes, bytes.alloc(1), OType.ANY);

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
@@ -887,10 +887,10 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
     int posForWrite = bytes.alloc(OByteSerializer.BYTE_SIZE);
     OByteSerializer.INSTANCE.serialize(configByte, bytes.bytes, posForWrite);    
     
-    if (uuid != null){
-      posForWrite = bytes.alloc(OUUIDSerializer.UUID_SIZE);
-      OUUIDSerializer.INSTANCE.serialize(uuid, bytes.bytes, posForWrite);
-    }        
+//    if (uuid != null){
+//      posForWrite = bytes.alloc(OUUIDSerializer.UUID_SIZE);
+//      OUUIDSerializer.INSTANCE.serialize(uuid, bytes.bytes, posForWrite);
+//    }        
     
     if (ridbag.isEmbedded()) {
       writeEmbeddedRidbag(bytes, ridbag);
@@ -906,10 +906,10 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
     boolean hasUUID = (configByte & 2) != 0;
     
     UUID uuid = null;
-    if (hasUUID){
-      uuid = OUUIDSerializer.INSTANCE.deserialize(bytes.bytes, bytes.offset);
-      bytes.skip(OUUIDSerializer.UUID_SIZE);
-    }
+//    if (hasUUID){
+//      uuid = OUUIDSerializer.INSTANCE.deserialize(bytes.bytes, bytes.offset);
+//      bytes.skip(OUUIDSerializer.UUID_SIZE);
+//    }
     
     ORidBag ridbag = null;
     if (isEmbedded){

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
@@ -1,13 +1,10 @@
 package com.orientechnologies.orient.core.serialization.serializer.record.binary;
 
 import com.orientechnologies.common.collection.OMultiValue;
-import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.serialization.types.OByteSerializer;
 import com.orientechnologies.common.serialization.types.ODecimalSerializer;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
-import com.orientechnologies.common.serialization.types.OUUIDSerializer;
-import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
@@ -37,10 +34,8 @@ import static com.orientechnologies.orient.core.serialization.serializer.record.
 import com.orientechnologies.orient.core.storage.OStorageProxy;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.ORecordSerializationContext;
 import com.orientechnologies.orient.core.storage.index.sbtreebonsai.local.OBonsaiBucketPointer;
-import com.orientechnologies.orient.core.storage.ridbag.sbtree.AbsoluteChange;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.Change;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.ChangeSerializationHelper;
-import com.orientechnologies.orient.core.storage.ridbag.sbtree.DiffChange;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.OBonsaiCollectionPointer;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.OSBTreeCollectionManager;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.OSBTreeRidBag;
@@ -848,21 +843,8 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
     }
     else{
       OVarIntSerializer.write(bytes, 0);
-      
-//      Map<? extends OIdentifiable, Change> changes = ridbag.getChanges();
-//      OVarIntSerializer.write(bytes, changes.size());
-//      for (Map.Entry<? extends OIdentifiable, Change> entry : changes.entrySet()) {
-//        OIdentifiable key = entry.getKey();
-//
-//        if (key.getIdentity().isTemporary())
-//          //noinspection unchecked
-//          key = key.getRecord();
-//
-//        writeLinkOptimized(bytes, key);
-//
-//        bytes.offset = bytes.alloc(OByteSerializer.BYTE_SIZE + OIntegerSerializer.INT_SIZE);
-//        bytes.offset += entry.getValue().serialize(bytes.bytes, bytes.offset);
-//      }
+
+      //removed changes serialization
     }
   }
   
@@ -879,7 +861,7 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
       uuid = sbTreeCollectionManager.listenForChanges(ridbag);
     
     byte configByte = 0;
-    if (ridbag.isEmbedded())// || OGlobalConfiguration.RID_BAG_SBTREEBONSAI_TO_EMBEDDED_THRESHOLD.getValueAsInteger() >= ridbag.size())
+    if (ridbag.isEmbedded())
       configByte |= 1;
 
     if (uuid != null)
@@ -889,10 +871,7 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
     int posForWrite = bytes.alloc(OByteSerializer.BYTE_SIZE);
     OByteSerializer.INSTANCE.serialize(configByte, bytes.bytes, posForWrite);    
     
-//    if (uuid != null){
-//      posForWrite = bytes.alloc(OUUIDSerializer.UUID_SIZE);
-//      OUUIDSerializer.INSTANCE.serialize(uuid, bytes.bytes, posForWrite);
-//    }        
+    //removed serializing UUID
     
     if (ridbag.isEmbedded()) {
       writeEmbeddedRidbag(bytes, ridbag);
@@ -905,13 +884,10 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
   private static ORidBag readRidbag(BytesContainer bytes){
     byte configByte = OByteSerializer.INSTANCE.deserialize(bytes.bytes, bytes.offset++);    
     boolean isEmbedded = (configByte & 1) != 0;
-    boolean hasUUID = (configByte & 2) != 0;
+//    boolean hasUUID = (configByte & 2) != 0;
     
     UUID uuid = null;
-//    if (hasUUID){
-//      uuid = OUUIDSerializer.INSTANCE.deserialize(bytes.bytes, bytes.offset);
-//      bytes.skip(OUUIDSerializer.UUID_SIZE);
-//    }
+    //removed deserializing UUID
     
     ORidBag ridbag = null;
     if (isEmbedded){
@@ -930,7 +906,8 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
       long fileId = OVarIntSerializer.readAsLong(bytes);
       long pageIndex = OVarIntSerializer.readAsLong(bytes);
       int pageOffset = OVarIntSerializer.readAsInteger(bytes);
-      int bagSize = OVarIntSerializer.readAsInteger(bytes);            
+      //read bag size
+      OVarIntSerializer.readAsInteger(bytes);            
       
       OBonsaiCollectionPointer pointer = null;
       if (fileId != -1)

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerBinaryV1.java
@@ -843,24 +843,26 @@ public class ORecordSerializerBinaryV1 extends ORecordSerializerBinaryV0{
     OVarIntSerializer.write(bytes, ridbag.size());
 
     if (context != null){
-      ((OSBTreeRidBag)ridbag.getDelegate()).serializeChangesWithContext(context, pointer);
+      ((OSBTreeRidBag)ridbag.getDelegate()).handleContextSBTree(context, pointer);
       OVarIntSerializer.write(bytes, 0);
     }
     else{
-      Map<? extends OIdentifiable, Change> changes = ridbag.getChanges();
-      OVarIntSerializer.write(bytes, changes.size());
-      for (Map.Entry<? extends OIdentifiable, Change> entry : changes.entrySet()) {
-        OIdentifiable key = entry.getKey();
-
-        if (key.getIdentity().isTemporary())
-          //noinspection unchecked
-          key = key.getRecord();
-
-        writeLinkOptimized(bytes, key);
-
-        bytes.offset = bytes.alloc(OByteSerializer.BYTE_SIZE + OIntegerSerializer.INT_SIZE);
-        bytes.offset += entry.getValue().serialize(bytes.bytes, bytes.offset);
-      }
+      OVarIntSerializer.write(bytes, 0);
+      
+//      Map<? extends OIdentifiable, Change> changes = ridbag.getChanges();
+//      OVarIntSerializer.write(bytes, changes.size());
+//      for (Map.Entry<? extends OIdentifiable, Change> entry : changes.entrySet()) {
+//        OIdentifiable key = entry.getKey();
+//
+//        if (key.getIdentity().isTemporary())
+//          //noinspection unchecked
+//          key = key.getRecord();
+//
+//        writeLinkOptimized(bytes, key);
+//
+//        bytes.offset = bytes.alloc(OByteSerializer.BYTE_SIZE + OIntegerSerializer.INT_SIZE);
+//        bytes.offset += entry.getValue().serialize(bytes.bytes, bytes.offset);
+//      }
     }
   }
   

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -71,12 +71,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   public void setSize(int size) {
     this.size = size;
   }
-
-  @Override
-  public int getSize() {
-    return size;
-  }
-
+  
   private final class RIDBagIterator implements Iterator<OIdentifiable>, OResettable, OSizeable, OAutoConvertToRecord {
     private final NavigableMap<OIdentifiable, Change>                    changedValues;
     private final SBTreeMapEntryIterator                                 sbTreeIterator;
@@ -972,6 +967,5 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   public void replace(OMultiValueChangeEvent<Object, Object> event, Object newValue) {
     //do nothing not needed
   }
-  
-  
+    
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -72,6 +72,11 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     this.size = size;
   }
 
+  @Override
+  public int getSize() {
+    return size;
+  }
+
   private final class RIDBagIterator implements Iterator<OIdentifiable>, OResettable, OSizeable, OAutoConvertToRecord {
     private final NavigableMap<OIdentifiable, Change>                    changedValues;
     private final SBTreeMapEntryIterator                                 sbTreeIterator;
@@ -637,6 +642,29 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     return getSerializedSize();
   }
 
+  public void rearrangeChanges(){
+    ODatabaseDocumentInternal db = ODatabaseRecordThreadLocal.instance().getIfDefined();
+    for (Entry<OIdentifiable, Change> change : this.changes.entrySet()) {
+      OIdentifiable key = change.getKey();
+      if (db != null && db.getTransaction().isActive()) {
+        if (!key.getIdentity().isPersistent()) {
+          OIdentifiable newKey = db.getTransaction().getRecord(key.getIdentity());
+          if (newKey != null) {
+            changes.remove(key);
+            changes.put(newKey, change.getValue());
+          }
+        }
+      }
+    }
+  }
+  
+  public void serializeChangesWithContext(ORecordSerializationContext context,
+          OBonsaiCollectionPointer pointer){
+    rearrangeChanges();
+    this.collectionPointer = pointer;
+    context.push(new ORidBagUpdateSerializationOperation(changes, collectionPointer));       
+  }
+  
   @Override
   public int serialize(byte[] stream, int offset, UUID ownerUuid) {
     applyNewEntries();
@@ -682,25 +710,9 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     if (context == null) {
       ChangeSerializationHelper.INSTANCE.serializeChanges(changes, OLinkSerializer.INSTANCE, stream, offset);
     } else {
-
-      ODatabaseDocumentInternal db = ODatabaseRecordThreadLocal.instance().getIfDefined();
-      for (Entry<OIdentifiable, Change> change : this.changes.entrySet()) {
-        OIdentifiable key = change.getKey();
-        if (db != null && db.getTransaction().isActive()) {
-          if (!key.getIdentity().isPersistent()) {
-            OIdentifiable newKey = db.getTransaction().getRecord(key.getIdentity());
-            if (newKey != null) {
-              changes.remove(key);
-              changes.put(newKey, change.getValue());
-            }
-          }
-        }
-      }
-      this.collectionPointer = collectionPointer;
-      context.push(new ORidBagUpdateSerializationOperation(changes, collectionPointer));
-
+      serializeChangesWithContext(context, collectionPointer);
       // 0-length serialized list of changes
-      OIntegerSerializer.INSTANCE.serializeLiteral(0, stream, offset);
+      OIntegerSerializer.INSTANCE.serializeLiteral(0, stream, offset); 
       offset += OIntegerSerializer.INT_SIZE;
     }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -67,6 +67,11 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   private           List<OMultiValueChangeListener<OIdentifiable, OIdentifiable>> changeListeners;
   private transient ORecord                                                       owner;
 
+  @Override
+  public void setSize(int size) {
+    this.size = size;
+  }
+
   private final class RIDBagIterator implements Iterator<OIdentifiable>, OResettable, OSizeable, OAutoConvertToRecord {
     private final NavigableMap<OIdentifiable, Change>                    changedValues;
     private final SBTreeMapEntryIterator                                 sbTreeIterator;
@@ -702,7 +707,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     return offset;
   }
 
-  private void applyNewEntries() {
+  public void applyNewEntries() {
     for (Entry<OIdentifiable, OModifiableInteger> entry : newEntries.entrySet()) {
       OIdentifiable identifiable = entry.getKey();
       assert identifiable instanceof ORecord;
@@ -955,4 +960,6 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   public void replace(OMultiValueChangeEvent<Object, Object> event, Object newValue) {
     //do nothing not needed
   }
+  
+  
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -658,7 +658,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     }
   }
   
-  public void serializeChangesWithContext(ORecordSerializationContext context,
+  public void handleContextSBTree(ORecordSerializationContext context,
           OBonsaiCollectionPointer pointer){
     rearrangeChanges();
     this.collectionPointer = pointer;
@@ -710,7 +710,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     if (context == null) {
       ChangeSerializationHelper.INSTANCE.serializeChanges(changes, OLinkSerializer.INSTANCE, stream, offset);
     } else {
-      serializeChangesWithContext(context, collectionPointer);
+      handleContextSBTree(context, collectionPointer);
       // 0-length serialized list of changes
       OIntegerSerializer.INSTANCE.serializeLiteral(0, stream, offset); 
       offset += OIntegerSerializer.INT_SIZE;


### PR DESCRIPTION
Optimized rid-bags serialization using varints instead of fixed length fields.
Avoided serialization of UUIDs.
Avoided serialization of changes in SB Tree rid-bags.
This optimization is part of binary serializer optimizations (V1 serializer).
Old serializer is still present and it is still default serializer.