### PR TITLE
Remote pessimistic locking

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/binary/OBinaryRequestExecutor.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/binary/OBinaryRequestExecutor.java
@@ -138,4 +138,8 @@ public interface OBinaryRequestExecutor {
   OBinaryResponse executeSubscribeSequences(OSubscribeSequencesRequest request);
 
   OBinaryResponse executeExperimental(OExperimentalRequest request);
+
+  OBinaryResponse executeLockRecord(OLockRecordRequest request);
+
+  OBinaryResponse executeUnlockRecord(OUnlockRecordRequest request);
 }

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -50,6 +50,7 @@ import com.orientechnologies.orient.core.exception.*;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.security.OTokenException;
+import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.security.OCredentialInterceptor;
@@ -81,6 +82,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -2155,10 +2157,12 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
     }
   }
 
-  public void lockRecord(OIdentifiable iRecord, LOCKING_STRATEGY lockingStrategy) {
-    OExperimentalRequest request = new OExperimentalRequest(new OLockRecordRequest(iRecord.getIdentity(), lockingStrategy));
+  public OLockRecordResponse lockRecord(OIdentifiable iRecord, LOCKING_STRATEGY lockingStrategy, long timeout) {
+    OExperimentalRequest request = new OExperimentalRequest(
+        new OLockRecordRequest(iRecord.getIdentity(), lockingStrategy, timeout));
     OExperimentalResponse response = networkOperation(request, "Error locking record");
     OLockRecordResponse realResponse = (OLockRecordResponse) response.getResponse();
+    return realResponse;
   }
 
   public void unlockRecord(OIdentifiable iRecord) {

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -44,6 +44,7 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTxInternal
 import com.orientechnologies.orient.core.db.document.OLiveQueryMonitorRemote;
 import com.orientechnologies.orient.core.db.document.OTransactionOptimisticClient;
 import com.orientechnologies.orient.core.db.record.OCurrentStorageComponentsFactory;
+import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.exception.*;
 import com.orientechnologies.orient.core.id.ORID;
@@ -2152,6 +2153,18 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
         }
       }
     }
+  }
+
+  public void lockRecord(OIdentifiable iRecord, LOCKING_STRATEGY lockingStrategy) {
+    OExperimentalRequest request = new OExperimentalRequest(new OLockRecordRequest(iRecord.getIdentity(), lockingStrategy));
+    OExperimentalResponse response = networkOperation(request, "Error locking record");
+    OLockRecordResponse realResponse = (OLockRecordResponse) response.getResponse();
+  }
+
+  public void unlockRecord(OIdentifiable iRecord) {
+    OExperimentalRequest request = new OExperimentalRequest(new OUnlockRecordRequest(iRecord.getIdentity()));
+    OExperimentalResponse response = networkOperation(request, "Error locking record");
+    OUnlockRecordResponse realResponse = (OUnlockRecordResponse) response.getResponse();
   }
 
   @Override

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OExperimentalRequest.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OExperimentalRequest.java
@@ -17,8 +17,10 @@ import java.io.IOException;
  */
 public class OExperimentalRequest implements OBinaryRequest<OExperimentalResponse> {
 
-  private byte                                      messageID;
-  private OBinaryRequest<? extends OBinaryResponse> request;
+  public static final byte                                      REQUEST_RECORD_LOCK   = 48;
+  public static final byte                                      REQUEST_RECORD_UNLOCK = 49;
+  private             byte                                      messageID;
+  private             OBinaryRequest<? extends OBinaryResponse> request;
 
   public OExperimentalRequest() {
 
@@ -44,6 +46,10 @@ public class OExperimentalRequest implements OBinaryRequest<OExperimentalRespons
 
   private OBinaryRequest<? extends OBinaryResponse> createBinaryRequest(byte message) {
     switch (message) {
+    case REQUEST_RECORD_LOCK:
+      return new OLockRecordRequest();
+    case REQUEST_RECORD_UNLOCK:
+      return new OUnlockRecordRequest();
     //NONE FOR NOW
     }
 
@@ -75,6 +81,6 @@ public class OExperimentalRequest implements OBinaryRequest<OExperimentalRespons
 
   @Override
   public String getDescription() {
-    return "Experimental message:" + request == null ? "Not Defined" : request.getDescription();
+    return "Experimental message:" + (request == null ? "Not Defined" : request.getDescription());
   }
 }

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordRequest.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordRequest.java
@@ -15,14 +15,16 @@ import java.io.IOException;
 public class OLockRecordRequest implements OBinaryRequest<OLockRecordResponse> {
   private ORID                      identity;
   private OStorage.LOCKING_STRATEGY lockingStrategy;
+  private long                      timeout;
 
   public OLockRecordRequest() {
 
   }
 
-  public OLockRecordRequest(ORID identity, OStorage.LOCKING_STRATEGY lockingStrategy) {
+  public OLockRecordRequest(ORID identity, OStorage.LOCKING_STRATEGY lockingStrategy, long timeout) {
     this.identity = identity;
     this.lockingStrategy = lockingStrategy;
+    this.timeout = timeout;
   }
 
   @Override
@@ -33,6 +35,7 @@ public class OLockRecordRequest implements OBinaryRequest<OLockRecordResponse> {
     } else if (lockingStrategy == OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK) {
       network.writeByte((byte) 2);
     }
+    network.writeLong(timeout);
   }
 
   @Override
@@ -44,6 +47,7 @@ public class OLockRecordRequest implements OBinaryRequest<OLockRecordResponse> {
     } else if (lockKind == 2) {
       this.lockingStrategy = OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK;
     }
+    timeout = channel.readLong();
   }
 
   @Override
@@ -72,5 +76,9 @@ public class OLockRecordRequest implements OBinaryRequest<OLockRecordResponse> {
 
   public ORID getIdentity() {
     return identity;
+  }
+
+  public long getTimeout() {
+    return timeout;
   }
 }

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordRequest.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordRequest.java
@@ -1,0 +1,76 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
+import com.orientechnologies.orient.client.remote.OBinaryRequest;
+import com.orientechnologies.orient.client.remote.OBinaryResponse;
+import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.core.storage.OStorage;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+
+public class OLockRecordRequest implements OBinaryRequest<OLockRecordResponse> {
+  private ORID                      identity;
+  private OStorage.LOCKING_STRATEGY lockingStrategy;
+
+  public OLockRecordRequest() {
+
+  }
+
+  public OLockRecordRequest(ORID identity, OStorage.LOCKING_STRATEGY lockingStrategy) {
+    this.identity = identity;
+    this.lockingStrategy = lockingStrategy;
+  }
+
+  @Override
+  public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
+    network.writeRID(identity);
+    if (lockingStrategy == OStorage.LOCKING_STRATEGY.SHARED_LOCK) {
+      network.writeByte((byte) 1);
+    } else if (lockingStrategy == OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK) {
+      network.writeByte((byte) 2);
+    }
+  }
+
+  @Override
+  public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
+    identity = channel.readRID();
+    byte lockKind = channel.readByte();
+    if (lockKind == 1) {
+      this.lockingStrategy = OStorage.LOCKING_STRATEGY.SHARED_LOCK;
+    } else if (lockKind == 2) {
+      this.lockingStrategy = OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK;
+    }
+  }
+
+  @Override
+  public byte getCommand() {
+    return OExperimentalRequest.REQUEST_RECORD_LOCK;
+  }
+
+  @Override
+  public OLockRecordResponse createResponse() {
+    return new OLockRecordResponse();
+  }
+
+  @Override
+  public OBinaryResponse execute(OBinaryRequestExecutor executor) {
+    return executor.executeLockRecord(this);
+  }
+
+  @Override
+  public String getDescription() {
+    return "Lock record";
+  }
+
+  public OStorage.LOCKING_STRATEGY getLockingStrategy() {
+    return lockingStrategy;
+  }
+
+  public ORID getIdentity() {
+    return identity;
+  }
+}

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordResponse.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordResponse.java
@@ -1,0 +1,21 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.client.remote.OBinaryResponse;
+import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+
+public class OLockRecordResponse implements OBinaryResponse {
+  @Override
+  public void write(OChannelDataOutput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
+
+  }
+
+  @Override
+  public void read(OChannelDataInput network, OStorageRemoteSession session) throws IOException {
+
+  }
+}

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordResponse.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OLockRecordResponse.java
@@ -9,13 +9,44 @@ import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput
 import java.io.IOException;
 
 public class OLockRecordResponse implements OBinaryResponse {
+
+  private byte   recordType;
+  private int    version;
+  private byte[] record;
+
+  public OLockRecordResponse() {
+
+  }
+
+  public OLockRecordResponse(byte recordType, int version, byte[] record) {
+    this.recordType = recordType;
+    this.version = version;
+    this.record = record;
+  }
+
   @Override
   public void write(OChannelDataOutput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
-
+    channel.writeByte(recordType);
+    channel.writeVersion(version);
+    channel.writeBytes(record);
   }
 
   @Override
   public void read(OChannelDataInput network, OStorageRemoteSession session) throws IOException {
+    this.recordType = network.readByte();
+    this.version = network.readVersion();
+    this.record = network.readBytes();
+  }
 
+  public byte getRecordType() {
+    return recordType;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public byte[] getRecord() {
+    return record;
   }
 }

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OUnlockRecordRequest.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OUnlockRecordRequest.java
@@ -1,0 +1,58 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.client.binary.OBinaryRequestExecutor;
+import com.orientechnologies.orient.client.remote.OBinaryRequest;
+import com.orientechnologies.orient.client.remote.OBinaryResponse;
+import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+
+public class OUnlockRecordRequest implements OBinaryRequest<OUnlockRecordResponse> {
+  private ORID identity;
+
+  public OUnlockRecordRequest() {
+
+  }
+
+  public OUnlockRecordRequest(ORID identity) {
+    this.identity = identity;
+  }
+
+  @Override
+  public void write(OChannelDataOutput network, OStorageRemoteSession session) throws IOException {
+    network.writeRID(identity);
+  }
+
+  @Override
+  public void read(OChannelDataInput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
+    this.identity = channel.readRID();
+  }
+
+  @Override
+  public byte getCommand() {
+    return OExperimentalRequest.REQUEST_RECORD_UNLOCK;
+  }
+
+  @Override
+  public OUnlockRecordResponse createResponse() {
+    return new OUnlockRecordResponse();
+  }
+
+  @Override
+  public OBinaryResponse execute(OBinaryRequestExecutor executor) {
+    return executor.executeUnlockRecord(this);
+  }
+
+  @Override
+  public String getDescription() {
+    return "Unlock Record";
+  }
+
+  public ORID getIdentity() {
+    return identity;
+  }
+}

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OUnlockRecordResponse.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OUnlockRecordResponse.java
@@ -1,0 +1,21 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.client.remote.OBinaryResponse;
+import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.core.serialization.serializer.record.ORecordSerializer;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataInput;
+import com.orientechnologies.orient.enterprise.channel.binary.OChannelDataOutput;
+
+import java.io.IOException;
+
+public class OUnlockRecordResponse implements OBinaryResponse {
+  @Override
+  public void write(OChannelDataOutput channel, int protocolVersion, ORecordSerializer serializer) throws IOException {
+
+  }
+
+  @Override
+  public void read(OChannelDataInput network, OStorageRemoteSession session) throws IOException {
+
+  }
+}

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -27,6 +27,7 @@ import com.orientechnologies.orient.client.remote.OLiveQueryClientListener;
 import com.orientechnologies.orient.client.remote.ORemoteQueryResult;
 import com.orientechnologies.orient.client.remote.OStorageRemote;
 import com.orientechnologies.orient.client.remote.OStorageRemoteSession;
+import com.orientechnologies.orient.client.remote.message.OLockRecordResponse;
 import com.orientechnologies.orient.client.remote.message.ORemoteResultSet;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
@@ -61,6 +62,7 @@ import com.orientechnologies.orient.core.storage.OBasicTransaction;
 import com.orientechnologies.orient.core.storage.ORawBuffer;
 import com.orientechnologies.orient.core.storage.ORecordCallback;
 import com.orientechnologies.orient.core.storage.OStorage;
+import com.orientechnologies.orient.core.storage.OStorage.LOCKING_STRATEGY;
 import com.orientechnologies.orient.core.storage.impl.local.OMicroTransaction;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OOfflineClusterException;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.ORecordSerializationContext;
@@ -71,6 +73,8 @@ import com.orientechnologies.orient.core.tx.OTransactionOptimistic;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
+
+import static com.orientechnologies.orient.core.storage.OStorage.LOCKING_STRATEGY.*;
 
 /**
  * Created by tglman on 30/06/16.
@@ -650,7 +654,7 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
    */
   public <RET extends ORecord> RET executeReadRecord(final ORecordId rid, ORecord iRecord, final int recordVersion,
       final String fetchPlan, final boolean ignoreCache, final boolean iUpdateCache, final boolean loadTombstones,
-      final OStorage.LOCKING_STRATEGY lockingStrategy, RecordReader recordReader) {
+      final LOCKING_STRATEGY lockingStrategy, RecordReader recordReader) {
     checkOpenness();
     checkIfActive();
 
@@ -682,12 +686,12 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
         if (record.getInternalStatus() == ORecordElement.STATUS.NOT_LOADED)
           record.reload();
 
-        if (lockingStrategy == OStorage.LOCKING_STRATEGY.KEEP_SHARED_LOCK) {
+        if (lockingStrategy == KEEP_SHARED_LOCK) {
           OLogManager.instance()
               .warn(this, "You use deprecated record locking strategy: %s it may lead to deadlocks " + lockingStrategy);
           record.lock(false);
 
-        } else if (lockingStrategy == OStorage.LOCKING_STRATEGY.KEEP_EXCLUSIVE_LOCK) {
+        } else if (lockingStrategy == KEEP_EXCLUSIVE_LOCK) {
           OLogManager.instance()
               .warn(this, "You use deprecated record locking strategy: %s it may lead to deadlocks " + lockingStrategy);
           record.lock(true);
@@ -756,17 +760,17 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
     }
   }
 
-
   public String getClusterName(final ORecord record) {
     // DON'T ASSIGN CLUSTER WITH REMOTE: SERVER KNOWS THE RIGHT CLUSTER BASED ON LOCALITY
     return null;
   }
 
   @Override
-  public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy) {
+  public void internalLockRecord(OIdentifiable iRecord, LOCKING_STRATEGY lockingStrategy) {
     checkAndSendTransaction();
     OStorageRemote remote = getStorage();
-    remote.lockRecord(iRecord, lockingStrategy);
+    // -1 value means default timeout
+    remote.lockRecord(iRecord, lockingStrategy, -1);
   }
 
   @Override
@@ -777,16 +781,44 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
 
   @Override
   public <RET extends ORecord> RET lock(ORID recordId) throws OLockException {
-    return null;
+    checkOpenness();
+    checkIfActive();
+    pessimisticLockChecks(recordId);
+    checkAndSendTransaction();
+    OStorageRemote remote = getStorage();
+    // -1 value means default timeout
+    OLockRecordResponse response = remote.lockRecord(recordId, EXCLUSIVE_LOCK, -1);
+    ORecord record = fillRecordFromNetwork(recordId, response.getRecordType(), response.getVersion(), response.getRecord());
+    return (RET) record;
   }
 
   @Override
   public <RET extends ORecord> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException {
-    return null;
+    checkOpenness();
+    checkIfActive();
+    pessimisticLockChecks(recordId);
+    checkAndSendTransaction();
+    OStorageRemote remote = getStorage();
+    OLockRecordResponse response = remote.lockRecord(recordId, EXCLUSIVE_LOCK, timeoutUnit.toMillis(timeout));
+    ORecord record = fillRecordFromNetwork(recordId, response.getRecordType(), response.getVersion(), response.getRecord());
+    return (RET) record;
+  }
+
+  private ORecord fillRecordFromNetwork(ORID recordId, byte recordType, int version, byte[] buffer) {
+    beforeReadOperations(recordId);
+    ORecord toFillRecord = getLocalCache().findRecord(recordId);
+    if (toFillRecord == null)
+      toFillRecord = Orient.instance().getRecordFactoryManager().newInstance(recordType, recordId.getClusterId(), this);
+    ORecordInternal.fill(toFillRecord, recordId, version, buffer, false);
+    getLocalCache().updateRecord(toFillRecord);
+    afterReadOperations(recordId);
+    return toFillRecord;
   }
 
   @Override
   public void unlock(ORID recordId) throws OLockException {
-
+    checkOpenness();
+    checkIfActive();
+    internalUnlockRecord(recordId);
   }
 }

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -758,4 +758,17 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
     // DON'T ASSIGN CLUSTER WITH REMOTE: SERVER KNOWS THE RIGHT CLUSTER BASED ON LOCALITY
     return null;
   }
