### PR TITLE
Refactor noTx loop breaking logic for embedded databases

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -509,121 +509,7 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
     id = result.getProperty("value");
     return id;
   }
-
-  public <RET extends ORecord> RET executeSaveRecord(ORecord record, String clusterName, int ver, OPERATION_MODE mode,
-      boolean forceCreate, ORecordCallback<? extends Number> recordCreatedCallback,
-      ORecordCallback<Integer> recordUpdatedCallback) {
-
-    checkOpenness();
-    checkIfActive();
-    if (!record.isDirty())
-      return (RET) record;
-
-    final ORecordId rid = (ORecordId) record.getIdentity();
-
-    if (rid == null)
-      throw new ODatabaseException(
-          "Cannot create record because it has no identity. Probably is not a regular record or contains projections of fields rather than a full record");
-
-    record.setInternalStatus(ORecordElement.STATUS.MARSHALLING);
-    try {
-
-      byte[] stream = null;
-      final OStorageOperationResult<Integer> operationResult;
-
-      getMetadata().makeThreadLocalSchemaSnapshot();
-      if (record instanceof ODocument)
-        ODocumentInternal.checkClass((ODocument) record, this);
-      ORecordSerializationContext.pushContext();
-      final boolean isNew = forceCreate || rid.isNew();
-      try {
-
-        ORecord overwritten;
-        if (isNew) {
-          // NOTIFY IDENTITY HAS CHANGED
-          ORecordInternal.onBeforeIdentityChanged(record);
-          int id = assignAndCheckCluster(record, clusterName);
-          clusterName = getClusterNameById(id);
-          overwritten = (ORecord) beforeCreateOperations(record, clusterName);
-        } else {
-          overwritten = (ORecord) beforeUpdateOperations(record, clusterName);
-        }
-        if (overwritten != null) {
-          record = overwritten;
-        }
-        stream = getSerializer().toStream(record, false);
-
-        ORecordSaveThreadLocal.setLast(record);
-        try {
-          // SAVE IT
-          boolean updateContent = ORecordInternal.isContentChanged(record);
-          byte[] content = (stream == null) ? OCommonConst.EMPTY_BYTE_ARRAY : stream;
-          byte recordType = ORecordInternal.getRecordType(record);
-          final int modeIndex = mode.ordinal();
-
-          // CHECK IF RECORD TYPE IS SUPPORTED
-          Orient.instance().getRecordFactoryManager().getRecordTypeClass(recordType);
-
-          if (forceCreate || ORecordId.isNew(rid.getClusterPosition())) {
-            // CREATE
-            final OStorageOperationResult<OPhysicalPosition> ppos = getStorage()
-                .createRecord(rid, content, ver, recordType, modeIndex, (ORecordCallback<Long>) recordCreatedCallback);
-            operationResult = new OStorageOperationResult<Integer>(ppos.getResult().recordVersion, ppos.isMoved());
-
-          } else {
-            // UPDATE
-            operationResult = getStorage()
-                .updateRecord(rid, updateContent, content, ver, recordType, modeIndex, recordUpdatedCallback);
-          }
-
-          final int version = operationResult.getResult();
-
-          if (isNew) {
-            // UPDATE INFORMATION: CLUSTER ID+POSITION
-            ((ORecordId) record.getIdentity()).copyFrom(rid);
-            // NOTIFY IDENTITY HAS CHANGED
-            ORecordInternal.onAfterIdentityChanged(record);
-            // UPDATE INFORMATION: CLUSTER ID+POSITION
-          }
-
-          if (operationResult.getModifiedRecordContent() != null)
-            stream = operationResult.getModifiedRecordContent();
-          else if (version > record.getVersion() + 1 && getStorage() instanceof OStorageProxy)
-            // IN CASE OF REMOTE CONFLICT STRATEGY FORCE UNLOAD DUE TO INVALID CONTENT
-            record.unload();
-
-          ORecordInternal.fill(record, rid, version, stream, false);
-
-          callbackHookSuccess(record, isNew, stream, operationResult);
-        } catch (Exception t) {
-          callbackHookFailure(record, isNew, stream);
-          throw t;
-        }
-      } finally {
-        callbackHookFinalize(record, isNew, stream);
-        ORecordSerializationContext.pullContext();
-        getMetadata().clearThreadLocalSchemaSnapshot();
-        ORecordSaveThreadLocal.removeLast();
-      }
-
-      if (stream != null && stream.length > 0 && !operationResult.isMoved())
-        // ADD/UPDATE IT IN CACHE IF IT'S ACTIVE
-        getLocalCache().updateRecord(record);
-    } catch (OException e) {
-      throw e;
-    } catch (Exception t) {
-      if (!ORecordId.isValid(record.getIdentity().getClusterPosition()))
-        throw OException
-            .wrapException(new ODatabaseException("Error on saving record in cluster #" + record.getIdentity().getClusterId()), t);
-      else
-        throw OException.wrapException(new ODatabaseException("Error on saving record " + record.getIdentity()), t);
-
-    } finally {
-      record.setInternalStatus(ORecordElement.STATUS.LOADED);
-    }
-    return (RET) record;
-  }
-
+  
   @Override
   public void executeDeleteRecord(OIdentifiable record, int iVersion, boolean iRequired, OPERATION_MODE iMode,
       boolean prohibitTombstones) {
@@ -796,27 +682,6 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
     return callbackHooks(ORecordHook.TYPE.BEFORE_READ, identifiable) == ORecordHook.RESULT.SKIP;
   }
 
