### PR TITLE
Wip index rebuild without docs

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OCompositeIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OCompositeIndexDefinition.java
@@ -26,6 +26,7 @@ import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandExecutorSQLCreateIndex;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -155,6 +156,33 @@ public class OCompositeIndexDefinition extends OAbstractIndexDefinition {
 
     return compositeKeys;
   }
+
+  public Object getResultValueToIndex(final OResult result) {
+    final List<OCompositeKey> compositeKeys = new ArrayList<OCompositeKey>(10);
+    final OCompositeKey firstKey = new OCompositeKey();
+    boolean containsCollection = false;
+
+    compositeKeys.add(firstKey);
+
+    for (final OIndexDefinition indexDefinition : indexDefinitions) {
+      final Object value = indexDefinition.getResultValueToIndex(result);
+
+      if (value == null && isNullValuesIgnored())
+        return null;
+
+      //for empty collections we add null key in index
+      if (value instanceof Collection && ((Collection) value).isEmpty() && isNullValuesIgnored())
+        return null;
+
+      containsCollection = addKey(firstKey, compositeKeys, containsCollection, value);
+    }
+
+    if (!containsCollection)
+      return firstKey;
+
+    return compositeKeys;
+  }
+
 
   public int getMultiValueDefinitionIndex() {
     return multiValueDefinitionIndex;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -925,7 +925,7 @@ public abstract class OIndexAbstract<T> implements OIndexInternal<T> {
       ODatabaseDocumentInternal db = getDatabase();
       ORecordSerializer serializer = db.getSerializer();
       int id = db.getClusterIdByName(clusterName);
-      Iterator<OClusterBrowsePage> res = ((OAbstractPaginatedStorage) db.getStorage()).browseCluster(id);
+      Iterator<OClusterBrowsePage> res = ((OAbstractPaginatedStorage) db.getStorage().getUnderlying()).browseCluster(id);
       while (res.hasNext()) {
         OClusterBrowsePage page = res.next();
         for (final OClusterBrowseEntry record : page) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexCallback.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexCallback.java
@@ -20,7 +20,10 @@
 package com.orientechnologies.orient.core.index;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 public interface OIndexCallback {
   Object getDocumentValueToIndex(ODocument iDocument);
+
+  Object getResultValueToIndex(OResult result);
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyIndexDefinition.java
@@ -25,6 +25,7 @@ import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandExecutorSQLCreateIndex;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.Collections;
 import java.util.List;
@@ -77,6 +78,19 @@ public class OPropertyIndexDefinition extends OAbstractIndexDefinition {
     }
     return createValue(iDocument.<Object>field(field));
   }
+
+  public Object getResultValueToIndex(final OResult result) {
+    if (OType.LINK.equals(keyType)) {
+      final OIdentifiable identifiable = result.getProperty(field);
+      if (identifiable != null)
+        return createValue(identifiable.getIdentity());
+      else
+        return null;
+    }
+    return createValue(result.<Object>getProperty(field));
+  }
+
+
 
   @Override
   public boolean equals(final Object o) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyListIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyListIndexDefinition.java
@@ -23,6 +23,7 @@ import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.orient.core.db.record.OMultiValueChangeEvent;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.*;
 
@@ -46,6 +47,12 @@ public class OPropertyListIndexDefinition extends OAbstractIndexDefinitionMultiV
   public Object getDocumentValueToIndex(ODocument iDocument) {
     return createValue(iDocument.<Object>field(field));
   }
+
+  @Override
+  public Object getResultValueToIndex(OResult result) {
+    return createValue(result.<Object>getProperty(field));
+  }
+
 
   @Override
   public Object createValue(List<?> params) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyMapIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyMapIndexDefinition.java
@@ -22,6 +22,7 @@ package com.orientechnologies.orient.core.index;
 import com.orientechnologies.orient.core.db.record.OMultiValueChangeEvent;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.*;
 
@@ -59,6 +60,11 @@ public class OPropertyMapIndexDefinition extends OAbstractIndexDefinitionMultiVa
   @Override
   public Object getDocumentValueToIndex(ODocument iDocument) {
     return createValue(iDocument.<Object>field(field));
+  }
+
+  @Override
+  public Object getResultValueToIndex(OResult result) {
+    return createValue(result.<Object>getProperty(field));
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyRidBagIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OPropertyRidBagIndexDefinition.java
@@ -25,6 +25,7 @@ import com.orientechnologies.orient.core.db.record.OMultiValueChangeEvent;
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +71,11 @@ public class OPropertyRidBagIndexDefinition extends OAbstractIndexDefinitionMult
   @Override
   public Object getDocumentValueToIndex(ODocument iDocument) {
     return createValue(iDocument.<Object>field(field));
+  }
+
+  @Override
+  public Object getResultValueToIndex(OResult result) {
+    return createValue(result.<Object>getProperty(field));
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/index/ORuntimeKeyIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/ORuntimeKeyIndexDefinition.java
@@ -25,6 +25,7 @@ import com.orientechnologies.orient.core.exception.OConfigurationException;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.binary.OBinarySerializerFactory;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,6 +125,12 @@ public class ORuntimeKeyIndexDefinition<T> extends OAbstractIndexDefinition {
   public Object getDocumentValueToIndex(final ODocument iDocument) {
     throw new OIndexException("This method is not supported in given index definition.");
   }
+
+  @Override
+  public Object getResultValueToIndex(OResult result) {
+    throw new OIndexException("This method is not supported in given index definition.");
+  }
+
 
   @Override
   public boolean equals(final Object o) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OSimpleKeyIndexDefinition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OSimpleKeyIndexDefinition.java
@@ -26,6 +26,7 @@ import com.orientechnologies.orient.core.db.record.ORecordElement;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OSQLEngine;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -177,6 +178,11 @@ public class OSimpleKeyIndexDefinition extends OAbstractIndexDefinition {
   }
 
   public Object getDocumentValueToIndex(final ODocument iDocument) {
+    throw new OIndexException("This method is not supported in given index definition.");
+  }
+
+  @Override
+  public Object getResultValueToIndex(OResult result) {
     throw new OIndexException("This method is not supported in given index definition.");
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OResultBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OResultBinary.java
@@ -79,6 +79,9 @@ public class OResultBinary implements OResult {
 
   @Override
   public <T> T getProperty(String name) {
+    if ("@rid".equals(name)) {
+      return (T) id.orElse(null);
+    }
     BytesContainer bytes = new BytesContainer(this.bytes);
     bytes.skip(offset);
     return (T) serializer.deserializeFieldTyped(bytes, name, !id.isPresent(), schema, null);

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OResultBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/OResultBinary.java
@@ -20,6 +20,7 @@ import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.OMetadataInternal;
 import com.orientechnologies.orient.core.metadata.schema.OImmutableSchema;
+import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.OEdge;
 import com.orientechnologies.orient.core.record.OElement;
 import com.orientechnologies.orient.core.record.ORecord;
@@ -172,11 +173,15 @@ public class OResultBinary implements OResult {
   }
 
   private ODocument toDocument() {
-    ODocument doc = new ODocument();
-    BytesContainer bytes = new BytesContainer(this.bytes);
-    bytes.skip(offset);
-    serializer.deserialize(doc, bytes);
-    return doc;
+    if (id.isPresent()) {
+      ODocument doc = new ODocument();
+      doc.fromStream(this.bytes);
+      return doc;
+    } else {
+      BytesContainer bytes = new BytesContainer(this.bytes);
+      bytes.skip(offset);
+      return (ODocument) serializer.deserializeValue(bytes, OType.EMBEDDED, null);
+    }
   }
 
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ORebuildIndexStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ORebuildIndexStatementExecutionTest.java
@@ -1,6 +1,7 @@
 package com.orientechnologies.orient.core.sql.executor;
 
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.OMetadataInternal;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OType;
@@ -36,6 +37,7 @@ public class ORebuildIndexStatementExecutionTest {
 
       db.newInstance(className).field("key", "a").field("value", 2).save(className + "secondCluster");
 
+      ((OMetadataInternal)db.getMetadata()).clearThreadLocalSchemaSnapshot();
       // when
       OResultSet result = db.command("rebuild index " + className + "index1");
       Assert.assertTrue(result.hasNext());

--- a/lucene/src/main/java/com/orientechnologies/spatial/engine/OLuceneGeoSpatialIndexEngine.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/engine/OLuceneGeoSpatialIndexEngine.java
@@ -27,6 +27,7 @@ import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.index.OIndexDefinition;
 import com.orientechnologies.orient.core.index.OIndexKeyUpdater;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.storage.OStorage;
 import com.orientechnologies.spatial.query.OSpatialQueryContext;
 import com.orientechnologies.spatial.shape.OShapeBuilder;
@@ -105,7 +106,9 @@ public class OLuceneGeoSpatialIndexEngine extends OLuceneSpatialIndexEngineAbstr
 
   @Override
   public void put(Object key, Object value) {
-
+    if (key instanceof OResult) {
+      key = ((OResult) key).getElement().get();
+    }
     if (key instanceof OIdentifiable) {
       openIfClosed();
       ODocument location = ((OIdentifiable) key).getRecord();


### PR DESCRIPTION
Hi, 

This change the rebuild of the index to use OResultBinary instead of ODocument and raw browsing of records instead of high level iterator.

Would be cool as well a bit more high level evaluation and consider if it does make sense to do this  rebuild on this way.

Regards