### PR TITLE
Adding server version in info response #5650

### DIFF
--- a/tools/src/main/java/com/orientechnologies/orient/console/OConsoleDatabaseApp.java
+++ b/tools/src/main/java/com/orientechnologies/orient/console/OConsoleDatabaseApp.java
@@ -1397,6 +1397,7 @@ public class OConsoleDatabaseApp extends OrientConsole implements OCommandOutput
       if (dbCfg.getName() != null)
         resultSet.add(new ODocument().field("NAME", "Name").field("VALUE", dbCfg.getName()));
 
+      resultSet.add(new ODocument().field("NAME", "Server Version").field("VALUE", (OConstants.getVersionMajor()+"."+OConstants.getVersionMinor()+"."+OConstants.getVersionHotfix())));
       resultSet.add(new ODocument().field("NAME", "Version").field("VALUE", dbCfg.getVersion()));
       resultSet.add(new ODocument().field("NAME", "Conflict-Strategy").field("VALUE", dbCfg.getConflictStrategy()));
       resultSet.add(new ODocument().field("NAME", "Date-Format").field("VALUE", dbCfg.getDateFormat()));


### PR DESCRIPTION
Browsing through some of the issues I picked #5650 so I could familiarize myself with the code base. I don't think this is exactly what we want. I'm thinking this probably should be stored in the OStorageConfiguration object but I figured I'd go ahead and start this request and get some feedback. Thanks.

Result after change.
+----+-----------------+-------------------+
|#   |NAME             |VALUE              |
+----+-----------------+-------------------+
|0   |Server Version     |3.0.3             |
|1   |Version                 |20                 |
|2   |Conflict-Strategy  |version          |
|3   |Date-Format        |yyyy-MM-dd  |
|4   |Datetime-Format  |yyyy-MM-dd HH:mm:ss|
|5   |Timezone              |America/New_York   |
|6   |Locale-Country     |US               |
|7   |Locale-Language  |en                |
|8   |Charset                 |UTF-8          |
|9   |Schema-RID         |#0:1             |
|10  |Index-Manager-RID |#0:2         |
+----+-----------------+-------------------+