-  public <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName) {
-    ORecordId rid = (ORecordId) record.getIdentity();
-    assert rid.isNew();
-
-    ORecordInternal.onBeforeIdentityChanged(record);
-    int id = assignAndCheckCluster(record, clusterName);
-    clusterName = getClusterNameById(id);
-    checkSecurity(ORule.ResourceGeneric.CLUSTER, ORole.PERMISSION_CREATE, clusterName);
-
-    byte[] content = getSerializer().writeClassOnly(record);
-
-    final OStorageOperationResult<OPhysicalPosition> ppos = getStorage()
-        .createRecord(rid, content, record.getVersion(), recordType, OPERATION_MODE.SYNCHRONOUS.ordinal(), null);
-
-    ORecordInternal.setVersion(record, ppos.getResult().recordVersion);
-    ((ORecordId) record.getIdentity()).copyFrom(rid);
-    ORecordInternal.onAfterIdentityChanged(record);
-
-    return (RET) record;
-  }
-
   @Override
   public void afterReadOperations(OIdentifiable identifiable) {
     callbackHooks(ORecordHook.TYPE.AFTER_READ, identifiable);
@@ -825,84 +690,16 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
   @Override
   public ORecord saveAll(ORecord iRecord, String iClusterName, OPERATION_MODE iMode, boolean iForceCreate,
       ORecordCallback<? extends Number> iRecordCreatedCallback, ORecordCallback<Integer> iRecordUpdatedCallback) {
-    ORecord toRet = null;
-    ODirtyManager dirtyManager = ORecordInternal.getDirtyManager(iRecord);
-    Set<ORecord> newRecord = dirtyManager.getNewRecords();
-    Set<ORecord> updatedRecord = dirtyManager.getUpdateRecords();
-    dirtyManager.clearForSave();
-    if (newRecord != null) {
-      for (ORecord rec : newRecord) {
-        if (rec.getIdentity().isNew() && rec instanceof ODocument) {
-          ORecord ret = saveNew((ODocument) rec, dirtyManager, iClusterName, iRecord, iMode, iForceCreate, iRecordCreatedCallback,
-              iRecordUpdatedCallback);
-          if (ret != null)
-            toRet = ret;
-        }
+    OTransactionOptimisticClient tx = new OTransactionOptimisticClient(this) {
+      @Override
+      protected void checkTransaction() {
       }
-    }
-    if (updatedRecord != null) {
-      for (ORecord rec : updatedRecord) {
-        if (rec == iRecord) {
-          toRet = executeSaveRecord(rec, iClusterName, rec.getVersion(), iMode, iForceCreate, iRecordCreatedCallback,
-              iRecordUpdatedCallback);
-        } else
-          executeSaveRecord(rec, getClusterName(rec), rec.getVersion(), OPERATION_MODE.SYNCHRONOUS, false, null, null);
-      }
-    }
+    };
+    tx.begin();
+    tx.saveRecord(iRecord, iClusterName, iMode, iForceCreate, iRecordCreatedCallback, iRecordUpdatedCallback);
+    tx.commit();
 
-    if (toRet != null)
-      return toRet;
-    else
-      return executeSaveRecord(iRecord, iClusterName, iRecord.getVersion(), iMode, iForceCreate, iRecordCreatedCallback,
-          iRecordUpdatedCallback);
-  }
-
-  public ORecord saveNew(ODocument document, ODirtyManager manager, String iClusterName, ORecord original,
-      final OPERATION_MODE iMode, boolean iForceCreate, final ORecordCallback<? extends Number> iRecordCreatedCallback,
-      ORecordCallback<Integer> iRecordUpdatedCallback) {
-    ORecord toRet = null;
-    LinkedList<ODocument> path = new LinkedList<ODocument>();
-    ORecord next = document;
-    do {
-      if (next instanceof ODocument) {
-        ORecord nextToInspect = null;
-        List<OIdentifiable> toSave = manager.getPointed(next);
-        if (toSave != null) {
-          for (OIdentifiable oIdentifiable : toSave) {
-            if (oIdentifiable.getIdentity().isNew()) {
-              if (oIdentifiable instanceof ORecord)
-                nextToInspect = (ORecord) oIdentifiable;
-              else
-                nextToInspect = oIdentifiable.getRecord();
-              break;
-            }
-          }
-        }
-        if (nextToInspect != null) {
-          if (path.contains(nextToInspect)) {
-            if (nextToInspect == original)
-              executeSaveEmptyRecord(nextToInspect, iClusterName);
-            else
-              executeSaveEmptyRecord(nextToInspect, getClusterName(nextToInspect));
-          } else {
-            path.push((ODocument) next);
-            next = nextToInspect;
-          }
-        } else {
-          if (next == original)
-            toRet = executeSaveRecord(next, iClusterName, next.getVersion(), iMode, iForceCreate, iRecordCreatedCallback,
-                iRecordUpdatedCallback);
-          else
-            executeSaveRecord(next, getClusterName(next), next.getVersion(), OPERATION_MODE.SYNCHRONOUS, false, null, null);
-          next = path.pollFirst();
-        }
-
-      } else {
-        executeSaveRecord(next, null, next.getVersion(), iMode, false, null, null);
-        next = path.pollFirst();
-      }
-    } while (next != null);
-    return toRet;
+    return iRecord;
   }
 
   public String getClusterName(final ORecord record) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
@@ -115,14 +115,8 @@ public interface ODatabaseDocumentInternal extends ODatabaseSession, ODatabaseIn
       final boolean ignoreCache, final boolean iUpdateCache, final boolean loadTombstones,
       final OStorage.LOCKING_STRATEGY lockingStrategy, RecordReader recordReader);
 
-  <RET extends ORecord> RET executeSaveRecord(final ORecord record, String clusterName, final int ver, final OPERATION_MODE mode,
-      boolean forceCreate, final ORecordCallback<? extends Number> recordCreatedCallback,
-      ORecordCallback<Integer> recordUpdatedCallback);
-
   void executeDeleteRecord(OIdentifiable record, final int iVersion, final boolean iRequired, final OPERATION_MODE iMode,
       boolean prohibitTombstones);
-
-  <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName);
 
   void setDefaultTransactionMode();
 
