### PR TITLE
edit OrientDB license info so that GitHub recognizes it

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ OrientDB Community Edition is free for any use (Apache 2 license). If you are in
 [Get started with OrientDB](http://orientdb.com/getting-started/).
 
 --------
+
+## Licensing
+OrientDB is licensed by OrientDB LTD under the Apache 2 license. OrientDB relies on the following 3rd party libraries, which are compatible with the Apache license:
+
+- Javamail: CDDL license (http://www.oracle.com/technetwork/java/faq-135477.html)
+- java persistence 2.0: CDDL license
+- JNA: Apache 2 (https://github.com/twall/jna/blob/master/LICENSE)
+- Hibernate JPA 2.0 API: Eclipse Distribution License 1.0
+- ASM: OW2
+
+References:
+- Apache 2 license (Apache2):
+  http://www.apache.org/licenses/LICENSE-2.0.html
+
+- Common Development and Distribution License (CDDL-1.0):
+  http://opensource.org/licenses/CDDL-1.0
+
+- Eclipse Distribution License (EDL-1.0):
+  http://www.eclipse.org/org/documents/edl-v10.php (http://www.eclipse.org/org/documents/edl-v10.php)
+  
 ### Sponsors
 
 |[![](https://www.yourkit.com/images/yklogo.png)](https://www.yourkit.com/.net/profiler/index.jsp)|YourKit supports open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of <a href="https://www.yourkit.com/java/profiler/index.jsp">YourKit Java Profiler</a> and <a href="https://www.yourkit.com/.net/profiler/index.jsp">YourKit .NET Profiler</a>, innovative and intelligent tools for profiling Java and .NET applications.|

--- a/license.txt
+++ b/license.txt
@@ -1,32 +1,4 @@
--------------------------------------------------------------------------------------
- 3RDY PARTY LIBRARIES
---------------------------------------------------------------------
-3rd party libraries used by OrientDB, compatible with Apache license:
-
-- Javamail: CDDL license (http://www.oracle.com/technetwork/java/faq-135477.html)
-- java persistence 2.0: CDDL license
-- JNA: Apache 2 (https://github.com/twall/jna/blob/master/LICENSE)
-- Hibernate JPA 2.0 API: Eclipse Distribution License 1.0
-- ASM: OW2
-
-References:
-- Apache 2 license (Apache2):
-  http://www.apache.org/licenses/LICENSE-2.0.html
-
-- Common Development and Distribution License (CDDL-1.0):
-  http://opensource.org/licenses/CDDL-1.0
-
-- Eclipse Distribution License (EDL-1.0):
-  http://www.eclipse.org/org/documents/edl-v10.php (http://www.eclipse.org/org/documents/edl-v10.php)
-
--------------------------------------------------------------------------------------
- ORIENTDB LICENSE
--------------------------------------------------------------------------------------
-
-                   Copyright 1999-2016 (c) OrientDB LTD
-
-
-                                Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -203,3 +175,27 @@ References:
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/
         </sonatypeOssDistMgmtSnapshotsUrl>
 
-        <license.location>ODB-ASL-LICENSE.txt</license.location>
+        <license.location>license.txt</license.location>
         <!--Override with the given url on external modules-->
         <!--<license.location>https://github.com/orientechnologies/orientdb/raw/develop/ODB-ASL-LICENSE.txt</license.location>-->
         <heapSize>2048m</heapSize>


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in
https://landscape.cncf.io/selected=orient-db)

This PR is a replacement of #8274. Here's a summary of the changes:
- `license.txt` contents have been replaced with only the full text of the Apache license
- info pertaining to 3rd party software licensing is now stored in the `README`
- `ODB-ASL-LICENSE.txt` has been removed
- `pom.xml` has been updated to reference `license.txt`

@luigidellaquila please let me know what you think. For the sake of clarity, it seems best to include only one file with the word `license` in its filename (this is why I removed `ODB-ASL-LICENSE.txt`).

Thanks!