### PR TITLE
Solution proposal for #8498

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/ReturnMatchPathElementsStep.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/ReturnMatchPathElementsStep.java
@@ -2,24 +2,32 @@ package com.orientechnologies.orient.core.sql.executor;
 
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.record.OElement;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Created by luigidellaquila on 12/10/16.
  */
 public class ReturnMatchPathElementsStep extends AbstractUnrollStep {
 
+  private Set alreadyIn = new HashSet();
+  
   public ReturnMatchPathElementsStep(OCommandContext context, boolean profilingEnabled) {
     super(context, profilingEnabled);
   }
 
-  @Override protected Collection<OResult> unroll(OResult doc, OCommandContext iContext) {
+  @Override protected Collection<OResult> unroll(OResult doc, OCommandContext iContext) {    
     List<OResult> result = new ArrayList<>();
     for (String s : doc.getPropertyNames()) {
       Object elem = doc.getProperty(s);
+      if (alreadyIn.contains(elem)){
+        continue;
+      }
       if (elem instanceof OIdentifiable) {
         OResultInternal newelem = new OResultInternal();
         newelem.setElement((OIdentifiable) elem);
@@ -27,10 +35,15 @@ public class ReturnMatchPathElementsStep extends AbstractUnrollStep {
       }
       if (elem instanceof OResult) {
         result.add((OResult) elem);
+        OElement el = ((OResult) elem).getElement().orElse(null);
+        if (el != null){
+          alreadyIn.add(el);
+        }
       }
+      alreadyIn.add(elem);
       //else...? TODO
     }
-    return result;
+    return result;    
   }
 
   @Override public String prettyPrint(int depth, int indent) {


### PR DESCRIPTION
As described in  #8498 all unrolled elements will be contained in result set, which is contradictory to documentation:

> $pathElements (since 2.2.1), the same as $paths, but for each node present in the pattern, a single row is created in the result set (no duplicates)

 My idea is to track all elements previously fetched, and to ignore all reoccurred elements