### PR TITLE
Fix for issue #8459

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/console/OConsoleApplication.java
+++ b/core/src/main/java/com/orientechnologies/common/console/OConsoleApplication.java
@@ -52,6 +52,7 @@ public class OConsoleApplication {
   protected boolean                 interactiveMode;
   protected String[]                args;
   protected TreeMap<Method, Object> methods;
+  private boolean isInCollectingMode = false;
 
   public OConsoleApplication(String[] iArgs) {
     this.args = iArgs;
@@ -229,11 +230,12 @@ public class OConsoleApplication {
           out.println("[Started multi-line command. Type just 'end' to finish and execute]");
           commandBuffer.append(commandLine);
           commandLine = null;
+          isInCollectingMode = true;
         } else if (commandLine.startsWith("end") && commandBuffer.length() > 0) {
           // END: FLUSH IT
           commandLine = commandBuffer.toString();
-          commandBuffer.setLength(0);
-
+          commandBuffer.setLength(0);          
+          isInCollectingMode = false;
         } else if (commandBuffer.length() > 0) {
           // BUFFER IT
           commandBuffer.append(' ');
@@ -262,7 +264,7 @@ public class OConsoleApplication {
         }
       }
 
-      if (commandBuffer.length() > 0) {
+      if (!isInCollectingMode && commandBuffer.length() > 0) {
         if (iBatchMode && isEchoEnabled()) {
           out.println();
           out.print(getPrompt());


### PR DESCRIPTION
As described in #8459  console tries to execute `js` as javascript command. With this fix flag, which denotes if console is in "collecting" mode, is added.  `end` command switches off collecting mode.
I am wondering if there is some other case which should switch off "collecting" mode?