### PR TITLE
Fix OETL Console command block

### DIFF
--- a/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessor.java
+++ b/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessor.java
@@ -208,7 +208,7 @@ public class OETLProcessor {
       OETLContextWrapper.getInstance().getMessageHandler().error(this, "ETL process halted: ", e);
       executor.shutdownNow();
     } catch (Exception e) {
-      OETLContextWrapper.getInstance().getMessageHandler().error(this, "ETL process has problem: ", e);
+      OETLContextWrapper.getInstance().getMessageHandler().error(this, "ETL process has problem: " + e.getMessage());
       executor.shutdownNow();
     }
     executor.shutdown();

--- a/etl/src/main/java/com/orientechnologies/orient/etl/block/OETLConsoleBlock.java
+++ b/etl/src/main/java/com/orientechnologies/orient/etl/block/OETLConsoleBlock.java
@@ -37,7 +37,7 @@ public class OETLConsoleBlock extends OETLAbstractBlock {
   public ODocument getConfiguration() {
     return new ODocument().fromJSON("{parameters:[" + getCommonConfigurationParameters()
         + "{file:{optional:true,description:'Input filename with commands.sh to execute'}}"
-        + "{commands.sh:{optional:true,description:'Commands to execute in sequence as an array of strings'}}" + "]}");
+        + "{commands:{optional:true,description:'Commands to execute in sequence as an array of strings'}}" + "]}");
   }
 
   @Override
@@ -46,11 +46,11 @@ public class OETLConsoleBlock extends OETLAbstractBlock {
     if (iConfiguration.containsField("file"))
       file = iConfiguration.field("file");
 
-    if (iConfiguration.containsField("commands.sh"))
-      commands = iConfiguration.field("commands.sh");
+    if (iConfiguration.containsField("commands"))
+      commands = iConfiguration.field("commands");
 
     if (file == null && commands == null)
-      throw new OConfigurationException("file or commands.sh are mandatory");
+      throw new OConfigurationException("file or commands are mandatory");
 
     if (file != null)
       console = new OConsoleDatabaseApp(new String[] { file });


### PR DESCRIPTION
When using "console" block, using "commands" will cause an error

> Caused by: com.orientechnologies.orient.core.exception.OConfigurationException: file or commands.sh are mandatory

When there is an error processing the source, the error message is not clear.
Before the fix, it will display the error as follow

> ETL process has problem:  [OETLProcessor]

After the fix, it will display the error as follow

> ETL process has problem: java.lang.RuntimeException: java.io.IOException: (line 2) invalid char between encapsulated token and delimiter [OETLProcessor]

Tested in docker with OrientDB v3.023

Test files:
[test-files.zip](https://github.com/orientechnologies/orientdb/files/3678963/test-files.zip)

When running the test file, change the source file path in config.json to correct path as necessary.
