### PR TITLE
alter cluster sql issues

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/OCluster.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/OCluster.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public interface OCluster {
 
   enum ATTRIBUTES {
-    NAME, CONFLICTSTRATEGY, STATUS, ENCRYPTION
+    NAME, CONFLICTSTRATEGY, STATUS, @Deprecated ENCRYPTION
   }
 
   void configure(int iId, String iClusterName) throws IOException;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
@@ -1337,7 +1337,7 @@ public final class OPaginatedClusterV2 extends OPaginatedCluster {
 
   @Override
   public void setEncryption(final String method, final String key) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("Encryption should be configured on storage level.");
   }
 
   private static OPhysicalPosition createPhysicalPosition(final byte recordType, final long clusterPosition, final int version) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -5086,16 +5086,9 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
           OStorageClusterConfiguration.STATUS.valueOf(stringValue.toUpperCase(getConfiguration().getLocaleInstance())));
     }
     case ENCRYPTION:
-      if (cluster.getEntries() > 0) {
-        throw new IllegalArgumentException(
-            "Cannot change encryption setting on cluster '" + getName() + "' because it is not empty");
-      }
-      cluster.setEncryption(stringValue,
-          configuration.getContextConfiguration().getValueAsString(OGlobalConfiguration.STORAGE_ENCRYPTION_KEY));
-      changed = true;
-      break;
+      throw new UnsupportedOperationException("Encryption should be configured on storage level.");
     default:
-      throw new IllegalArgumentException("Runtime change of attribute '" + attribute + " is not supported");
+      throw new IllegalArgumentException("Runtime change of attribute '" + attribute + "' is not supported");
     }
 
     ((OClusterBasedStorageConfiguration) configuration).updateCluster(((OPaginatedCluster) cluster).generateClusterConfig());

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLAlterClusterCommandTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLAlterClusterCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.orientechnologies.orient.test.database.auto;
+
+import org.testng.Assert;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+@Test(groups = "sql-cluster-alter")
+public class SQLAlterClusterCommandTest extends DocumentDBBaseTest {
+
+    @Parameters(value = "url")
+    public SQLAlterClusterCommandTest(@Optional String url) {
+        super(url);
+    }
+
+    @Test
+    public void testCreateCluster() {
+        int expectedClusters = database.getClusters();
+        try {
+            database.command("create cluster europe");
+            Assert.assertEquals(database.getClusters(), expectedClusters + 1);
+        } finally {
+            database.command("drop cluster europe");
+        }
+        Assert.assertEquals(database.getClusters(), expectedClusters);
+    }
+
+    @Test
+    public void testAlterClusterName() {
+        try {
+            database.command("create cluster europe");
+            database.command("ALTER CLUSTER europe NAME \"my_orient\"");
+
+            int clusterId = database.getClusterIdByName("my_orient");
+            Assert.assertEquals(clusterId, 18);
+        } finally {
+            database.command("drop cluster my_orient");
+        }
+    }
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLAlterClusterNotSupportedCommandTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/SQLAlterClusterNotSupportedCommandTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.orientechnologies.orient.test.database.auto;
+
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+@Test(groups = "sql-cluster-alter")
+public class SQLAlterClusterNotSupportedCommandTest extends DocumentDBBaseTest {
+
+    @Parameters(value = "url")
+    public SQLAlterClusterNotSupportedCommandTest(@Optional String url) {
+        super(url);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testAlterClusterEncryption() {
+        try {
+            database.command("create cluster europe");
+            database.command("ALTER CLUSTER europe encryption aes");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testClusterCompression_lowercase() {
+        try {
+            database.command("create cluster europe");
+            database.command("alter cluster europe compression gzip");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testClusterCompression_uppercase() {
+        try {
+            database.command("create cluster europe");
+            database.command("alter cluster europe COMPRESSION gzip");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testClusterRecordOverflowGrowFactor() {
+        try {
+            database.command("create cluster europe");
+            database.command("alter cluster europe RECORD_OVERFLOW_GROW_FACTOR 3");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testClusterWAL() {
+        try {
+            database.command("create cluster europe");
+            database.command("alter cluster europe USE_WAL true");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testClusterRecordGrowFactor() {
+        try {
+            database.command("create cluster europe");
+            database.command("alter cluster europe RECORD_GROW_FACTOR 3");
+        } finally {
+            database.command("drop cluster europe");
+        }
+    }
+}


### PR DESCRIPTION
- Tested `alter cluster` commands for different attributes
- Deprecated attribute `compression` and adjusted exceptions + text
- Found several non-supported attributes, for which more meaningful exception texts were added 