@@ -239,5 +233,10 @@ public interface ODatabaseDocumentInternal extends ODatabaseSession, ODatabaseIn
   boolean isClusterVertex(int cluster);
 
   boolean isClusterEdge(int cluster);
+
+  ORecord saveAll(ORecord iRecord, String iClusterName, OPERATION_MODE iMode, boolean iForceCreate,
+      ORecordCallback<? extends Number> iRecordCreatedCallback, ORecordCallback<Integer> iRecordUpdatedCallback);
+
+  String getClusterName(final ORecord record);
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
@@ -1425,15 +1425,6 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
     return rid.getClusterId();
   }
 
-  public abstract <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName);
-
-  public abstract <RET extends ORecord> RET executeSaveRecord(final ORecord record, String clusterName, final int ver,
-      final OPERATION_MODE mode, boolean forceCreate, final ORecordCallback<? extends Number> recordCreatedCallback,
-      ORecordCallback<Integer> recordUpdatedCallback);
-
-  public abstract void executeDeleteRecord(OIdentifiable record, final int iVersion, final boolean iRequired,
-      final OPERATION_MODE iMode, boolean prohibitTombstones);
-
   /**
    * This method is internal, it can be subject to signature change or be removed, do not use.
    *
@@ -2729,4 +2720,5 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
       return true;
     return false;
   }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
@@ -1425,26 +1425,7 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
     return rid.getClusterId();
   }
 
-  public <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName) {
-    ORecordId rid = (ORecordId) record.getIdentity();
-    assert rid.isNew();
-
-    ORecordInternal.onBeforeIdentityChanged(record);
-    int id = assignAndCheckCluster(record, clusterName);
-    clusterName = getClusterNameById(id);
-    checkSecurity(ORule.ResourceGeneric.CLUSTER, ORole.PERMISSION_CREATE, clusterName);
-
-    byte[] content = getSerializer().writeClassOnly(record);
-
-    final OStorageOperationResult<OPhysicalPosition> ppos = getStorage()
-        .createRecord(rid, content, record.getVersion(), recordType, OPERATION_MODE.SYNCHRONOUS.ordinal(), null);
-
-    ORecordInternal.setVersion(record, ppos.getResult().recordVersion);
-    ((ORecordId) record.getIdentity()).copyFrom(rid);
-    ORecordInternal.onAfterIdentityChanged(record);
-
-    return (RET) record;
-  }
+  public abstract <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName);
 
   public abstract <RET extends ORecord> RET executeSaveRecord(final ORecord record, String clusterName, final int ver,
       final OPERATION_MODE mode, boolean forceCreate, final ORecordCallback<? extends Number> recordCreatedCallback,

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -255,24 +255,10 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   }
 
   @Override
-  public <RET extends ORecord> RET executeSaveRecord(ORecord record, String clusterName, int ver, OPERATION_MODE mode,
-      boolean forceCreate, ORecordCallback<? extends Number> recordCreatedCallback,
-      ORecordCallback<Integer> recordUpdatedCallback) {
-    checkOpenness();
-    return internal.executeSaveRecord(record, clusterName, ver, mode, forceCreate, recordCreatedCallback, recordUpdatedCallback);
-  }
-
-  @Override
   public void executeDeleteRecord(OIdentifiable record, int iVersion, boolean iRequired, OPERATION_MODE iMode,
       boolean prohibitTombstones) {
     checkOpenness();
     internal.executeDeleteRecord(record, iVersion, iRequired, iMode, prohibitTombstones);
-  }
-
-  @Override
-  public <RET extends ORecord> RET executeSaveEmptyRecord(ORecord record, String clusterName) {
-    checkOpenness();
-    return internal.executeSaveEmptyRecord(record, clusterName);
   }
 
   @Override
@@ -1534,4 +1520,14 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
     return internal.beforeReadOperations(identifiable);
   }
 
+  @Override
+  public ORecord saveAll(ORecord iRecord, String iClusterName, OPERATION_MODE iMode, boolean iForceCreate,
+      ORecordCallback<? extends Number> iRecordCreatedCallback, ORecordCallback<Integer> iRecordUpdatedCallback) {
+    return internal.saveAll(iRecord, iClusterName, iMode, iForceCreate, iRecordCreatedCallback, iRecordUpdatedCallback);
+  }
+
+  @Override
+  public String getClusterName(ORecord record) {
+    return internal.getClusterName(record);
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -224,32 +224,6 @@ public abstract class OTransactionAbstract implements OTransaction {
     return lockedRecords;
   }
 
-  public String getClusterName(final ORecord record) {
-    if (ODatabaseRecordThreadLocal.instance().get().getStorage().isRemote())
-      // DON'T ASSIGN CLUSTER WITH REMOTE: SERVER KNOWS THE RIGHT CLUSTER BASED ON LOCALITY
-      return null;
-
-    int clusterId = record.getIdentity().getClusterId();
-    if (clusterId == ORID.CLUSTER_ID_INVALID) {
-      // COMPUTE THE CLUSTER ID
-      OClass schemaClass = null;
-      if (record instanceof ODocument)
-        schemaClass = ODocumentInternal.getImmutableSchemaClass(getDatabase(), (ODocument) record);
-      if (schemaClass != null) {
-        // FIND THE RIGHT CLUSTER AS CONFIGURED IN CLASS
-        if (schemaClass.isAbstract())
-          throw new OSchemaException("Document belongs to abstract class '" + schemaClass.getName() + "' and cannot be saved");
-        clusterId = schemaClass.getClusterForNewInstance((ODocument) record);
-        return database.getClusterNameById(clusterId);
-      } else {
-        return database.getClusterNameById(database.getStorage().getDefaultClusterId());
-      }
-
-    } else {
-      return database.getClusterNameById(clusterId);
-    }
-  }
-
   public abstract void internalRollback();
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
@@ -322,7 +322,7 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
             recordOperation = addRecord(rec, ORecordOperation.CREATED, iClusterName);
             originalSaved = true;
           } else
-            addRecord(rec, ORecordOperation.CREATED, getClusterName(rec));
+            addRecord(rec, ORecordOperation.CREATED, database.getClusterName(rec));
         }
       }
       if (updatedRecord != null) {
@@ -336,7 +336,7 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
             recordOperation = addRecord(rec, operation, iClusterName);
             originalSaved = true;
           } else
-            addRecord(rec, ORecordOperation.UPDATED, getClusterName(rec));
+            addRecord(rec, ORecordOperation.UPDATED, database.getClusterName(rec));
         }
       }
     } while (dirtyManager.getNewRecords() != null || dirtyManager.getUpdateRecords() != null);


### PR DESCRIPTION
Hi All,

This PR contains a couple of commit that refactor the logic of loop braking for the case of embedded, this new implementation will get all the record from the dirty manager, create a tx out of them and commit the tx, in this way we can use the tx way for generate rids and completely remove the need of creation of an empty record for breaking loops.

This implementation is an hard requirement for future evolutions in the distributed layer that require just one way to handle the data (the transaction).

Same logic could be implemented also for remote noTx, but currently is not done, will be done in future, with as well a major clean up of dirty management logic.