### PR TITLE
ISSUE-8842 Resolves client connection strategy problem even if one se…

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1774,14 +1774,14 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
           throw new OStorageException("Cannot create a connection to remote server because url list is empty");
       }
 
-      final String serverURL = serverURLs.get(this.nextServerToConnect) + "/" + getName();
-      if (session != null)
-        session.serverURLIndex = this.nextServerToConnect;
-
       this.nextServerToConnect++;
       if (this.nextServerToConnect >= serverURLs.size())
         // RESET INDEX
         this.nextServerToConnect = 0;
+
+      final String serverURL = serverURLs.get(this.nextServerToConnect) + "/" + getName();
+      if (session != null)
+        session.serverURLIndex = this.nextServerToConnect;
 
       return serverURL;
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.java
@@ -1357,7 +1357,7 @@ public class ODatabaseDocumentTx implements ODatabaseDocumentInternal {
       }
     }
     OrientDBConfigBuilder builder = OrientDBConfig.builder();
-    final String connectionStrategy = pars != null ? (String) pars.get("connectionStrategy") : null;
+    final String connectionStrategy = pars != null ? (String) pars.get(OGlobalConfiguration.CLIENT_CONNECTION_STRATEGY.getKey()) : null;
     if (connectionStrategy != null)
       builder.addConfig(OGlobalConfiguration.CLIENT_CONNECTION_STRATEGY, connectionStrategy);
 


### PR DESCRIPTION
Resolves client connection strategy problem even if one sets the property other than STICKY, It does not effect the strategy value because It is controlled with deprecated "connectionStrategy" key value whereas it is set as "client.connection.strategy". Another bug is about getting next available url when the strategy is ROUND_ROBIN_CONNECT. When one of the servers is somehow down and dropped from the server urls and when the current index was the last one as the index management is not handled before getting from array list, The application always gets ArrayIndexOutOfBound Exception.