+
+  @Override
+  public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy) {
+    checkAndSendTransaction();
+    OStorageRemote remote = getStorage();
+    remote.lockRecord(iRecord, lockingStrategy);
+  }
+
+  @Override
+  public void internalUnlockRecord(OIdentifiable iRecord) {
+    OStorageRemote remote = getStorage();
+    remote.unlockRecord(iRecord.getIdentity());
+  }
 }

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -292,7 +292,7 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
 
     switch (iType) {
     case NOTX:
-      setDefaultTransactionMode();
+      setDefaultTransactionMode(null);
       break;
 
     case OPTIMISTIC:

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentRemote.java
@@ -20,6 +20,7 @@
 
 package com.orientechnologies.orient.core.db.document;
 
+import com.orientechnologies.common.concur.lock.OLockException;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.client.remote.OLiveQueryClientListener;
@@ -40,6 +41,7 @@ import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
 import com.orientechnologies.orient.core.fetch.OFetchHelper;
 import com.orientechnologies.orient.core.hook.ORecordHook;
 import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.index.OClassIndexManager;
 import com.orientechnologies.orient.core.index.OIndexManagerRemote;
 import com.orientechnologies.orient.core.metadata.OMetadataDefault;
@@ -68,6 +70,7 @@ import com.orientechnologies.orient.core.tx.OTransactionOptimistic;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by tglman on 30/06/16.
@@ -770,5 +773,20 @@ public class ODatabaseDocumentRemote extends ODatabaseDocumentAbstract {
   public void internalUnlockRecord(OIdentifiable iRecord) {
     OStorageRemote remote = getStorage();
     remote.unlockRecord(iRecord.getIdentity());
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId) throws OLockException {
+    return null;
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException {
+    return null;
+  }
+
+  @Override
+  public void unlock(ORID recordId) throws OLockException {
+
   }
 }

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/message/OLockMessagesTests.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/message/OLockMessagesTests.java
@@ -1,0 +1,57 @@
+package com.orientechnologies.orient.client.remote.message;
+
+import com.orientechnologies.orient.core.id.ORecordId;
+import com.orientechnologies.orient.core.serialization.serializer.record.binary.ORecordSerializerNetworkFactory;
+import com.orientechnologies.orient.core.storage.OStorage;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class OLockMessagesTests {
+
+  @Test
+  public void testReadWriteLockRequest() throws IOException {
+    OLockRecordRequest request = new OLockRecordRequest(new ORecordId(10, 10), OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK, 10);
+    MockChannel channel = new MockChannel();
+    request.write(channel, null);
+
+    channel.close();
+
+    OLockRecordRequest other = new OLockRecordRequest();
+    other.read(channel, -1, ORecordSerializerNetworkFactory.INSTANCE.current());
+    assertEquals(other.getIdentity(), request.getIdentity());
+    assertEquals(other.getTimeout(), request.getTimeout());
+    assertEquals(other.getLockingStrategy(), request.getLockingStrategy());
+  }
+
+  @Test
+  public void testReadWriteLockResponse() throws IOException {
+    OLockRecordResponse response = new OLockRecordResponse((byte) 1, 2, "value".getBytes());
+    MockChannel channel = new MockChannel();
+    response.write(channel, 0, null);
+
+    channel.close();
+
+    OLockRecordResponse other = new OLockRecordResponse();
+    other.read(channel, null);
+    assertEquals(other.getRecordType(), response.getRecordType());
+    assertEquals(other.getVersion(), response.getVersion());
+    assertArrayEquals(other.getRecord(), response.getRecord());
+  }
+
+  @Test
+  public void testReadWriteUnlockRequest() throws IOException {
+    OUnlockRecordRequest request = new OUnlockRecordRequest(new ORecordId(10, 10));
+    MockChannel channel = new MockChannel();
+    request.write(channel, null);
+
+    channel.close();
+
+    OUnlockRecordRequest other = new OUnlockRecordRequest();
+    other.read(channel, -1, ORecordSerializerNetworkFactory.INSTANCE.current());
+    assertEquals(other.getIdentity(), request.getIdentity());
+  }
+}

--- a/core/src/main/java/com/orientechnologies/common/concur/lock/ONotThreadRWLockManager.java
+++ b/core/src/main/java/com/orientechnologies/common/concur/lock/ONotThreadRWLockManager.java
@@ -1,0 +1,105 @@
+package com.orientechnologies.common.concur.lock;
+
+import com.orientechnologies.common.exception.OException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class ONotThreadRWLockManager<T> implements OSimpleRWLockManager<T> {
+
+  private class LockGuard {
+    private int       count;
+    private Condition condition;
+    private boolean   shared;
+
+    public LockGuard(int count, Condition condition, boolean shared) {
+      this.count = count;
+      this.condition = condition;
+      this.shared = shared;
+    }
+  }
+
+  private final Lock              lock = new ReentrantLock();
+  private final Map<T, LockGuard> map  = new HashMap<>();
+
+  public ONotThreadRWLockManager() {
+  }
+
+  public void lock(T key, boolean shared, long timeout) {
+
+    lock.lock();
+    try {
+      try {
+
+        LockGuard c;
+        do {
+          c = map.get(key);
+          if (c != null) {
+            if (c.shared && shared) {
+              c.count++;
+              return;
+            } else {
+              if (timeout == 0) {
+                c.condition.await();
+              } else {
+                if (!c.condition.await(timeout, TimeUnit.MILLISECONDS)) {
+                  throw new OLockException(String.format("Time out acquire lock for resource: '%s' ", key));
+                }
+              }
+            }
+          }
+        } while (c != null);
+        c = new LockGuard(1, lock.newCondition(), shared);
+        map.put(key, c);
+      } catch (InterruptedException e) {
+        throw OException.wrapException(new OInterruptedException("Interrupted Lock"), e);
+      }
+    } finally {
+      lock.unlock();
+    }
+
+  }
+
+  public void unlock(T key, boolean shared) {
+    lock.lock();
+    try {
+      LockGuard c = map.get(key);
+      assert c != null;
+      if (c.shared != shared) {
+        throw new OLockException("Impossible to release a not acquired lock");
+      }
+      c.count--;
+      if (c.count == 0) {
+        map.remove(key);
+        c.condition.signalAll();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void acquireReadLock(T key, long timeout) {
+    lock(key, true, timeout);
+  }
+
+  @Override
+  public void acquireWriteLock(T key, long timeout) {
+    lock(key, false, timeout);
+  }
+
+  @Override
+  public void releaseReadLock(T key) {
+    unlock(key, true);
+  }
+
+  @Override
+  public void releaseWriteLock(T key) {
+    unlock(key, false);
+  }
+
+}

--- a/core/src/main/java/com/orientechnologies/common/concur/lock/OSimpleRWLockManager.java
+++ b/core/src/main/java/com/orientechnologies/common/concur/lock/OSimpleRWLockManager.java
@@ -1,0 +1,13 @@
+package com.orientechnologies.common.concur.lock;
+
+public interface OSimpleRWLockManager<T> {
+
+  void acquireReadLock(T key, long timeout);
+
+  void acquireWriteLock(T key, long timeout);
+
+  void releaseReadLock(T key);
+
+  void releaseWriteLock(T key);
+
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/config/OGlobalConfiguration.java
@@ -26,6 +26,7 @@ import com.orientechnologies.common.util.OApi;
 import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.cache.ORecordCacheWeakRefs;
+import com.orientechnologies.orient.core.db.OrientDBConfig;
 import com.orientechnologies.orient.core.engine.local.OEngineLocalPaginated;
 import com.orientechnologies.orient.core.index.OIndexDefinition;
 import com.orientechnologies.orient.core.metadata.OMetadataDefault;
@@ -226,7 +227,9 @@ public enum OGlobalConfiguration {
       + "on the given TCP/IP port. Used for internal testing purposes only. Never touch it if you don't know what you doing.",
       Integer.class, null),
 
-  STORAGE_PESSIMISTIC_LOCKING("storage.pessimisticLock", "Enable/Disable pessimistic locking feature", Boolean.class, false),
+  STORAGE_PESSIMISTIC_LOCKING("storage.pessimisticLock",
+      "Set the approach of the pessimistic locking, valid options: none, modification, readwrite", String.class,
+      OrientDBConfig.LOCK_TYPE_MODIFICATION),
 
   USE_WAL("storage.useWAL", "Whether WAL should be used in paginated storage", Boolean.class, true),
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/ODatabase.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/ODatabase.java
@@ -20,6 +20,7 @@
 package com.orientechnologies.orient.core.db;
 
 import com.orientechnologies.common.concur.ONeedRetryException;
+import com.orientechnologies.common.concur.lock.OLockException;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
 import com.orientechnologies.orient.core.command.OCommandRequest;
@@ -50,11 +51,13 @@ import com.orientechnologies.orient.core.util.OBackupable;
 
 import java.io.Closeable;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
  * Generic Database interface. Represents the lower level of the Database providing raw API to access to the raw records.<br>
- * Limits: <ul> <li>Maximum records per cluster/class = <b>9.223.372.036 Billions</b>: 2^63 = 9.223.372.036.854.775.808 records</li>
+ * Limits: <ul> <li>Maximum records per cluster/class = <b>9.223.372.036 Billions</b>: 2^63 = 9.223.372.036.854.775.808
+ * records</li>
  * <li>Maximum records per database = <b>302.231.454.903.657 Billions</b>: 2^15 clusters x 2^63 records = (2^78) 32.768 *
  * 9,223.372.036.854.775.808 = 302.231,454.903.657.293.676.544 records</li> <li>Maximum storage per database =
  * <b>19.807.040.628.566.084 Terabytes</b>: 2^31 data-segments x 2^63 bytes = (2^94) 2.147.483.648 x 9,223.372.036.854.775.808
@@ -581,34 +584,40 @@ public interface ODatabase<T> extends OBackupable, Closeable {
   <RET extends T> RET load(T iObject, String iFetchPlan);
 
   /**
-   * Loads a record using a fetch plan.
+   * Pessimistic lock a record.
+   * <p>
+   * In case of lock inside the transaction the lock will be release by the commit operation, In case of lock outside a transaction
+   * unlock need to be call manually.
    *
-   * @param iObject          Record to load
-   * @param iFetchPlan       Fetch plan used
-   * @param iLockingStrategy
+   * @param recordId the id of the record that need to be locked
    *
-   * @return The record received
+   * @return the record updated to the last state after the lock.
    *
-   * @deprecated Usage of this method may lead to deadlocks.
+   * @throws OLockException In case of deadlock detected
    */
-  @Deprecated
-  <RET extends T> RET load(T iObject, String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy);
+  <RET extends T> RET lock(ORID recordId) throws OLockException;
 
   /**
-   * Loads a record using a fetch plan.
+   * Pessimistic lock a record.
    *
-   * @param iObject          Record to load
-   * @param iFetchPlan       Fetch plan used
-   * @param iLockingStrategy
+   * @param recordId    the id of the record that need to be locked
+   * @param timeout     for the record locking
+   * @param timeoutUnit relative for the timeout
    *
-   * @return The record received
+   * @return the record updated to the last state after the lock.
    *
-   * @deprecated Usage of this method may lead to deadlocks.
+   * @throws OLockException In case of deadlock detected
    */
-  @Deprecated
-  <RET extends T> RET load(T iObject, String iFetchPlan, boolean iIgnoreCache, boolean iUpdateCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy);
+  <RET extends T> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException;
+
+  /**
+   * Pessimistic unlock
+   *
+   * @param recordId the id of the record to unlock
+   *
+   * @throws OLockException if the record  is not locked.
+   */
+  void unlock(ORID recordId) throws OLockException;
 
   /**
    * Loads a record using a fetch plan.
@@ -674,20 +683,6 @@ public interface ODatabase<T> extends OBackupable, Closeable {
    * @return The loaded entity
    */
   <RET extends T> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache);
-
-  @Deprecated
-  /**
-   * @deprecated Usage of this method may lead to deadlocks.
-   */
-  <RET extends T> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy);
-
-  @Deprecated
-  /**
-   * @deprecated Usage of this method may lead to deadlocks.
-   */
-  <RET extends T> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache, boolean iUpdateCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy);
 
   /**
    * Saves an entity in synchronous mode. If the entity is not dirty, then the operation will be ignored. For custom entity

--- a/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
@@ -257,4 +257,8 @@ public interface ODatabaseDocumentInternal extends ODatabaseSession, ODatabaseIn
   }
 
   OView getViewFromCluster(int cluster);
+
+  void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy);
+
+  void internalUnlockRecord(OIdentifiable iRecord);
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/ODatabaseDocumentInternal.java
@@ -40,8 +40,10 @@ import com.orientechnologies.orient.core.storage.ORecordCallback;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.OSBTreeCollectionManager;
 import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionAbstract;
 import com.orientechnologies.orient.core.tx.OTransactionInternal;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public interface ODatabaseDocumentInternal extends ODatabaseSession, ODatabaseInternal<ORecord> {
@@ -119,7 +121,7 @@ public interface ODatabaseDocumentInternal extends ODatabaseSession, ODatabaseIn
   void executeDeleteRecord(OIdentifiable record, final int iVersion, final boolean iRequired, final OPERATION_MODE iMode,
       boolean prohibitTombstones);
 
-  void setDefaultTransactionMode();
+  void setDefaultTransactionMode(Map<ORID, OTransactionAbstract.LockedRecordMetadata> noTxLocks);
 
   @Override
   OMetadataInternal getMetadata();

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBConfig.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBConfig.java
@@ -29,11 +29,14 @@ import com.orientechnologies.orient.core.db.ODatabase.ATTRIBUTES;
  */
 public class OrientDBConfig {
 
-  private OrientDBConfig          parent;
-  private OContextConfiguration   configurations;
-  private Map<ATTRIBUTES, Object> attributes;
-  private Set<ODatabaseListener>  listeners;
-  private ClassLoader             classLoader;
+  public static final String                  LOCK_TYPE_MODIFICATION = "modification";
+  public static final String                  LOCK_TYPE_READWRITE    = "readwrite";
+
+  private             OrientDBConfig          parent;
+  private             OContextConfiguration   configurations;
+  private             Map<ATTRIBUTES, Object> attributes;
+  private             Set<ODatabaseListener>  listeners;
+  private             ClassLoader             classLoader;
 
   protected OrientDBConfig() {
     configurations = new OContextConfiguration();

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
@@ -1078,25 +1078,6 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
     return (RET) currentTx.loadRecord(iRecord.getIdentity(), iRecord, iFetchPlan, false, false, OStorage.LOCKING_STRATEGY.DEFAULT);
   }
 
-  @SuppressWarnings("unchecked")
-  @Override
-  @Deprecated
-  public <RET extends ORecord> RET load(ORecord iRecord, String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkIfActive();
-    return (RET) currentTx
-        .loadRecord(iRecord.getIdentity(), iRecord, iFetchPlan, iIgnoreCache, !iIgnoreCache, loadTombstone, iLockingStrategy);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  @Deprecated
-  public <RET extends ORecord> RET load(final ORecord iRecord, final String iFetchPlan, final boolean iIgnoreCache,
-      final boolean iUpdateCache, final boolean loadTombstone, final OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkIfActive();
-    return (RET) currentTx
-        .loadRecord(iRecord.getIdentity(), iRecord, iFetchPlan, iIgnoreCache, iUpdateCache, loadTombstone, iLockingStrategy);
-  }
 
   @SuppressWarnings("unchecked")
   @Override
@@ -1123,24 +1104,6 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
       boolean ignoreCache) throws ORecordNotFoundException {
     checkIfActive();
     return (RET) currentTx.loadRecordIfVersionIsNotLatest(rid, recordVersion, fetchPlan, ignoreCache);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  @Deprecated
-  public <RET extends ORecord> RET load(final ORID iRecordId, String iFetchPlan, final boolean iIgnoreCache,
-      final boolean loadTombstone, OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkIfActive();
-    return (RET) currentTx.loadRecord(iRecordId, null, iFetchPlan, iIgnoreCache, loadTombstone, iLockingStrategy);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  @Deprecated
-  public <RET extends ORecord> RET load(final ORID iRecordId, String iFetchPlan, final boolean iIgnoreCache,
-      final boolean iUpdateCache, final boolean loadTombstone, OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkIfActive();
-    return (RET) currentTx.loadRecord(iRecordId, null, iFetchPlan, iIgnoreCache, iUpdateCache, loadTombstone, iLockingStrategy);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentAbstract.java
@@ -1078,7 +1078,6 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
     return (RET) currentTx.loadRecord(iRecord.getIdentity(), iRecord, iFetchPlan, false, false, OStorage.LOCKING_STRATEGY.DEFAULT);
   }
 
-
   @SuppressWarnings("unchecked")
   @Override
   public <RET extends ORecord> RET load(final ORecord iRecord) {
@@ -2607,6 +2606,16 @@ public abstract class ODatabaseDocumentAbstract extends OListenerManger<ODatabas
 
   public OView getViewFromCluster(int cluster) {
     return getMetadata().getImmutableSchemaSnapshot().getViewByClusterId(cluster);
+  }
+
+  protected void pessimisticLockChecks(ORID recordId) {
+    ORecord record = getTransaction().getRecord(recordId);
+    if (record != null && record.isDirty()) {
+      throw new ODatabaseException("Impossible to lock a record modified in transaction");
+    }
+    if (!recordId.isPersistent()) {
+      throw new ODatabaseException("Impossible to lock an not persistent record");
+    }
   }
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
@@ -20,6 +20,7 @@
 
 package com.orientechnologies.orient.core.db.document;
 
+import com.orientechnologies.common.concur.lock.OLockException;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
@@ -1199,7 +1200,6 @@ public class ODatabaseDocumentEmbedded extends ODatabaseDocumentAbstract impleme
     }
   }
 
-
   @Override
   public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy) {
 
@@ -1232,16 +1232,27 @@ public class ODatabaseDocumentEmbedded extends ODatabaseDocumentAbstract impleme
 
   @Override
   public <RET extends ORecord> RET lock(ORID recordId) throws OLockException {
-    return null;
+    checkOpenness();
+    checkIfActive();
+    pessimisticLockChecks(recordId);
+    internalLockRecord(recordId, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
+    return load(recordId, null, true);
   }
 
   @Override
   public <RET extends ORecord> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException {
-    return null;
+    checkOpenness();
+    checkIfActive();
+    pessimisticLockChecks(recordId);
+    //TODO: add support for customizable timeout
+    internalLockRecord(recordId, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
+    return load(recordId, null, true);
   }
 
   @Override
   public void unlock(ORID recordId) throws OLockException {
-
+    checkOpenness();
+    checkIfActive();
+    internalUnlockRecord(recordId);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
@@ -1202,14 +1202,17 @@ public class ODatabaseDocumentEmbedded extends ODatabaseDocumentAbstract impleme
 
   @Override
   public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy) {
+    internalLockRecord(iRecord, lockingStrategy, 0);
+  }
 
+  public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy, long timeout) {
     final ORID rid = new ORecordId(iRecord.getIdentity());
     OTransactionAbstract transaction = (OTransactionAbstract) getTransaction();
     if (!transaction.isLockedRecord(iRecord)) {
       if (lockingStrategy == OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK)
-        ((OAbstractPaginatedStorage) getStorage().getUnderlying()).acquireWriteLock(rid);
+        ((OAbstractPaginatedStorage) getStorage().getUnderlying()).acquireWriteLock(rid, timeout);
       else if (lockingStrategy == OStorage.LOCKING_STRATEGY.SHARED_LOCK)
-        ((OAbstractPaginatedStorage) getStorage().getUnderlying()).acquireReadLock(rid);
+        ((OAbstractPaginatedStorage) getStorage().getUnderlying()).acquireReadLock(rid, timeout);
       else
         throw new IllegalStateException("Unsupported locking strategy " + lockingStrategy);
     }
@@ -1244,8 +1247,7 @@ public class ODatabaseDocumentEmbedded extends ODatabaseDocumentAbstract impleme
     checkOpenness();
     checkIfActive();
     pessimisticLockChecks(recordId);
-    //TODO: add support for customizable timeout
-    internalLockRecord(recordId, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
+    internalLockRecord(recordId, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK, timeoutUnit.toMillis(timeout));
     return load(recordId, null, true);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentEmbedded.java
@@ -78,6 +78,7 @@ import com.orientechnologies.orient.core.tx.OTransactionAbstract;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by tglman on 27/06/16.
@@ -1226,6 +1227,21 @@ public class ODatabaseDocumentEmbedded extends ODatabaseDocumentAbstract impleme
       ((OAbstractPaginatedStorage) getStorage().getUnderlying()).releaseWriteLock(rid);
     else if (strategy == OStorage.LOCKING_STRATEGY.SHARED_LOCK)
       ((OAbstractPaginatedStorage) getStorage().getUnderlying()).releaseReadLock(rid);
+
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId) throws OLockException {
+    return null;
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException {
+    return null;
+  }
+
+  @Override
+  public void unlock(ORID recordId) throws OLockException {
 
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -1,5 +1,6 @@
 package com.orientechnologies.orient.core.db.document;
 
+import com.orientechnologies.common.concur.lock.OLockException;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
@@ -61,6 +62,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.orientechnologies.orient.core.db.document.ODatabaseDocumentTxInternal.closeAllOnShutdown;
@@ -566,20 +568,6 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   }
 
   @Override
-  public <RET extends ORecord> RET load(ORecord iObject, String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkOpenness();
-    return internal.load(iObject, iFetchPlan, iIgnoreCache, loadTombstone, iLockingStrategy);
-  }
-
-  @Override
-  public <RET extends ORecord> RET load(ORecord iObject, String iFetchPlan, boolean iIgnoreCache, boolean iUpdateCache,
-      boolean loadTombstone, OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkOpenness();
-    return internal.load(iObject, iFetchPlan, iIgnoreCache, iUpdateCache, loadTombstone, iLockingStrategy);
-  }
-
-  @Override
   public <RET extends ORecord> RET load(ORecord iObject, String iFetchPlan, boolean iIgnoreCache) {
     checkOpenness();
     return internal.load(iObject, iFetchPlan, iIgnoreCache);
@@ -613,20 +601,6 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   public <RET extends ORecord> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache) {
     checkOpenness();
     return internal.load(iRecordId, iFetchPlan, iIgnoreCache);
-  }
-
-  @Override
-  public <RET extends ORecord> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone,
-      OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkOpenness();
-    return internal.load(iRecordId, iFetchPlan, iIgnoreCache, loadTombstone, iLockingStrategy);
-  }
-
-  @Override
-  public <RET extends ORecord> RET load(ORID iRecordId, String iFetchPlan, boolean iIgnoreCache, boolean iUpdateCache,
-      boolean loadTombstone, OStorage.LOCKING_STRATEGY iLockingStrategy) {
-    checkOpenness();
-    return internal.load(iRecordId, iFetchPlan, iIgnoreCache, iUpdateCache, loadTombstone, iLockingStrategy);
   }
 
   @Override
@@ -1560,5 +1534,23 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   @Override
   public void internalUnlockRecord(OIdentifiable iRecord) {
     internal.internalUnlockRecord(iRecord);
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId) throws OLockException {
+    checkOpenness();
+    return internal.lock(recordId);
+  }
+
+  @Override
+  public <RET extends ORecord> RET lock(ORID recordId, long timeout, TimeUnit timeoutUnit) throws OLockException {
+    checkOpenness();
+    return internal.lock(recordId, timeout, timeoutUnit);
+  }
+
+  @Override
+  public void unlock(ORID recordId) throws OLockException {
+    checkOpenness();
+    internal.unlock(recordId);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -48,6 +48,7 @@ import com.orientechnologies.orient.core.storage.ORecordMetadata;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.ridbag.sbtree.OSBTreeCollectionManager;
 import com.orientechnologies.orient.core.tx.OTransaction;
+import com.orientechnologies.orient.core.tx.OTransactionAbstract;
 import com.orientechnologies.orient.core.tx.OTransactionInternal;
 import com.orientechnologies.orient.core.util.OURLConnection;
 import com.orientechnologies.orient.core.util.OURLHelper;
@@ -263,9 +264,9 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   }
 
   @Override
-  public void setDefaultTransactionMode() {
+  public void setDefaultTransactionMode(Map<ORID, OTransactionAbstract.LockedRecordMetadata> noTxLocks) {
     checkOpenness();
-    internal.setDefaultTransactionMode();
+    internal.setDefaultTransactionMode(noTxLocks);
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -75,23 +75,23 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   protected static ConcurrentMap<String, OrientDBInternal> embedded = new ConcurrentHashMap<>();
   protected static ConcurrentMap<String, OrientDBInternal> remote   = new ConcurrentHashMap<>();
 
-  protected     ODatabaseDocumentInternal internal;
-  private final String                    url;
-  private       OrientDBInternal          factory;
-  private final String                    type;
-  private final String                    dbName;
-  private final String                    baseUrl;
-  private final Map<String, Object>     preopenProperties = new HashMap<>();
-  private final Map<ATTRIBUTES, Object> preopenAttributes = new HashMap<>();
+  protected       ODatabaseDocumentInternal internal;
+  private final   String                    url;
+  private         OrientDBInternal          factory;
+  private final   String                    type;
+  private final   String                    dbName;
+  private final   String                    baseUrl;
+  private final   Map<String, Object>       preopenProperties = new HashMap<>();
+  private final   Map<ATTRIBUTES, Object>   preopenAttributes = new HashMap<>();
   // TODO review for the case of browseListener before open.
-  private final Set<ODatabaseListener>  preopenListener   = new HashSet<>();
-  private ODatabaseInternal<?>    databaseOwner;
-  private OIntent                 intent;
-  private OStorage                delegateStorage;
-  private ORecordConflictStrategy conflictStrategy;
-  private ORecordSerializer       serializer;
-  protected final AtomicReference<Thread> owner = new AtomicReference<Thread>();
-  private final boolean ownerProtection;
+  private final   Set<ODatabaseListener>    preopenListener   = new HashSet<>();
+  private         ODatabaseInternal<?>      databaseOwner;
+  private         OIntent                   intent;
+  private         OStorage                  delegateStorage;
+  private         ORecordConflictStrategy   conflictStrategy;
+  private         ORecordSerializer         serializer;
+  protected final AtomicReference<Thread>   owner             = new AtomicReference<Thread>();
+  private final   boolean                   ownerProtection;
 
   private static OShutdownHandler shutdownHandler = new OShutdownHandler() {
     @Override
@@ -1549,5 +1549,15 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
   @Override
   public OView getViewFromCluster(int cluster) {
     return internal.getViewFromCluster(cluster);
+  }
+
+  @Override
+  public void internalLockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY lockingStrategy) {
+    internal.internalLockRecord(iRecord, lockingStrategy);
+  }
+
+  @Override
+  public void internalUnlockRecord(OIdentifiable iRecord) {
+    internal.internalUnlockRecord(iRecord);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/iterator/OIdentifiableIterator.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/iterator/OIdentifiableIterator.java
@@ -283,9 +283,9 @@ public abstract class OIdentifiableIterator<REC extends OIdentifiable> implement
       try {
         if (iRecord != null) {
           ORecordInternal.setIdentity(iRecord, new ORecordId(current.getClusterId(), current.getClusterPosition()));
-          iRecord = database.load(iRecord, fetchPlan, false, true, lockingStrategy);
+          iRecord = database.load(iRecord, fetchPlan, false);
         } else
-          iRecord = database.load(current, fetchPlan, false, true, lockingStrategy);
+          iRecord = database.load(current, fetchPlan, false);
       } catch (ODatabaseException e) {
         if (Thread.interrupted() || database.isClosed())
           // THREAD INTERRUPTED: RETURN

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -941,21 +941,6 @@ public class ODocument extends ORecordAbstract
     return (ODocument) result;
   }
 
-  @Deprecated
-  public ODocument load(final String iFetchPlan, boolean iIgnoreCache, boolean loadTombstone) {
-    Object result;
-    try {
-      result = getDatabase().load(this, iFetchPlan, iIgnoreCache, loadTombstone, OStorage.LOCKING_STRATEGY.DEFAULT);
-    } catch (Exception e) {
-      throw OException.wrapException(new ORecordNotFoundException(getIdentity()), e);
-    }
-
-    if (result == null)
-      throw new ORecordNotFoundException(getIdentity());
-
-    return (ODocument) result;
-  }
-
   @Override
   public ODocument reload(final String fetchPlan, final boolean ignoreCache) {
     super.reload(fetchPlan, ignoreCache);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OMicroTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OMicroTransaction.java
@@ -732,4 +732,8 @@ public final class OMicroTransaction implements OBasicTransaction, OTransactionI
   public ORecordOperation getRecordEntry(ORID currentRid) {
     return recordOperations.get(currentRid);
   }
+
+  public Set<ORID> getLockedRecords() {
+    return null;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransaction.java
@@ -141,16 +141,15 @@ public interface OTransaction extends OBasicTransaction {
 
   boolean isLockedRecord(OIdentifiable iRecord);
 
+  @Deprecated
   OStorage.LOCKING_STRATEGY lockingStrategy(OIdentifiable iRecord);
 
+  @Deprecated
   OTransaction lockRecord(OIdentifiable iRecord, OStorage.LOCKING_STRATEGY iLockingStrategy);
 
+  @Deprecated
   OTransaction unlockRecord(OIdentifiable iRecord);
 
-  HashMap<ORID, OStorage.LOCKING_STRATEGY> getLockedRecords();
-
   int getEntryCount();
-
-  boolean hasRecordCreation();
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -33,6 +33,7 @@ import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedSt
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class OTransactionAbstract implements OTransaction {
   protected final ODatabaseDocumentInternal       database;
@@ -106,13 +107,9 @@ public abstract class OTransactionAbstract implements OTransaction {
         final LockedRecordMetadata lockedRecordMetadata = lock.getValue();
 
         if (lockedRecordMetadata.strategy.equals(OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK)) {
-          for (int i = 0; i < lockedRecordMetadata.locksCount; i++) {
-            ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseWriteLock(lock.getKey());
-          }
+          ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseWriteLock(lock.getKey());
         } else if (lockedRecordMetadata.strategy.equals(OStorage.LOCKING_STRATEGY.SHARED_LOCK)) {
-          for (int i = 0; i < lockedRecordMetadata.locksCount; i++) {
-            ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseReadLock(lock.getKey());
-          }
+          ((OAbstractPaginatedStorage) getDatabase().getStorage().getUnderlying()).releaseReadLock(lock.getKey());
         }
       } catch (Exception e) {
         OLogManager.instance().debug(this, "Error on releasing lock against record " + lock.getKey(), e);
@@ -195,5 +192,9 @@ public abstract class OTransactionAbstract implements OTransaction {
 
   protected void setLocks(Map<ORID, LockedRecordMetadata> locks) {
     this.locks = locks;
+  }
+
+  public Set<ORID> getLockedRecords() {
+    return locks.keySet();
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -35,12 +35,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class OTransactionAbstract implements OTransaction {
-  protected final ODatabaseDocumentInternal           database;
-  protected       TXSTATUS                            status         = TXSTATUS.INVALID;
-  protected       ISOLATION_LEVEL                     isolationLevel = ISOLATION_LEVEL.READ_COMMITTED;
-  protected       HashMap<ORID, LockedRecordMetadata> locks          = new HashMap<ORID, LockedRecordMetadata>();
+  protected final ODatabaseDocumentInternal       database;
+  protected       TXSTATUS                        status         = TXSTATUS.INVALID;
+  protected       ISOLATION_LEVEL                 isolationLevel = ISOLATION_LEVEL.READ_COMMITTED;
+  protected       Map<ORID, LockedRecordMetadata> locks          = new HashMap<ORID, LockedRecordMetadata>();
 
-  private static final class LockedRecordMetadata {
+  public static final class LockedRecordMetadata {
     private final OStorage.LOCKING_STRATEGY strategy;
     private       int                       locksCount;
 
@@ -199,5 +199,13 @@ public abstract class OTransactionAbstract implements OTransaction {
       throw new OLockException("Cannot unlock a never acquired lock");
     }
     return null;
+  }
+
+  public Map<ORID, LockedRecordMetadata> getInternalLocks() {
+    return locks;
+  }
+
+  protected void setLocks(Map<ORID, LockedRecordMetadata> locks) {
+    this.locks = locks;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -23,16 +23,10 @@ import com.orientechnologies.common.concur.lock.OLockException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.cache.OLocalRecordCache;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
-import com.orientechnologies.orient.core.exception.OSchemaException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
-import com.orientechnologies.orient.core.metadata.schema.OClass;
-import com.orientechnologies.orient.core.record.ORecord;
-import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.storage.OStorageProxy;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
@@ -129,37 +123,7 @@ public abstract class OTransactionAbstract implements OTransaction {
 
   @Override
   public OTransaction lockRecord(final OIdentifiable iRecord, final OStorage.LOCKING_STRATEGY lockingStrategy) {
-    final OStorage stg = database.getStorage();
-    if (!(stg.getUnderlying() instanceof OAbstractPaginatedStorage))
-      throw new OLockException("Cannot lock record across remote connections");
-
-    final ORID rid = new ORecordId(iRecord.getIdentity());
-
-    LockedRecordMetadata lockedRecordMetadata = locks.get(rid);
-    boolean addItem = false;
-
-    if (lockedRecordMetadata == null) {
-      lockedRecordMetadata = new LockedRecordMetadata(lockingStrategy);
-      addItem = true;
-    } else if (lockedRecordMetadata.strategy != lockingStrategy) {
-      assert lockedRecordMetadata.locksCount == 0;
-      lockedRecordMetadata = new LockedRecordMetadata(lockingStrategy);
-      addItem = true;
-    }
-
-    if (lockingStrategy == OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK)
-      ((OAbstractPaginatedStorage) stg.getUnderlying()).acquireWriteLock(rid);
-    else if (lockingStrategy == OStorage.LOCKING_STRATEGY.SHARED_LOCK)
-      ((OAbstractPaginatedStorage) stg.getUnderlying()).acquireReadLock(rid);
-    else
-      throw new IllegalStateException("Unsupported locking strategy " + lockingStrategy);
-
-    lockedRecordMetadata.locksCount++;
-
-    if (addItem) {
-      locks.put(rid, lockedRecordMetadata);
-    }
-
+    database.internalLockRecord(iRecord, lockingStrategy);
     return this;
   }
 
@@ -187,28 +151,7 @@ public abstract class OTransactionAbstract implements OTransaction {
 
   @Override
   public OTransaction unlockRecord(final OIdentifiable iRecord) {
-    final OStorage stg = database.getStorage();
-    if (!(stg.getUnderlying() instanceof OAbstractPaginatedStorage))
-      throw new OLockException("Cannot lock record across remote connections");
-
-    final ORID rid = iRecord.getIdentity();
-
-    final LockedRecordMetadata lockedRecordMetadata = locks.get(rid);
-
-    if (lockedRecordMetadata == null || lockedRecordMetadata.locksCount == 0)
-      throw new OLockException("Cannot unlock a never acquired lock");
-    else if (lockedRecordMetadata.strategy == OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK)
-      ((OAbstractPaginatedStorage) stg.getUnderlying()).releaseWriteLock(rid);
-    else if (lockedRecordMetadata.strategy == OStorage.LOCKING_STRATEGY.SHARED_LOCK)
-      ((OAbstractPaginatedStorage) stg.getUnderlying()).releaseReadLock(rid);
-    else
-      throw new IllegalStateException("Unsupported locking strategy " + lockedRecordMetadata.strategy);
-
-    lockedRecordMetadata.locksCount--;
-
-    if (lockedRecordMetadata.locksCount == 0)
-      locks.remove(rid);
-
+    database.internalUnlockRecord(iRecord);
     return this;
   }
 
@@ -226,4 +169,35 @@ public abstract class OTransactionAbstract implements OTransaction {
 
   public abstract void internalRollback();
 
+  public void trackLockedRecord(ORID rid, OStorage.LOCKING_STRATEGY lockingStrategy) {
+    OTransactionAbstract.LockedRecordMetadata lockedRecordMetadata = locks.get(rid);
+    boolean addItem = false;
+
+    if (lockedRecordMetadata == null) {
+      lockedRecordMetadata = new OTransactionAbstract.LockedRecordMetadata(lockingStrategy);
+      addItem = true;
+    } else if (lockedRecordMetadata.strategy != lockingStrategy) {
+      assert lockedRecordMetadata.locksCount == 0;
+      lockedRecordMetadata = new OTransactionAbstract.LockedRecordMetadata(lockingStrategy);
+      addItem = true;
+    }
+    lockedRecordMetadata.locksCount++;
+    if (addItem) {
+      locks.put(rid, lockedRecordMetadata);
+    }
+  }
+
+  public OStorage.LOCKING_STRATEGY trackUnlockRecord(ORID rid) {
+    final LockedRecordMetadata lockedRecordMetadata = locks.get(rid);
+    if (lockedRecordMetadata != null && lockedRecordMetadata.locksCount > 0) {
+      lockedRecordMetadata.locksCount--;
+      if (lockedRecordMetadata.locksCount == 0) {
+        locks.remove(rid);
+        return lockedRecordMetadata.strategy;
+      }
+    } else {
+      throw new OLockException("Cannot unlock a never acquired lock");
+    }
+    return null;
+  }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionAbstract.java
@@ -155,18 +155,6 @@ public abstract class OTransactionAbstract implements OTransaction {
     return this;
   }
 
-  @Override
-  public HashMap<ORID, OStorage.LOCKING_STRATEGY> getLockedRecords() {
-    final HashMap<ORID, OStorage.LOCKING_STRATEGY> lockedRecords = new HashMap<ORID, OStorage.LOCKING_STRATEGY>();
-
-    for (Map.Entry<ORID, LockedRecordMetadata> entry : locks.entrySet()) {
-      if (entry.getValue().locksCount > 0)
-        lockedRecords.put(entry.getKey(), entry.getValue().strategy);
-    }
-
-    return lockedRecords;
-  }
-
   public abstract void internalRollback();
 
   public void trackLockedRecord(ORID rid, OStorage.LOCKING_STRATEGY lockingStrategy) {

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionInternal.java
@@ -26,6 +26,7 @@ import com.orientechnologies.orient.core.storage.OBasicTransaction;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Expose the api for extract the internal details needed by the storage for perform the transaction commit
@@ -84,5 +85,7 @@ public interface OTransactionInternal extends OBasicTransaction {
    * @return the change or null if there is no change for the specified rid
    */
   ORecordOperation getRecordEntry(ORID currentRid);
+
+  Set<ORID> getLockedRecords();
 
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
@@ -51,8 +51,11 @@ import java.util.*;
  * @author Luca Garulli (l.garulli--(at)--orientdb.com)
  */
 public class OTransactionNoTx extends OTransactionAbstract {
-  public OTransactionNoTx(final ODatabaseDocumentInternal iDatabase) {
+  public OTransactionNoTx(final ODatabaseDocumentInternal iDatabase, Map<ORID, LockedRecordMetadata> noTxLocks) {
     super(iDatabase);
+    if (noTxLocks != null) {
+      setLocks(noTxLocks);
+    }
   }
 
   public void begin() {

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionNoTx.java
@@ -70,11 +70,6 @@ public class OTransactionNoTx extends OTransactionAbstract {
   }
 
   @Override
-  public boolean hasRecordCreation() {
-    return false;
-  }
-
-  @Override
   public void commit(boolean force) {
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
@@ -25,6 +25,7 @@ import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.db.ODatabase.OPERATION_MODE;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.document.LatestVersionRecordReader;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.db.document.RecordReader;
 import com.orientechnologies.orient.core.db.document.SimpleRecordReader;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
@@ -46,6 +47,7 @@ import com.orientechnologies.orient.core.storage.OBasicTransaction;
 import com.orientechnologies.orient.core.storage.ORecordCallback;
 import com.orientechnologies.orient.core.storage.OStorage;
 
+import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -401,7 +403,7 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
       break;
       case ORecordOperation.LOADED:
         /**
-         * Read hooks already invoked in {@link com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx#executeReadRecord}
+         * Read hooks already invoked in {@link ODatabaseDocumentTx#executeReadRecord}
          */
         break;
       case ORecordOperation.UPDATED: {
@@ -476,7 +478,7 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
         case ORecordOperation.LOADED:
           /**
            * Read hooks already invoked in
-           * {@link com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx#executeReadRecord} .
+           * {@link ODatabaseDocumentTx#executeReadRecord} .
            */
           break;
         case ORecordOperation.UPDATED:

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
@@ -572,4 +572,5 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
   public boolean isAlreadyCleared() {
     return alreadyCleared;
   }
+
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -36,6 +36,7 @@ import com.orientechnologies.orient.core.record.ORecordInternal;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
 import com.orientechnologies.orient.core.storage.OBasicTransaction;
+import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChanges.OPERATION;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey.OTransactionIndexEntry;
 
@@ -43,19 +44,19 @@ import java.util.*;
 import java.util.Map.Entry;
 
 public abstract class OTransactionRealAbstract extends OTransactionAbstract implements OTransactionInternal {
-  protected Map<ORID, ORID>                                   updatedRids           = new HashMap<ORID, ORID>();
-  protected Map<ORID, ORecordOperation>                       allEntries            = new LinkedHashMap<ORID, ORecordOperation>();
-  protected Map<String, OTransactionIndexChanges>             indexEntries          = new LinkedHashMap<String, OTransactionIndexChanges>();
-  protected Map<ORID, List<OTransactionRecordIndexOperation>> recordIndexOperations = new HashMap<ORID, List<OTransactionRecordIndexOperation>>();
-  protected int id;
-  protected int                 newObjectCounter = -2;
-  protected Map<String, Object> userData         = new HashMap<String, Object>();
-
+  protected       Map<ORID, ORID>                                   updatedRids           = new HashMap<ORID, ORID>();
+  protected       Map<ORID, ORecordOperation>                       allEntries            = new LinkedHashMap<ORID, ORecordOperation>();
+  protected       Map<String, OTransactionIndexChanges>             indexEntries          = new LinkedHashMap<String, OTransactionIndexChanges>();
+  protected       Map<ORID, List<OTransactionRecordIndexOperation>> recordIndexOperations = new HashMap<ORID, List<OTransactionRecordIndexOperation>>();
+  protected       int                                               id;
+  protected       int                                               newObjectCounter      = -2;
+  protected       Map<String, Object>                               userData              = new HashMap<String, Object>();
+  private         Map<ORID, LockedRecordMetadata>                   noTxLocks;
   /**
    * This set is used to track which documents are changed during tx, if documents are changed but not saved all changes are made
    * during tx will be undone.
    */
-  protected final Set<ODocument> changedDocuments = new HashSet<ODocument>();
+  protected final Set<ODocument>                                    changedDocuments      = new HashSet<ODocument>();
 
   protected OTransactionRealAbstract(ODatabaseDocumentInternal database, int id) {
     super(database);
@@ -106,7 +107,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract impl
     newObjectCounter = -2;
     status = TXSTATUS.INVALID;
 
-    database.setDefaultTransactionMode();
+    database.setDefaultTransactionMode(getNoTxLocks());
 
     userData.clear();
   }
@@ -564,5 +565,13 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract impl
 
   public int getNewObjectCounter() {
     return newObjectCounter;
+  }
+
+  public void setNoTxLocks(Map<ORID, LockedRecordMetadata> noTxLocks) {
+    this.noTxLocks = noTxLocks;
+  }
+
+  public Map<ORID, LockedRecordMetadata> getNoTxLocks() {
+    return noTxLocks;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -62,16 +62,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract impl
     super(database);
     this.id = id;
   }
-
-  @Override
-  public boolean hasRecordCreation() {
-    for (ORecordOperation op : allEntries.values()) {
-      if (op.type == ORecordOperation.CREATED)
-        return true;
-    }
-    return false;
-  }
-
+  
   @Override
   public void addChangedDocument(ODocument document) {
     if (getRecord(document.getIdentity()) == null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -62,7 +62,7 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract impl
     super(database);
     this.id = id;
   }
-  
+
   @Override
   public void addChangedDocument(ODocument document) {
     if (getRecord(document.getIdentity()) == null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/type/ODocumentWrapper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/type/ODocumentWrapper.java
@@ -75,11 +75,6 @@ public class ODocumentWrapper implements Serializable {
     return (RET) this;
   }
 
-  public <RET extends ODocumentWrapper> RET load(final String iFetchPlan, final boolean iIgnoreCache, final boolean loadTombstone) {
-    document = document.load(iFetchPlan, iIgnoreCache, loadTombstone);
-    return (RET) this;
-  }
-
   public <RET extends ODocumentWrapper> RET reload() {
     document.reload();
     return (RET) this;

--- a/core/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryProtocol.java
+++ b/core/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinaryProtocol.java
@@ -59,7 +59,6 @@ public class OChannelBinaryProtocol {
   public static final byte REQUEST_RECORD_CREATE    = 31;
   public static final byte REQUEST_RECORD_UPDATE    = 32;
   public static final byte REQUEST_RECORD_DELETE    = 33;
-  public static final byte REQUEST_RECORD_COPY      = 34;                 // NOT USED ANYMORE
   public static final byte REQUEST_BATCH_OPERATIONS = 35;                // since 3.0
   public static final byte REQUEST_POSITIONS_HIGHER = 36;                 // since 1.3.0
   public static final byte REQUEST_POSITIONS_LOWER  = 37;                 // since 1.3.0

--- a/core/src/test/java/com/orientechnologies/common/concur/lock/SimpleRWNotThreadBoundTest.java
+++ b/core/src/test/java/com/orientechnologies/common/concur/lock/SimpleRWNotThreadBoundTest.java
@@ -1,0 +1,119 @@
+package com.orientechnologies.common.concur.lock;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class SimpleRWNotThreadBoundTest {
+
+  @Test
+  public void testWriteWaitRead() throws InterruptedException {
+
+    OSimpleRWLockManager<String> manager = new ONotThreadRWLockManager<>();
+    manager.acquireReadLock("aaa", 0);
+
+    CountDownLatch error = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireWriteLock("aaa", 10);
+      } catch (OLockException e) {
+        error.countDown();
+      }
+
+    }).start();
+
+    assertTrue(error.await(20, TimeUnit.MILLISECONDS));
+    manager.releaseReadLock("aaa");
+  }
+
+  @Test
+  public void testReadWaitWrite() throws InterruptedException {
+
+    OSimpleRWLockManager<String> manager = new ONotThreadRWLockManager<>();
+    manager.acquireWriteLock("aaa", 0);
+
+    CountDownLatch error = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireReadLock("aaa", 10);
+      } catch (OLockException e) {
+        error.countDown();
+      }
+
+    }).start();
+
+    assertTrue(error.await(20, TimeUnit.MILLISECONDS));
+
+    manager.releaseWriteLock("aaa");
+
+  }
+
+  @Test
+  public void testReadReleaseAcquireWrite() throws InterruptedException {
+
+    OSimpleRWLockManager<String> manager = new ONotThreadRWLockManager<>();
+    manager.acquireReadLock("aaa", 0);
+
+    CountDownLatch error = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireWriteLock("aaa", 10);
+      } catch (OLockException e) {
+        error.countDown();
+      }
+
+    }).start();
+
+    assertTrue(error.await(20, TimeUnit.MILLISECONDS));
+
+    CountDownLatch ok = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireWriteLock("aaa", 10);
+        ok.countDown();
+      } catch (OLockException e) {
+      }
+
+    }).start();
+
+    manager.releaseReadLock("aaa");
+
+    assertTrue(ok.await(20, TimeUnit.MILLISECONDS));
+
+  }
+
+  @Test
+  public void testReadReadWaitWrite() throws InterruptedException {
+
+    OSimpleRWLockManager<String> manager = new ONotThreadRWLockManager<>();
+    manager.acquireReadLock("aaa", 0);
+
+    CountDownLatch ok = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireReadLock("aaa", 10);
+        ok.countDown();
+      } catch (OLockException e) {
+      }
+
+    }).start();
+
+    CountDownLatch error = new CountDownLatch(1);
+    new Thread(() -> {
+      try {
+        manager.acquireWriteLock("aaa", 10);
+      } catch (OLockException e) {
+        error.countDown();
+      }
+
+    }).start();
+
+    assertTrue(ok.await(20, TimeUnit.MILLISECONDS));
+    assertTrue(error.await(20, TimeUnit.MILLISECONDS));
+    manager.releaseReadLock("aaa");
+  }
+
+}

--- a/core/src/test/java/com/orientechnologies/orient/core/db/document/ODatabasePessimisticLockTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/document/ODatabasePessimisticLockTest.java
@@ -25,7 +25,8 @@ public class ODatabasePessimisticLockTest {
 
   @Before
   public void before() {
-    OrientDBConfig config = OrientDBConfig.builder().addConfig(OGlobalConfiguration.STORAGE_PESSIMISTIC_LOCKING, true).build();
+    OrientDBConfig config = OrientDBConfig.builder()
+        .addConfig(OGlobalConfiguration.STORAGE_PESSIMISTIC_LOCKING, OrientDBConfig.LOCK_TYPE_READWRITE).build();
     orientDB = new OrientDB("embedded:", config);
     orientDB.create("test", ODatabaseType.MEMORY);
     ODatabaseSession session = orientDB.open("test", "admin", "admin");

--- a/core/src/test/java/com/orientechnologies/orient/core/db/document/OPessimisticLockTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/document/OPessimisticLockTest.java
@@ -1,39 +1,24 @@
-package com.orientechnologies.orient.server.lock;
+package com.orientechnologies.orient.core.db.document;
 
-import com.orientechnologies.common.io.OFileUtils;
-import com.orientechnologies.orient.core.Orient;
-import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.OrientDB;
 import com.orientechnologies.orient.core.db.OrientDBConfig;
-import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
+import com.orientechnologies.orient.core.record.OElement;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.storage.OStorage;
-import com.orientechnologies.orient.server.OServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.io.File;
 
 public class OPessimisticLockTest {
 
   private static final String            SERVER_DIRECTORY = "./target/lock";
-  private              OServer           server;
   private              OrientDB          orientDB;
   private              ODatabaseDocument session;
 
   @Before
   public void before() throws Exception {
-    OGlobalConfiguration.CLASS_MINIMUM_CLUSTERS.setValue(1);
-    server = new OServer(false);
-    server.setServerRootDirectory(SERVER_DIRECTORY);
-    server.startup(getClass().getClassLoader().getResourceAsStream("orientdb-server-config.xml"));
-    server.activate();
-
-    orientDB = new OrientDB("remote:localhost", "root", "root", OrientDBConfig.defaultConfig());
+    orientDB = new OrientDB("embedded:", OrientDBConfig.defaultConfig());
     orientDB.create(OPessimisticLockTest.class.getSimpleName(), ODatabaseType.MEMORY);
     session = orientDB.open(OPessimisticLockTest.class.getSimpleName(), "admin", "admin");
     session.createVertexClass("ToLock");
@@ -42,19 +27,17 @@ public class OPessimisticLockTest {
   @Test
   public void lockHappyPathNoCrashNoTx() {
     ORecord rid = session.save(new ODocument("ToLock"));
-    session.getTransaction().lockRecord(rid, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
-    ODocument record = session.load(rid);
+    OElement record = session.lock(rid.getIdentity());
     record.setProperty("one", "value");
     session.save(record);
-    session.getTransaction().unlockRecord(rid);
+    session.unlock(record.getIdentity());
   }
 
   @Test
   public void lockHappyPathNoCrashTx() {
     ORecord rid = session.save(new ODocument("ToLock"));
     session.begin();
-    session.getTransaction().lockRecord(rid, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
-    ODocument record = session.load(rid);
+    ODocument record = session.lock(rid.getIdentity());
     record.setProperty("one", "value");
     session.save(record);
     session.commit();
@@ -66,10 +49,5 @@ public class OPessimisticLockTest {
     session.close();
     orientDB.drop(OPessimisticLockTest.class.getSimpleName());
     orientDB.close();
-    server.shutdown();
-
-    Orient.instance().shutdown();
-    OFileUtils.deleteRecursively(new File(SERVER_DIRECTORY));
-    Orient.instance().startup();
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -55,7 +55,10 @@ import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import com.orientechnologies.orient.core.sql.parser.OLocalResultSetLifecycleDecorator;
 import com.orientechnologies.orient.core.sql.query.OSQLAsynchQuery;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import com.orientechnologies.orient.core.storage.*;
+import com.orientechnologies.orient.core.storage.OCluster;
+import com.orientechnologies.orient.core.storage.OPhysicalPosition;
+import com.orientechnologies.orient.core.storage.ORecordMetadata;
+import com.orientechnologies.orient.core.storage.OStorageProxy;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.OOfflineClusterException;
 import com.orientechnologies.orient.core.storage.index.sbtree.OTreeInternal;
 import com.orientechnologies.orient.core.storage.index.sbtreebonsai.local.OSBTreeBonsai;
@@ -80,6 +83,7 @@ import java.nio.charset.Charset;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
 
@@ -1401,8 +1405,10 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
 
   @Override
   public OBinaryResponse executeLockRecord(OLockRecordRequest request) {
-    connection.getDatabase().getTransaction().lockRecord(request.getIdentity(), request.getLockingStrategy());
-    return new OLockRecordResponse();
+    //TODO: support properly the locking strategies.
+    ORecord record = connection.getDatabase().lock(request.getIdentity(), request.getTimeout(), TimeUnit.MILLISECONDS);
+    byte[] bytes = getRecordBytes(connection, record);
+    return new OLockRecordResponse(ORecordInternal.getRecordType(record), record.getVersion(), bytes);
   }
 
   @Override

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -1399,4 +1399,16 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
   public OBinaryResponse executeExperimental(OExperimentalRequest request) {
     return new OExperimentalResponse(request.getRequest().execute(this));
   }
+
+  @Override
+  public OBinaryResponse executeLockRecord(OLockRecordRequest request) {
+    connection.getDatabase().getTransaction().lockRecord(request.getIdentity(), request.getLockingStrategy());
+    return new OLockRecordResponse();
+  }
+
+  @Override
+  public OBinaryResponse executeUnlockRecord(OUnlockRecordRequest request) {
+    connection.getDatabase().getTransaction().unlockRecord(request.getIdentity());
+    return new OUnlockRecordResponse();
+  }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -518,7 +518,7 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
   public OBinaryResponse executeCommand(OCommandRequest request) {
     OTransaction oldTx = connection.getDatabase().getTransaction();
     try {
-      connection.getDatabase().swapTx(new OTransactionNoTx(connection.getDatabase()));
+      connection.getDatabase().swapTx(new OTransactionNoTx(connection.getDatabase(), null));
 
       final boolean live = request.isLive();
       final boolean asynch = request.isAsynch();

--- a/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OConnectionBinaryExecutor.java
@@ -269,8 +269,7 @@ public final class OConnectionBinaryExecutor implements OBinaryRequestExecutor {
       response = new OReadRecordResponse(OBlob.RECORD_TYPE, 0, record, new HashSet<>());
 
     } else {
-      final ORecord record = connection.getDatabase()
-          .load(rid, fetchPlanString, ignoreCache, loadTombstones, OStorage.LOCKING_STRATEGY.NONE);
+      final ORecord record = connection.getDatabase().load(rid, fetchPlanString, ignoreCache);
       if (record != null) {
         byte[] bytes = getRecordBytes(connection, record);
         final Set<ORecord> recordsToSend = new HashSet<ORecord>();

--- a/server/src/test/java/com/orientechnologies/orient/server/lock/OPessimisticLockTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/lock/OPessimisticLockTest.java
@@ -40,7 +40,6 @@ public class OPessimisticLockTest {
   }
 
   @Test
-  @Ignore
   public void lockHappyPathNoCrashNoTx() {
     ORecord rid = session.save(new ODocument("ToLock"));
     session.getTransaction().lockRecord(rid, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);

--- a/server/src/test/java/com/orientechnologies/orient/server/lock/OPessimisticLockTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/server/lock/OPessimisticLockTest.java
@@ -1,0 +1,76 @@
+package com.orientechnologies.orient.server.lock;
+
+import com.orientechnologies.common.io.OFileUtils;
+import com.orientechnologies.orient.core.Orient;
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import com.orientechnologies.orient.core.db.ODatabaseType;
+import com.orientechnologies.orient.core.db.OrientDB;
+import com.orientechnologies.orient.core.db.OrientDBConfig;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
+import com.orientechnologies.orient.core.record.ORecord;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.storage.OStorage;
+import com.orientechnologies.orient.server.OServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+
+public class OPessimisticLockTest {
+
+  private static final String            SERVER_DIRECTORY = "./target/lock";
+  private              OServer           server;
+  private              OrientDB          orientDB;
+  private              ODatabaseDocument session;
+
+  @Before
+  public void before() throws Exception {
+    OGlobalConfiguration.CLASS_MINIMUM_CLUSTERS.setValue(1);
+    server = new OServer(false);
+    server.setServerRootDirectory(SERVER_DIRECTORY);
+    server.startup(getClass().getClassLoader().getResourceAsStream("orientdb-server-config.xml"));
+    server.activate();
+
+    orientDB = new OrientDB("remote:localhost", "root", "root", OrientDBConfig.defaultConfig());
+    orientDB.create(OPessimisticLockTest.class.getSimpleName(), ODatabaseType.MEMORY);
+    session = orientDB.open(OPessimisticLockTest.class.getSimpleName(), "admin", "admin");
+    session.createVertexClass("ToLock");
+  }
+
+  @Test
+  @Ignore
+  public void lockHappyPathNoCrashNoTx() {
+    ORecord rid = session.save(new ODocument("ToLock"));
+    session.getTransaction().lockRecord(rid, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
+    ODocument record = session.load(rid);
+    record.setProperty("one", "value");
+    session.save(record);
+    session.getTransaction().unlockRecord(rid);
+  }
+
+  @Test
+  public void lockHappyPathNoCrashTx() {
+    ORecord rid = session.save(new ODocument("ToLock"));
+    session.begin();
+    session.getTransaction().lockRecord(rid, OStorage.LOCKING_STRATEGY.EXCLUSIVE_LOCK);
+    ODocument record = session.load(rid);
+    record.setProperty("one", "value");
+    session.save(record);
+    session.commit();
+
+  }
+
+  @After
+  public void after() {
+    session.close();
+    orientDB.drop(OPessimisticLockTest.class.getSimpleName());
+    orientDB.close();
+    server.shutdown();
+
+    Orient.instance().shutdown();
+    OFileUtils.deleteRecursively(new File(SERVER_DIRECTORY));
+    Orient.instance().startup();
+  }
+}

--- a/server/src/test/resources/orientdb-server-config.xml
+++ b/server/src/test/resources/orientdb-server-config.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<orient-server>
+    <handlers>
+        <handler class="com.orientechnologies.orient.server.handler.OJMXPlugin">
+            <parameters>
+                <parameter value="true" name="enabled"/>
+                <parameter value="true" name="profilerManaged"/>
+            </parameters>
+        </handler>
+        <handler class="com.orientechnologies.orient.server.handler.OAutomaticBackup">
+            <parameters>
+                <!-- CAN BE: FULL_BACKUP, INCREMENTAL_BACKUP, EXPORT -->
+                <parameter name="mode" value="FULL_BACKUP"/>
+                <!-- OPTION FOR EXPORT -->
+                <parameter name="exportOptions" value=""/>
+                <parameter value="false" name="enabled"/>
+                <parameter value="4h" name="delay"/>
+                <parameter value="backup" name="target.directory"/>
+                <parameter value="${DBNAME}-${DATE:yyyyMMddHHmmss}.zip" name="target.fileName"/>
+                <!-- DEFAULT: NO ONE, THAT MEANS ALL DATABASES. USE COMMA TO SEPARATE MULTIPLE DATABASE NAMES -->
+                <parameter value="" name="db.include"/>
+                <!-- DEFAULT: NO ONE, THAT MEANS ALL DATABASES. USE COMMA TO SEPARATE MULTIPLE DATABASE NAMES -->
+                <parameter value="" name="db.exclude"/>
+            </parameters>
+        </handler>
+        <handler class="com.orientechnologies.orient.server.handler.OServerSideScriptInterpreter">
+            <parameters>
+                <parameter value="true" name="enabled"/>
+                <parameter value="SQL" name="allowedLanguages"/>
+            </parameters>
+        </handler>
+    </handlers>
+    <network>
+        <protocols>
+            <protocol
+                    implementation="com.orientechnologies.orient.server.network.protocol.binary.ONetworkProtocolBinary"
+                    name="binary"/>
+            <protocol implementation="com.orientechnologies.orient.server.network.protocol.http.ONetworkProtocolHttpDb"
+                      name="http"/>
+        </protocols>
+        <listeners>
+            <listener protocol="binary" port-range="2424-2430" ip-address="0.0.0.0"/>
+            <listener protocol="http" port-range="2480-2490" ip-address="0.0.0.0">
+                <commands>
+                    <command
+                            implementation="com.orientechnologies.orient.server.network.protocol.http.command.get.OServerCommandGetStaticContent"
+                            pattern="GET|www GET|studio/ GET| GET|*.htm GET|*.html GET|*.xml GET|*.jpeg GET|*.jpg GET|*.png GET|*.gif GET|*.js GET|*.css GET|*.swf GET|*.ico GET|*.txt GET|*.otf GET|*.pjs GET|*.svg">
+                        <parameters>
+                            <entry value="Cache-Control: no-cache, no-store, max-age=0, must-revalidate\r\nPragma: no-cache"
+                                   name="http.cache:*.htm *.html"/>
+                            <entry value="Cache-Control: max-age=120" name="http.cache:default"/>
+                        </parameters>
+                    </command>
+                </commands>
+                <parameters>
+                    <parameter value="utf-8" name="network.http.charset"/>
+                </parameters>
+            </listener>
+        </listeners>
+    </network>
+    <storages>
+    </storages>
+    <users>
+        <user resources="*" password="root" name="root"/>
+        <user resources="connect,server.listDatabases" password="guest" name="guest"/>
+    </users>
+    <properties>
+        <entry name="log.console.level" value="info"/>
+        <entry name="log.file.level" value="fine"/>
+    </properties>
+    <isAfterFirstTime>true</isAfterFirstTime>
+</orient-server>


### PR DESCRIPTION
Hi All,

this add a new api for locking records and implement it in remote, the new api is just ` db.lock()` without considering possibilities of read/write lock, we should check the use of lock api in the query engine.
I had to reimplement as well the lock manager to not be thread-bound. 