### PR TITLE
Update OTransactionOptimistic.java

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionOptimistic.java
@@ -532,9 +532,8 @@ public class OTransactionOptimistic extends OTransactionRealAbstract {
 
     status = TXSTATUS.COMMITTING;
 
-    if (!allEntries.isEmpty() || !indexEntries.isEmpty()) {
-      database.internalCommit(this);
-    }
+    database.internalCommit(this);
+   
 
     invokeCallbacks();
 


### PR DESCRIPTION
different transaction type between client and remote server when no changing data in the transaction.

once this pooled resource reused to execute ddl statement ,server response error.

eg: client NoTx but remote server is OTransactionOptimistic

I don't know if this will affect the remote server side, tested this modify at client side only;