### PR TITLE
Changed comparison to be ge rather than gt

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
+++ b/core/src/main/java/com/orientechnologies/common/collection/OMultiValue.java
@@ -198,7 +198,7 @@ public class OMultiValue {
     if (!isMultiValue(iObject))
       return null;
 
-    if (iIndex > getSize(iObject))
+    if (iIndex >= getSize(iObject))
       return null;
 
     try {


### PR DESCRIPTION
Currently it will result in an exception and a warning in the database, so it's not that bad, but unless there's a special reason I'm missing it should be `>=`

Warning that occurs without this fix:
`java.lang.IndexOutOfBoundsException: Index: 0, Size: 0`