### PR TITLE
Issue #8488 proposal

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OExpression.java
@@ -113,7 +113,7 @@ public class OExpression extends SimpleNode {
       return arrayConcatExpression.execute(iCurrentRecord, ctx);
     }
     if (json != null) {
-      return json.toMap(iCurrentRecord, ctx);
+      return json.toObjectDetermineType(iCurrentRecord, ctx);
     }
     if (booleanValue != null) {
       return booleanValue;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OJson.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OJson.java
@@ -68,6 +68,35 @@ public class OJson extends SimpleNode {
 
     return doc;
   }
+  
+  private ODocument toDocument(OResult source, OCommandContext ctx, String className){
+    ODocument retDoc = new ODocument(className);
+    for (OJsonItem item : items) {
+      String name = item.getLeftValue();
+      if (name == null || name.trim().startsWith("@")) {
+        continue;
+      }        
+      Object value = item.right.execute(source, ctx);
+      retDoc.field(name, value);
+    }
+    return retDoc;
+  }
+  
+  /**
+   * choosing return type is based on existence of @class field in JSON
+   * @param source
+   * @param ctx
+   * @return 
+   */
+  public Object toObjectDetermineType(OResult source, OCommandContext ctx){
+    String className = getClassNameForDocument(ctx);
+    if (className != null){
+      return toDocument(source, ctx, className);
+    }
+    else{
+      return toMap(source, ctx);
+    }
+  }
 
   public Map<String, Object> toMap(OIdentifiable source, OCommandContext ctx) {
     Map<String, Object> doc = new HashMap<String, Object>();


### PR DESCRIPTION
Related to #8488 . Cause of the issue is because value of the embedded map entry is recognized as map instead as document instance. Idea is if in json "@class" field exists that json will be treated as document of specified class. So, with this fix, command:
`UPDATE DTest SET document = {"testkey":{"@class":"ODocument", "name":"testvalue"}} WHERE id = "123";`

will be executed as expected