### PR TITLE
Fixed OCommandSQLParsingException which throws when user try update CUSTOM attribute from Java API

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OClassImpl.java
@@ -225,10 +225,10 @@ public class OClassImpl extends ODocumentWrapperNoClass implements OClass {
       final OStorage storage = database.getStorage();
 
       if (storage instanceof OStorageProxy) {
-        final String cmd = String.format("alter class `%s` custom %s=%s", getName(), name, value);
+        final String cmd = String.format("alter class `%s` custom `%s`=%s", getName(), name, value);
         database.command(new OCommandSQL(cmd)).execute();
       } else if (isDistributedCommand()) {
-        final String cmd = String.format("alter class `%s` custom %s=%s", getName(), name, value);
+        final String cmd = String.format("alter class `%s` custom `%s`=%s", getName(), name, value);
         final OCommandSQL commandSQL = new OCommandSQL(cmd);
         commandSQL.addExcludedNode(((OAutoshardedStorage) storage).getNodeId());
 

--- a/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OPropertyImpl.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/metadata/schema/OPropertyImpl.java
@@ -759,7 +759,7 @@ public class OPropertyImpl extends ODocumentWrapperNoClass implements OProperty 
 
     acquireSchemaWriteLock();
     try {
-      final String cmd = String.format("alter property %s custom %s=%s", getFullNameQuoted(), name, quoteString(value));
+      final String cmd = String.format("alter property %s custom `%s`=%s", getFullNameQuoted(), name, quoteString(value));
 
       final ODatabaseDocumentInternal database = getDatabase();
       final OStorage storage = database.getStorage();

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/AlterPropertyTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/AlterPropertyTest.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.metadata.schema;
 
+import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
+import com.orientechnologies.orient.core.db.ODatabaseInternal;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.exception.OSchemaException;
@@ -134,6 +136,19 @@ public class AlterPropertyTest {
     schema.reload();
     Assert.assertNull(schema.getClass("testAlterPropertyWithDot").getProperty("a.b"));
     Assert.assertNotNull(schema.getClass("testAlterPropertyWithDot").getProperty("c"));
+  }
+
+  @Test
+  public void testAlterCustomAttributeInProperty() {
+    OSchema schema = db.getMetadata().getSchema();
+    OClass oClass = schema.createClass("TestCreateCustomAttributeClass");
+    OProperty property = oClass.createProperty("property", OType.STRING);
+
+    property.setCustom("customAttribute", "value1");
+    assertEquals("value1", property.getCustom("customAttribute"));
+
+    property.setCustom("custom.attribute", "value2");
+    assertEquals("value2", property.getCustom("custom.attribute"));
   }
 
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OClassImplTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/metadata/schema/OClassImplTest.java
@@ -15,6 +15,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import static org.testng.Assert.*;
+import static org.testng.AssertJUnit.assertEquals;
 
 public class OClassImplTest {
 
@@ -531,5 +532,17 @@ public class OClassImplTest {
 
     List<?> result = db.query(new OSQLSynchQuery<Object>("select from " + className + " where name = 'foo'"));
     Assert.assertEquals(result.size(), 1);
+  }
+
+  @Test
+  public void testAlterCustomAttributeInClass() {
+    OSchema schema = db.getMetadata().getSchema();
+    OClass oClass = schema.createClass("TestCreateCustomAttributeClass");
+
+    oClass.setCustom("customAttribute", "value1");
+    assertEquals("value1", oClass.getCustom("customAttribute"));
+
+    oClass.setCustom("custom.attribute", "value2");
+    assertEquals("value2", oClass.getCustom("custom.attribute"));
   }
 }

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/schema/AlterClassTest.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/schema/AlterClassTest.java
@@ -1,0 +1,60 @@
+package com.orientechnologies.orient.server.distributed.schema;
+
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.server.distributed.AbstractServerClusterTest;
+import com.orientechnologies.orient.server.distributed.ServerRun;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AlterClassTest extends AbstractServerClusterTest {
+
+    private OClass oClass;
+
+    @Test
+    public void test() throws Exception {
+        init(2);
+        prepare(true);
+        execute();
+    }
+
+    @Override
+    protected void onAfterDatabaseCreation(OrientBaseGraph db) {
+        oClass = db.getRawGraph().getMetadata().getSchema().createClass("AlterPropertyTestClass");
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return "testdb";
+    }
+
+    @Override
+    protected String getDatabaseURL(ServerRun server) {
+        return "plocal:" + server.getDatabasePath(getDatabaseName());
+    }
+
+    @Override
+    protected void executeTest() throws Exception {
+        ODatabaseDocument db = new ODatabaseDocumentTx(getDatabaseURL(serverInstance.get(0)));
+        db.open("admin", "admin");
+        try {
+            testAlterCustomAttributeInClass();
+            testAlterCustomAttributeWithDotInClass();
+        } finally {
+            db.close();
+        }
+    }
+
+    private void testAlterCustomAttributeInClass() {
+        oClass.setCustom("customAttribute", "value");
+        assertEquals("value", oClass.getCustom("customAttribute"));
+    }
+
+    private void testAlterCustomAttributeWithDotInClass() {
+        oClass.setCustom("custom.attribute", "value");
+        assertEquals("value", oClass.getCustom("custom.attribute"));
+    }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/schema/AlterPropertyTest.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/schema/AlterPropertyTest.java
@@ -1,0 +1,65 @@
+package com.orientechnologies.orient.server.distributed.schema;
+
+import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OProperty;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.server.distributed.AbstractServerClusterTest;
+import com.orientechnologies.orient.server.distributed.ServerRun;
+import com.tinkerpop.blueprints.impls.orient.OrientBaseGraph;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AlterPropertyTest extends AbstractServerClusterTest {
+
+    private OProperty property;
+
+    @Test
+    public void test() throws Exception {
+        init(2);
+        prepare(true);
+        execute();
+    }
+
+    @Override
+    protected void onAfterDatabaseCreation(OrientBaseGraph db) {
+        OClass oClass = db.getRawGraph().getMetadata().getSchema().createClass("AlterPropertyTestClass");
+
+        property = oClass.createProperty("property", OType.STRING);
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return "testdb";
+    }
+
+    @Override
+    protected String getDatabaseURL(ServerRun server) {
+        return "plocal:" + server.getDatabasePath(getDatabaseName());
+    }
+
+    @Override
+    protected void executeTest() throws Exception {
+        ODatabaseDocument db = new ODatabaseDocumentTx(getDatabaseURL(serverInstance.get(0)));
+        db.open("admin", "admin");
+        try {
+            testAlterCustomAttributeInProperty();
+            testAlterCustomAttributeWithDotInProperty();
+        } finally {
+            db.close();
+        }
+    }
+
+    private void testAlterCustomAttributeInProperty() {
+        property.setCustom("customAttribute", "value");
+        assertEquals("value", property.getCustom("customAttribute"));
+    }
+
+    private void testAlterCustomAttributeWithDotInProperty() {
+        property.setCustom("custom.attribute", "value");
+        assertEquals("value", property.getCustom("custom.attribute"));
+    }
+}


### PR DESCRIPTION
Wrapped custom name by `` for execute alter command in distributed database mode

Fixed OCommandSQLParsingException which throws when user try update CUSTOM
attribute from Java API

## Steps for reproduce
1. Run OrientDB in distributed mode
2. Try to update custom attribute for class or property. Name of custom property must contains dot for reproduce bug.
`property.setCustom("custom.name", "value")`