### PR TITLE
Fix a crash when using sbtreebonsai.freeSpaceReuseTrigger=0 and there…

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/sbtreebonsai/local/OSBTreeBonsaiLocal.java
@@ -1409,8 +1409,10 @@ public class OSBTreeBonsaiLocal<K, V> extends ODurableComponent implements OSBTr
     sysCacheEntry.acquireExclusiveLock();
     try {
       final OSysBucket sysBucket = new OSysBucket(sysCacheEntry, getChanges(atomicOperation, sysCacheEntry));
-      if ((1.0 * sysBucket.freeListLength()) / ((1.0 * getFilledUpTo(atomicOperation, fileId)) * PAGE_SIZE
-          / OSBTreeBonsaiBucket.MAX_BUCKET_SIZE_BYTES) >= freeSpaceReuseTrigger) {
+      long freeListLength = sysBucket.freeListLength();
+      if ((freeListLength > 0) &&
+          ((1.0 * freeListLength) / ((1.0 * getFilledUpTo(atomicOperation, fileId)) * PAGE_SIZE
+          / OSBTreeBonsaiBucket.MAX_BUCKET_SIZE_BYTES) >= freeSpaceReuseTrigger)) {
         final AllocationResult allocationResult = reuseBucketFromFreeList(sysBucket, atomicOperation);
         return allocationResult;
       } else {


### PR DESCRIPTION
… are no free list items to use

In this particular case, the original if condition becomes '0 >= 0' which is true and causes a NullPointerException later at OAtomicOperation line 223.

Note, it looks like this same issue is in master, but I have no way to test that at the moment.