### PR TITLE
java IO deletion instead nio

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/io/OFileUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OFileUtils.java
@@ -157,13 +157,17 @@ public class OFileUtils {
       Files.walkFileTree(rootPath, new SimpleFileVisitor<Path>() {
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-          Files.deleteIfExists(file);
+          if (file != null && file.toFile() != null && file.toFile().exists()){
+            file.toFile().delete();
+          }
           return FileVisitResult.CONTINUE;
         }
 
         @Override
         public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-          Files.deleteIfExists(dir);
+          if (dir != null && dir.toFile() != null && dir.toFile().exists()){
+            dir.toFile().delete();
+          }
           return FileVisitResult.CONTINUE;
         }
       });


### PR DESCRIPTION
Sometimes in windows environment dir can not be deleted because some contained file is not deleted. Probably cause for such behaviour is file locking issues in windows environment, but so far I've found that all acquired lock are released. With classic java io files and dirs eventually will be deleted, and issue doesn't appear any more.