### PR TITLE
Provide 'fluent interface' on OElement #8564

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/OElement.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/OElement.java
@@ -48,16 +48,18 @@ public interface OElement extends ORecord{
    * Sets a property value
    * @param name the property name
    * @param value the property value
+   * @return The Object instance itself giving a "fluent interface". Useful to call multiple methods in chain.
    */
-  public void setProperty(String name, Object value);
+  public <RET extends OElement> RET setProperty(String name, Object value);
 
   /**
    * Sets a property value
    * @param name the property name
    * @param value the property value
    * @param fieldType Forced type (not auto-determined)
+   * @return The Object instance itself giving a "fluent interface". Useful to call multiple methods in chain.
    */
-  public void setProperty(String name, Object value, OType... fieldType);
+  public <RET extends OElement> RET setProperty(String name, Object value, OType... fieldType);
 
   /**
    * Remove a property

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -349,9 +349,10 @@ public class ODocument extends ORecordAbstract
    *
    * @param iFieldName     The property name
    * @param iPropertyValue The property value
+   * @return The Object instance itself giving a "fluent interface". Useful to call multiple methods in chain.
    */
-  public void setProperty(final String iFieldName, Object iPropertyValue) {
-    setProperty(iFieldName, iPropertyValue, OCommonConst.EMPTY_TYPES_ARRAY);
+  public ODocument setProperty(final String iFieldName, Object iPropertyValue) {
+    return setProperty(iFieldName, iPropertyValue, OCommonConst.EMPTY_TYPES_ARRAY);
   }
 
   /**
@@ -360,8 +361,9 @@ public class ODocument extends ORecordAbstract
    * @param iPropetyName   The property name
    * @param iPropertyValue The property value
    * @param iFieldType     Forced type (not auto-determined)
+   * @return The Object instance itself giving a "fluent interface". Useful to call multiple methods in chain.
    */
-  public void setProperty(String iPropetyName, Object iPropertyValue, OType... iFieldType) {
+  public ODocument setProperty(String iPropetyName, Object iPropertyValue, OType... iFieldType) {
     if (iPropetyName == null)
       throw new IllegalArgumentException("Field is null");
 
@@ -370,10 +372,10 @@ public class ODocument extends ORecordAbstract
 
     if (ODocumentHelper.ATTRIBUTE_CLASS.equals(iPropetyName)) {
       setClassName(iPropertyValue.toString());
-      return;
+      return this;
     } else if (ODocumentHelper.ATTRIBUTE_RID.equals(iPropetyName)) {
       _recordId.fromString(iPropertyValue.toString());
-      return;
+      return this;
     } else if (ODocumentHelper.ATTRIBUTE_VERSION.equals(iPropetyName)) {
       if (iPropertyValue != null) {
         int v;
@@ -385,7 +387,7 @@ public class ODocument extends ORecordAbstract
 
         _recordVersion = v;
       }
-      return;
+      return this;
     }
 
     checkForLoading();
@@ -419,7 +421,7 @@ public class ODocument extends ORecordAbstract
       if (iPropertyValue == null) {
         if (oldValue == null)
           // BOTH NULL: UNCHANGED
-          return;
+          return this;
       } else {
 
         try {
@@ -430,7 +432,7 @@ public class ODocument extends ORecordAbstract
                 setDirty();
 
               // SAVE VALUE: UNCHANGED
-              return;
+              return this;
             }
           }
         } catch (Exception e) {
@@ -488,6 +490,7 @@ public class ODocument extends ORecordAbstract
         entry.setChanged(true);
       }
     }
+    return this;
   }
 
   public <RET> RET removeProperty(final String iFieldName) {

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeDelegate.java
@@ -150,19 +150,21 @@ public class OEdgeDelegate implements OEdge {
   }
 
   @Override
-  public void setProperty(String name, Object value) {
+  public OEdgeDelegate setProperty(String name, Object value) {
     if (element == null) {
       promoteToRegularEdge();
     }
     element.setProperty(name, value);
+    return this;
   }
 
   @Override
-  public void setProperty(String name, Object value, OType... fieldType) {
+  public OEdgeDelegate setProperty(String name, Object value, OType... fieldType) {
     if (element == null) {
       promoteToRegularEdge();
     }
     element.setProperty(name, value, fieldType);
+    return this;
   }
 
   private void promoteToRegularEdge() {

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OVertexDelegate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OVertexDelegate.java
@@ -261,13 +261,15 @@ public class OVertexDelegate implements OVertex {
   }
 
   @Override
-  public void setProperty(String name, Object value) {
+  public OVertexDelegate setProperty(String name, Object value) {
     element.setProperty(name, value);
+    return this;
   }
 
   @Override
-  public void setProperty(String name, Object value, OType... fieldType) {
+  public OVertexDelegate setProperty(String name, Object value, OType... fieldType) {
     element.setProperty(name, value, fieldType);
+    return this;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OViewDocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OViewDocument.java
@@ -29,7 +29,7 @@ public class OViewDocument extends ODocument {
   }
 
   @Override
-  public void setProperty(String iFieldName, Object iPropertyValue) {
+  public OViewDocument setProperty(String iFieldName, Object iPropertyValue) {
     super.setProperty(iFieldName, iPropertyValue);
     if (view != null && view.isUpdatable()) {
       String originField = view.getOriginRidField();
@@ -43,5 +43,6 @@ public class OViewDocument extends ODocument {
         }
       }
     }
+    return this;
   }
 }


### PR DESCRIPTION
Changed the _setProperty_ methods in _OElement_ interface to return a object extending _OElement_ itself giving it a 'fluent interface'.
```
session.newElement("MyElement")
    .setProperty("prop1", "val1")
    .setProperty("prop2", "val2")
    .save();
```
Only few implementing classes needed to be changed in this context to return the object instance itself.

see: [#8564](https://github.com/orientechnologies/orientdb/issues/8564)