### PR TITLE
Fix for Issues #8285 and #8284

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/console/OConsoleApplication.java
+++ b/core/src/main/java/com/orientechnologies/common/console/OConsoleApplication.java
@@ -303,7 +303,26 @@ public class OConsoleApplication {
       // COMMENT: JUMP IT
       return RESULT.OK;
 
-    String[] commandWords = OStringParser.getWords(iCommand, wordSeparator);
+    String[] commandWords;
+    if (iCommand.toLowerCase().startsWith("load script")){
+      commandWords = iCommand.split(" ");
+      for (int i = 2; i < commandWords.length; i++){
+        boolean wrappedInQuotes = false;
+        if (commandWords[i].startsWith("'") && commandWords[i].endsWith("'")){
+          wrappedInQuotes = true;
+        }
+        else if (commandWords[i].startsWith("\"") && commandWords[i].endsWith("\"")){
+          wrappedInQuotes = true;
+        }
+        
+        if (wrappedInQuotes){
+          commandWords[i] = commandWords[i].substring(1, commandWords[i].length() - 1);
+        }
+      }
+    }
+    else{
+      commandWords = OStringParser.getWords(iCommand, wordSeparator);
+    }
 
     for (String cmd : helpCommands)
       if (cmd.equals(commandWords[0])) {

--- a/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
@@ -63,16 +63,16 @@ public class OStringParser {
         if (nextChar == 'u') {
           i = readUnicode(iText, i + 2, buffer);
         } else if (nextChar == 'n') {
-          buffer.append(stringBeginChar == ' ' ? "\n" : "\\\n");
+          buffer.append(stringBeginChar == ' ' ? "\n" : "\\n");
           i++;
         } else if (nextChar == 'r') {
-          buffer.append(stringBeginChar == ' ' ? "\r" : "\\\r");
+          buffer.append(stringBeginChar == ' ' ? "\r" : "\\r");
           i++;
         } else if (nextChar == 't') {
-          buffer.append(stringBeginChar == ' ' ? "\t" : "\\\t");
+          buffer.append(stringBeginChar == ' ' ? "\t" : "\\t");
           i++;
         } else if (nextChar == 'f') {
-          buffer.append(stringBeginChar == ' ' ? "\f" : "\\\f");
+          buffer.append(stringBeginChar == ' ' ? "\f" : "\\f");
           i++;
         } else if (stringBeginChar != ' ' && nextChar == '\'' || nextChar == '"') {
           buffer.append('\\');

--- a/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
+++ b/core/src/main/java/com/orientechnologies/common/parser/OStringParser.java
@@ -63,16 +63,16 @@ public class OStringParser {
         if (nextChar == 'u') {
           i = readUnicode(iText, i + 2, buffer);
         } else if (nextChar == 'n') {
-          buffer.append(stringBeginChar == ' ' ? "\n" : "\\n");
+          buffer.append(stringBeginChar == ' ' ? "\n" : "\\\n");
           i++;
         } else if (nextChar == 'r') {
-          buffer.append(stringBeginChar == ' ' ? "\r" : "\\r");
+          buffer.append(stringBeginChar == ' ' ? "\r" : "\\\r");
           i++;
         } else if (nextChar == 't') {
-          buffer.append(stringBeginChar == ' ' ? "\t" : "\\t");
+          buffer.append(stringBeginChar == ' ' ? "\t" : "\\\t");
           i++;
         } else if (nextChar == 'f') {
-          buffer.append(stringBeginChar == ' ' ? "\f" : "\\f");
+          buffer.append(stringBeginChar == ' ' ? "\f" : "\\\f");
           i++;
         } else if (stringBeginChar != ' ' && nextChar == '\'' || nextChar == '"') {
           buffer.append('\\');

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OLocalPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/OLocalPaginatedStorage.java
@@ -95,14 +95,7 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
 
     File f = new File(url);
 
-    String sp;
-    if (f.exists() || !exists(Paths.get(f.getParent()))) {
-      // ALREADY EXISTS OR NOT LEGACY
-      sp = OSystemVariableResolver.resolveSystemVariables(OFileUtils.getPath(new File(url).getPath()));
-    } else {
-      // LEGACY DB
-      sp = OSystemVariableResolver.resolveSystemVariables(OFileUtils.getPath(new File(url).getParent()));
-    }
+    String sp = OSystemVariableResolver.resolveSystemVariables(OFileUtils.getPath(new File(url).getPath()));    
 
     storagePath = Paths.get(OIOUtils.getPathFromDatabaseName(sp));
     variableParser = new OStorageVariableParser(storagePath);


### PR DESCRIPTION
* For issue #8285 support for legacy is removed. Cause of the issue is that that DB is detected as legacy DB.
* For issue #8284 is fixed encoding of jump characters. Now windows paths can be used as paths pointing to script. Nevertheless windows path should be between quotes or single quotes

Please pay extra attention to changes in OStringParser, because this tokenizer is used on few places