### PR TITLE
Deletion SB-Tree RidBags

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
@@ -40,9 +40,8 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
   private final OPair<ODirection, String> connection;
   private final String[]                  labels;
 
-
-  public OEdgeIterator(final OVertex iSourceVertex, final Object iMultiValue,
-      final Iterator<?> iterator, final OPair<ODirection, String> connection, final String[] iLabels, final int iSize) {
+  public OEdgeIterator(final OVertex iSourceVertex, final Object iMultiValue, final Iterator<?> iterator,
+      final OPair<ODirection, String> connection, final String[] iLabels, final int iSize) {
     this(iSourceVertex, null, iMultiValue, iterator, connection, iLabels, iSize);
   }
 
@@ -84,9 +83,7 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
       return null;
     }
 
-    final OElement value = (OElement)record;
-
-
+    final OElement value = (OElement) record;
 
     final OEdge edge;
     if (value.isVertex()) {
@@ -117,7 +114,8 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
     return iObject.isLabeled(labels);
   }
 
-  @Override public boolean canUseMultiValueDirectly() {
+  @Override
+  public boolean canUseMultiValueDirectly() {
     return true;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
@@ -63,14 +63,14 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
 
     if (rec == null) {
       // SKIP IT
-      OLogManager.instance().warn(this, "Record (%s) is null", iObject);
+      OLogManager.instance().debug(this, "Record (%s) is null", iObject);
       return null;
     }
 
     final ORecord record = rec.getRecord();
     if (record == null) {
       // SKIP IT
-      OLogManager.instance().warn(this, "Record (%s) is null", rec);
+      OLogManager.instance().debug(this, "Record (%s) is null", rec);
       return null;
     }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
@@ -63,14 +63,14 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
 
     if (rec == null) {
       // SKIP IT
-      OLogManager.instance().warn(this, "Record (%s) is null", iObject);
+      OLogManager.instance().warn(this, "In thread: " + Thread.currentThread().getId() + " Record (%s) is null", iObject);
       return null;
     }
 
     final ORecord record = rec.getRecord();
     if (record == null) {
       // SKIP IT
-      OLogManager.instance().warn(this, "Record (%s) is null", rec);
+      OLogManager.instance().warn(this, "In thread: " + Thread.currentThread().getId() + " Record (%s) is null", rec);
       return null;
     }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OEdgeIterator.java
@@ -55,6 +55,7 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
     this.labels = iLabels;
   }
 
+  @Override
   public OEdge createGraphElement(final Object iObject) {
     if (iObject instanceof OElement && ((OElement) iObject).isEdge())
       return ((OElement) iObject).asEdge().get();
@@ -63,14 +64,14 @@ public class OEdgeIterator extends OLazyWrapperIterator<OEdge> {
 
     if (rec == null) {
       // SKIP IT
-      OLogManager.instance().debug(this, "Record (%s) is null", iObject);
+      OLogManager.instance().warn(this, "Record (%s) is null", iObject);
       return null;
     }
 
     final ORecord record = rec.getRecord();
     if (record == null) {
       // SKIP IT
-      OLogManager.instance().debug(this, "Record (%s) is null", rec);
+      OLogManager.instance().warn(this, "Record (%s) is null", rec);
       return null;
     }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
@@ -1,22 +1,22 @@
 /*
-  *
-  *  *  Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
-  *  *
-  *  *  Licensed under the Apache License, Version 2.0 (the "License");
-  *  *  you may not use this file except in compliance with the License.
-  *  *  You may obtain a copy of the License at
-  *  *
-  *  *       http://www.apache.org/licenses/LICENSE-2.0
-  *  *
-  *  *  Unless required by applicable law or agreed to in writing, software
-  *  *  distributed under the License is distributed on an "AS IS" BASIS,
-  *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  *  *  See the License for the specific language governing permissions and
-  *  *  limitations under the License.
-  *  *
-  *  * For more information: http://orientdb.com
-  *
-  */
+ *
+ *  *  Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  * For more information: http://orientdb.com
+ *
+ */
 
 package com.orientechnologies.orient.core.storage.ridbag.sbtree;
 
@@ -172,23 +172,23 @@ public abstract class OSBTreeCollectionManagerAbstract
 
     //noinspection SynchronizationOnLocalVariableOrMethodParameter
     synchronized (lock) {
-      SBTreeBonsaiContainer container = treeCache.get(cacheKey);            
-       
-      if (container != null && container.usagesCounter <= 1){
+      SBTreeBonsaiContainer container = treeCache.get(cacheKey);
+
+      if (container != null && container.usagesCounter <= 1) {
         List<OBonsaiCollectionPointer> collectionToDelete = markedForDeletion.get(cacheKey);
-        if (collectionToDelete != null){
-          synchronized(collectionToDelete){
-            for (OBonsaiCollectionPointer pointer : collectionToDelete){
+        if (collectionToDelete != null) {
+          synchronized (collectionToDelete) {
+            for (OBonsaiCollectionPointer pointer : collectionToDelete) {
               final CacheKey ck = new CacheKey(storage, pointer);
               treeCache.remove(ck);
             }
-            collectionToDelete.clear();            
+            collectionToDelete.clear();
           }
           //should be safe logical removal because add in is synchronized on same object
           markedForDeletion.remove(cacheKey);
         }
       }
-      
+
       if (container != null) {
         container.usagesCounter++;
         tree = container.tree;
@@ -203,10 +203,10 @@ public abstract class OSBTreeCollectionManagerAbstract
           treeCache.put(cacheKey, container);
         }
       }
-            
+
     }
 
-    evict();        
+    evict();
 
     return tree;
   }
@@ -237,16 +237,14 @@ public abstract class OSBTreeCollectionManagerAbstract
 
       if (container.usagesCounter != 0) {
         List<OBonsaiCollectionPointer> pointersCollection = markedForDeletion.get(cacheKey);
-        //lets say that I know what I am doing
-        if (pointersCollection == null){
+        if (pointersCollection == null) {
           pointersCollection = new LinkedList<>();
           markedForDeletion.put(cacheKey, pointersCollection);
         }
-        synchronized(pointersCollection){
+        synchronized (pointersCollection) {
           pointersCollection.add(collectionPointer);
         }
-      }
-      else{
+      } else {
         treeCache.remove(cacheKey);
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
@@ -182,8 +182,10 @@ public abstract class OSBTreeCollectionManagerAbstract
               final CacheKey ck = new CacheKey(storage, pointer);
               treeCache.remove(ck);
             }
-            collectionToDelete.clear();
+            collectionToDelete.clear();            
           }
+          //should be safe logical removal because add in is synchronized on same object
+          markedForDeletion.remove(cacheKey);
         }
       }
       

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeCollectionManagerAbstract.java
@@ -174,7 +174,7 @@ public abstract class OSBTreeCollectionManagerAbstract
     synchronized (lock) {
       SBTreeBonsaiContainer container = treeCache.get(cacheKey);
 
-      if (container != null && container.usagesCounter <= 1) {
+      if (container != null && container.usagesCounter == 0) {
         List<OBonsaiCollectionPointer> collectionToDelete = markedForDeletion.get(cacheKey);
         if (collectionToDelete != null) {
           synchronized (collectionToDelete) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -80,8 +80,8 @@ public class OSBTreeRidBag implements ORidBagDelegate {
    * Entries with not valid id.
    */
   private final IdentityHashMap<OIdentifiable, OModifiableInteger> newEntries        = new IdentityHashMap<>();
-  private       OBonsaiCollectionPointer                           collectionPointer;
-  private       int                                                size;
+  private OBonsaiCollectionPointer collectionPointer;
+  private int                      size;
 
   private boolean autoConvertToRecord = true;
 
@@ -438,16 +438,16 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   }
 
   //for test let it be linear [50..1000]
-  private int getPrefectchSize(){
+  private int getPrefectchSize() {
     int prefectchSize = 50;
-    if (changes.size() < 1000 && changes.size() >= 0){
+    if (changes.size() < 1000 && changes.size() >= 0) {
       float a = (50.f - 1000.f) / 1000.f;
       float b = 1000.f;
-      prefectchSize = (int)(a * changes.size() + b);
+      prefectchSize = (int) (a * changes.size() + b);
     }
     return prefectchSize;
   }
-  
+
   @Override
   public Iterator<OIdentifiable> iterator() {
     int prefetchSize = getPrefectchSize();
@@ -456,9 +456,11 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   }
 
   @Override
-  public Iterator<OIdentifiable> rawIterator() {        
+  public Iterator<OIdentifiable> rawIterator() {
     int prefectchSize = getPrefectchSize();
-    OLogManager.instance().debug(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize, (Object[])null);
+    OLogManager.instance()
+        .debug(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize,
+            (Object[]) null);
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
         collectionPointer != null ? new SBTreeMapEntryIterator(prefectchSize) : null, false);
   }
@@ -599,7 +601,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
           changes.put(identifiable, new DiffChange(-1));
           size = -1;
         } else
-          // Return immediately to prevent firing of event
+        // Return immediately to prevent firing of event
         {
           return;
         }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -437,15 +437,16 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     }
   }
 
-  //for test let it be linear [50..1000]
+  //for test let it be linear [1..10]
   private int getPrefectchSize() {
-    int prefectchSize = 50;
-    if (changes.size() < 1000 && changes.size() >= 0) {
-      float a = (50.f - 1000.f) / 1000.f;
-      float b = 1000.f;
+    int prefectchSize = 1;
+    float downThrashhold = 100.f;
+    if (changes.size() < downThrashhold && changes.size() >= 0) {
+      float b = 10.f;
+      float a = ((float)prefectchSize - b) / downThrashhold;      
       prefectchSize = (int) (a * changes.size() + b);
     }
-    return prefectchSize;
+    return prefectchSize; 
   }
 
   @Override
@@ -459,7 +460,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   public Iterator<OIdentifiable> rawIterator() {
     int prefectchSize = getPrefectchSize();
     OLogManager.instance()
-        .debug(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize,
+        .info(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize,
             (Object[]) null);
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
         collectionPointer != null ? new SBTreeMapEntryIterator(prefectchSize) : null, false);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -460,7 +460,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   public Iterator<OIdentifiable> rawIterator() {
     int prefectchSize = getPrefectchSize();
     OLogManager.instance()
-        .info(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize,
+        .debug(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize,
             (Object[]) null);
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
         collectionPointer != null ? new SBTreeMapEntryIterator(prefectchSize) : null, false);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -436,16 +436,30 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     }
   }
 
+  //for test let it be linear
+  private int getPrefectchSize(){
+    int prefectchSize = 5;
+    if (changes.size() < 1000 && changes.size() >= 0){
+      float a = (5.f - 1000.f) / 1000.f;
+      float b = 1000.f;
+      prefectchSize = (int)(a * changes.size() + b);
+    }
+    return prefectchSize;
+  }
+  
   @Override
   public Iterator<OIdentifiable> iterator() {
+    int prefetchSize = getPrefectchSize();
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
-        collectionPointer != null ? new SBTreeMapEntryIterator(1000) : null, autoConvertToRecord);
+        collectionPointer != null ? new SBTreeMapEntryIterator(prefetchSize) : null, autoConvertToRecord);
   }
 
   @Override
-  public Iterator<OIdentifiable> rawIterator() {
+  public Iterator<OIdentifiable> rawIterator() {        
+    int prefectchSize = getPrefectchSize();
+    System.out.println("!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize);
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
-        collectionPointer != null ? new SBTreeMapEntryIterator(1000) : null, false);
+        collectionPointer != null ? new SBTreeMapEntryIterator(prefectchSize) : null, false);
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/ridbag/sbtree/OSBTreeRidBag.java
@@ -21,6 +21,7 @@
 package com.orientechnologies.orient.core.storage.ridbag.sbtree;
 
 import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import com.orientechnologies.common.types.OModifiableInteger;
@@ -436,11 +437,11 @@ public class OSBTreeRidBag implements ORidBagDelegate {
     }
   }
 
-  //for test let it be linear
+  //for test let it be linear [50..1000]
   private int getPrefectchSize(){
-    int prefectchSize = 5;
+    int prefectchSize = 50;
     if (changes.size() < 1000 && changes.size() >= 0){
-      float a = (5.f - 1000.f) / 1000.f;
+      float a = (50.f - 1000.f) / 1000.f;
       float b = 1000.f;
       prefectchSize = (int)(a * changes.size() + b);
     }
@@ -457,7 +458,7 @@ public class OSBTreeRidBag implements ORidBagDelegate {
   @Override
   public Iterator<OIdentifiable> rawIterator() {        
     int prefectchSize = getPrefectchSize();
-    System.out.println("!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize);
+    OLogManager.instance().debug(this, "!!!!!!!!!!!!!!!!!!!!!!CHANGES SIZE: " + changes.size() + " prefectch size: " + prefectchSize, (Object[])null);
     return new RIDBagIterator(new IdentityHashMap<>(newEntries), changes,
         collectionPointer != null ? new SBTreeMapEntryIterator(prefectchSize) : null, false);
   }


### PR DESCRIPTION
There are two possible improvements here. Both are related to heavy load MT environment

1. Noticed that sometimes deletion from tree cache fails because usage count is greater then 0. So here if usage count in delete is greater than 0, pointer will be marked for delete and will be deleted on the first load when usage counter is equal to 0.

2. It looks like that prefetch size of 1000 in heavy load MT environment can cause increased number of ghost records, and thus it can affects (negatively) performances. So here is proposed dynamically calculating prefetch size as linear function of number of changes. So with this prefectch size should be in range [50..1000] 