### PR TITLE
Moves docker image generation to qa profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,12 @@ node("master") {
 
                 stage('Run tests on Java8') {
                     lock("label": "memory", "quantity": 6) {
-                        docker.image("${mvnJdk8Image}").inside("--label collectd_docker_app=${appNameLabel} --label collectd_docker_task=${taskLabel} "
-                                + "--name ${containerName} --memory=6g ${env.VOLUMES} --cap-add=SYS_PTRACE") {
+                        docker.image("${mvnJdk8Image}")
+                                .inside("""--label collectd_docker_app=${appNameLabel} 
+                                    --label collectd_docker_task=${taskLabel} 
+                                    --name ${containerName} 
+                                    --memory=6g ${env.VOLUMES} 
+                                    --cap-add=SYS_PTRACE""") {
                             try {
                                 //skip integration test for now
                                 sh "${mvnHome}/bin/mvn -V  -fae clean install   -Dsurefire.useFile=false -DskipITs"
@@ -45,8 +49,10 @@ node("master") {
 
                 stage('Run QA/Integration tests on Java8') {
                     lock("label": "memory", "quantity": 5) {
-                        docker.image("${mvnJdk8Image}").inside("--label collectd_docker_app=${appNameLabel} --label collectd_docker_task=${taskLabel} " +
-                                "--name ${containerName} --memory=5g ${env.VOLUMES}") {
+                        docker.image("${mvnJdk8Image}").inside("""--label collectd_docker_app=${appNameLabel} 
+                                --label collectd_docker_task=${taskLabel} 
+                                --name ${containerName} 
+                                --memory=5g ${env.VOLUMES}""") {
                             try {
                                 sh "${mvnHome}/bin/mvn -f distribution/pom.xml clean install -Pqa"
                             } finally {
@@ -59,8 +65,10 @@ node("master") {
 
                 stage('Publish Javadoc') {
                     lock("label": "memory", "quantity": 2) {
-                        docker.image("${mvnJdk8Image}").inside("--label collectd_docker_app=${appNameLabel} --label collectd_docker_task=${taskLabel} " +
-                                "--name ${containerName} --memory=2g ${env.VOLUMES}") {
+                        docker.image("${mvnJdk8Image}").inside("""--label collectd_docker_app=${appNameLabel} 
+                                --label collectd_docker_task=${taskLabel} 
+                                --name ${containerName} 
+                                --memory=2g ${env.VOLUMES}""") {
                             sh "${mvnHome}/bin/mvn  javadoc:aggregate"
                             sh "rsync -ra --stats ${WORKSPACE}/target/site/apidocs/ -e ${env.RSYNC_JAVADOC}/${env.BRANCH_NAME}/"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,14 +9,12 @@ node("master") {
         ansiColor('xterm') {
             milestone()
             def mvnHome = tool 'mvn'
-            def mvnJdk8Image = "orientdb/mvn-gradle-zulu-jdk-8"
+            def mvnJdk8Image = "azul/zulu-openjdk-alpine:8"
 
-            def containerName = env.JOB_NAME.replaceAll(/\//, "_") +
-                    "_build_${currentBuild.number}"
+            def containerName = env.JOB_NAME.replaceAll(/\//, "_") + "_build_${currentBuild.number}"
 
             def appNameLabel = "docker_ci";
             def taskLabel = env.JOB_NAME.replaceAll(/\//, "_")
-
 
             stage('Source checkout') {
                 checkout scm
@@ -34,11 +32,11 @@ node("master") {
                                     --cap-add=SYS_PTRACE""") {
                             try {
                                 //skip integration test for now
-                                sh "${mvnHome}/bin/mvn -V  -fae clean install   -Dsurefire.useFile=false -DskipITs"
+                                sh "./mvnw  -V  -fae clean install   -Dsurefire.useFile=false -DskipITs"
                                 //clean distribution to enable recreation of databases
-                                sh "${mvnHome}/bin/mvn -f distribution/pom.xml clean"
-                                sh "${mvnHome}/bin/mvn -f distribution-tp2/pom.xml clean"
-                                sh "${mvnHome}/bin/mvn clean deploy -DskipTests -DskipITs"
+                                sh "./mvnw  -f distribution/pom.xml clean"
+                                sh "./mvnw  -f distribution-tp2/pom.xml clean"
+                                sh "./mvnw  clean deploy -DskipTests -DskipITs"
                             } finally {
                                 junit allowEmptyResults: true, testResults: '**/target/surefire-reports/TEST-*.xml'
 
@@ -54,7 +52,7 @@ node("master") {
                                 --name ${containerName} 
                                 --memory=5g ${env.VOLUMES}""") {
                             try {
-                                sh "${mvnHome}/bin/mvn -f distribution/pom.xml clean install -Pqa"
+                                sh "./mvnw  -f distribution/pom.xml clean install -Pqa"
                             } finally {
                                 junit allowEmptyResults: true, testResults: '**/target/failsafe-reports/TEST-*.xml'
 
@@ -69,7 +67,7 @@ node("master") {
                                 --label collectd_docker_task=${taskLabel} 
                                 --name ${containerName} 
                                 --memory=2g ${env.VOLUMES}""") {
-                            sh "${mvnHome}/bin/mvn  javadoc:aggregate"
+                            sh "./mvnw   javadoc:aggregate"
                             sh "rsync -ra --stats ${WORKSPACE}/target/site/apidocs/ -e ${env.RSYNC_JAVADOC}/${env.BRANCH_NAME}/"
                         }
                     }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -209,62 +209,44 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>1.1.1</version>
-                <executions>
-                    <execution>
-                        <id>build-image</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <imageName>orientdb/orientdb</imageName>
-                    <imageTags>
-                        <imageTag>${project.version}</imageTag>
-                    </imageTags>
-                    <dockerDirectory>${project.basedir}/docker</dockerDirectory>
-                    <!-- copy the service's jar file from target into the root directory of the image -->
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}/</directory>
-                            <include>${project.build.finalName}.tar.gz</include>
-                        </resource>
-                    </resources>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <buildDirectory>${project.build.directory}</buildDirectory>
-                        <buildName>${project.build.finalName}</buildName>
-                        <loadScriptPath>${basedir}/src/main/resources/demoDB.osql</loadScriptPath>
-                    </systemPropertyVariables>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
             <id>qa</id>
+
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>1.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>build-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <imageName>orientdb/orientdb</imageName>
+                            <imageTags>
+                                <imageTag>${project.version}</imageTag>
+                            </imageTags>
+                            <dockerDirectory>${project.basedir}/docker</dockerDirectory>
+                            <!-- copy the service's jar file from target into the root directory of the image -->
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.build.directory}/</directory>
+                                    <include>${project.build.finalName}.tar.gz</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
@@ -272,7 +254,6 @@
                             <systemPropertyVariables>
                                 <buildDirectory>${project.build.directory}</buildDirectory>
                                 <buildName>${project.build.finalName}</buildName>
-                                <loadScriptPath>${basedir}/src/main/resources/demoDB.osql</loadScriptPath>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>


### PR DESCRIPTION
This PR refactors the distribution/pom.xm in order to avoid the docker image creation every time an _install_ is performed.
The docker image is created ONLY for qa tests

the command:

```mvn clean install```

doesn't create the docker image

while the command

```mvn clean install -Pqa```

creates the docker image (you need docker installed on the system)


@tglman, please review 
 


 