### PR TITLE
Spatial improvements (st_distance)

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionAbstract.java
@@ -135,18 +135,20 @@ public abstract class OSQLFunctionAbstract implements OSQLFunction {
    * Attempts to identify the source as a map-like object with single property and return it.
    *
    * @param source The object to check
+   * @param requireSingleProperty True if the method should return null when source doesn't have a single property.
+   *                              Otherwise, the object will be returned.
    * @return If source is a map-like object with single property, that property will be returned
-   *         If source is a map-like object with multiple properties, null is returned, indicating an error
+   *         If source is a map-like object with multiple properties and requireSingleProperty is true, null is returned indicating an error
    *         If source is not a map-like object, it is returned
    */
-  protected Object getSingleProperty(Object source) {
+  protected Object getSingleProperty(Object source, boolean requireSingleProperty) {
     if (source instanceof OResult) {
       final OResult result = (OResult)source;
       // TODO we might want to add .size() and iterator with .next() to OResult. The current implementation is
       // quite heavy compared to the result we actually want (the single first property).
       final Set<String> propertyNames = result.getPropertyNames();
       if (propertyNames.size() != 1) {
-        return null;
+        return requireSingleProperty ? null : source;
       }
       return result.getProperty(propertyNames.iterator().next());
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionAbstract.java
@@ -19,19 +19,22 @@
   */
 package com.orientechnologies.orient.core.sql.functions;
 
+import com.orientechnologies.common.collection.OMultiValue;
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
 import com.orientechnologies.orient.core.db.OScenarioThreadLocal;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.storage.OAutoshardedStorage;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Abstract class to extend to build Custom SQL Functions. Extend it and register it with:
  * <code>OSQLParser.getInstance().registerStatelessFunction()</code> or
  * <code>OSQLParser.getInstance().registerStatefullFunction()</code> to being used by the SQL engine.
- * 
+ *
  * @author Luca Garulli (l.garulli--(at)--orientdb.com)
- * 
+ *
  */
 public abstract class OSQLFunctionAbstract implements OSQLFunction {
   protected String name;
@@ -103,5 +106,50 @@ public abstract class OSQLFunctionAbstract implements OSQLFunction {
 
   protected String getDistributedStorageId() {
     return ((OAutoshardedStorage) ODatabaseRecordThreadLocal.instance().get().getStorage()).getStorageId();
+  }
+
+  /**
+   * Attempt to extract a single item from object if it's a multi value {@link OMultiValue}
+   * If source is a multi value
+   *
+   * @param source a value to attempt extract single value from it
+   * @return If source is not a multi value, it will return source as is.
+   * If it is, it will return the single element in it.
+   * If source is a multi value with more than 1 element null is returned, indicating an error
+   */
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  protected Object getSingleItem(Object source) {
+    if (OMultiValue.isMultiValue(source)) {
+      if (OMultiValue.getSize(source) > 1) {
+        return null;
+      }
+      source = OMultiValue.getFirstValue(source);
+      if (source instanceof OResult && ((OResult) source).isElement()) {
+        source = ((OResult) source).getElement().get();
+      }
+    }
+    return source;
+  }
+
+  /**
+   * Attempts to identify the source as a map-like object with single property and return it.
+   *
+   * @param source The object to check
+   * @return If source is a map-like object with single property, that property will be returned
+   *         If source is a map-like object with multiple properties, null is returned, indicating an error
+   *         If source is not a map-like object, it is returned
+   */
+  protected Object getSingleProperty(Object source) {
+    if (source instanceof OResult) {
+      final OResult result = (OResult)source;
+      // TODO we might want to add .size() and iterator with .next() to OResult. The current implementation is
+      // quite heavy compared to the result we actually want (the single first property).
+      final Set<String> propertyNames = result.getPropertyNames();
+      if (propertyNames.size() != 1) {
+        return null;
+      }
+      return result.getProperty(propertyNames.iterator().next());
+    }
+    return source;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
@@ -1,7 +1,6 @@
 package com.orientechnologies.orient.core.sql.functions.graph;
 
 import com.orientechnologies.common.collection.OMultiCollectionIterator;
-import com.orientechnologies.common.collection.OMultiValue;
 import com.orientechnologies.common.util.ORawPair;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.command.OCommandExecutorAbstract;
@@ -12,7 +11,6 @@ import com.orientechnologies.orient.core.record.*;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.record.impl.OEdgeToVertexIterable;
 import com.orientechnologies.orient.core.sql.OSQLHelper;
-import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
 
 import java.util.*;
@@ -67,13 +65,9 @@ public class OSQLFunctionShortestPath extends OSQLFunctionMathAbstract {
     final OShortestPathContext ctx = new OShortestPathContext();
 
     Object source = iParams[0];
-    if (OMultiValue.isMultiValue(source)) {
-      if (OMultiValue.getSize(source) > 1)
-        throw new IllegalArgumentException("Only one sourceVertex is allowed");
-      source = OMultiValue.getFirstValue(source);
-      if (source instanceof OResult && ((OResult) source).isElement()) {
-        source = ((OResult) source).getElement().get();
-      }
+    source = getSingleItem(source);
+    if (source == null) {
+      throw new IllegalArgumentException("Only one sourceVertex is allowed");
     }
     source = OSQLHelper.getValue(source, record, iContext);
     if (source instanceof OIdentifiable) {
@@ -87,13 +81,9 @@ public class OSQLFunctionShortestPath extends OSQLFunctionMathAbstract {
     }
 
     Object dest = iParams[1];
-    if (OMultiValue.isMultiValue(dest)) {
-      if (OMultiValue.getSize(dest) > 1)
-        throw new IllegalArgumentException("Only one destinationVertex is allowed");
-      dest = OMultiValue.getFirstValue(dest);
-      if (dest instanceof OResult && ((OResult) dest).isElement()) {
-        dest = ((OResult) dest).getElement().get();
-      }
+    dest = getSingleItem(dest);
+    if (dest == null) {
+      throw new IllegalArgumentException("Only one destinationVertex is allowed");
     }
     dest = OSQLHelper.getValue(dest, record, iContext);
     if (dest instanceof OIdentifiable) {

--- a/lucene/src/main/java/com/orientechnologies/spatial/functions/OSTDistanceFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/functions/OSTDistanceFunction.java
@@ -23,7 +23,7 @@ import org.locationtech.spatial4j.shape.Shape;
 /**
  * Created by Enrico Risa on 25/09/15.
  */
-public class OSTDistanceFunction extends OSQLFunctionAbstract {
+public class OSTDistanceFunction extends OSpatialFunctionAbstract {
 
   public static final String        NAME    = "st_distance";
   private             OShapeFactory factory = OShapeFactory.INSTANCE;
@@ -35,9 +35,9 @@ public class OSTDistanceFunction extends OSQLFunctionAbstract {
   @Override
   public Object execute(Object iThis, OIdentifiable iCurrentRecord, Object iCurrentResult, Object[] iParams,
       OCommandContext iContext) {
-    Shape shape = factory.fromObject(iParams[0]);
 
-    Shape shape1 = factory.fromObject(iParams[1]);
+    Shape shape = toShape(iParams[0]);
+    Shape shape1 = toShape(iParams[1]);
 
     return factory.operation().distance(shape, shape1);
   }

--- a/lucene/src/main/java/com/orientechnologies/spatial/functions/OSTDistanceSphereFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/functions/OSTDistanceSphereFunction.java
@@ -43,9 +43,10 @@ public class OSTDistanceSphereFunction extends OSpatialFunctionAbstractIndexable
     if (containsNull(iParams)) {
       return null;
     }
-    Shape shape = factory.fromObject(iParams[0]);
 
-    Shape shape1 = factory.fromObject(iParams[1]);
+    Shape shape = toShape(iParams[0]);
+    Shape shape1 = toShape(iParams[1]);
+
     double distance = factory.context().getDistCalc().distance(shape.getCenter(), shape1.getCenter());
     final double docDistInKM = DistanceUtils.degrees2Dist(distance, DistanceUtils.EARTH_EQUATORIAL_RADIUS_KM);
     return docDistInKM * 1000;

--- a/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstract.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstract.java
@@ -18,11 +18,15 @@
 package com.orientechnologies.spatial.functions;
 
 import com.orientechnologies.orient.core.sql.functions.OSQLFunctionAbstract;
+import com.orientechnologies.spatial.shape.OShapeFactory;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * Created by Enrico Risa on 22/07/16.
  */
 public abstract class OSpatialFunctionAbstract extends OSQLFunctionAbstract {
+
+  OShapeFactory factory = OShapeFactory.INSTANCE;
 
   public OSpatialFunctionAbstract(String iName, int iMinParams, int iMaxParams) {
     super(iName, iMinParams, iMaxParams);
@@ -35,5 +39,16 @@ public abstract class OSpatialFunctionAbstract extends OSQLFunctionAbstract {
     }
 
     return false;
+  }
+
+  protected Shape toShape(Object param) {
+    final Object singleItem = getSingleItem(param);
+    if (singleItem != null) {
+      final Object singleProp = getSingleProperty(singleItem);
+      if (singleProp != null) {
+        return factory.fromObject(singleProp);
+      }
+    }
+    return null;
   }
 }

--- a/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstract.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstract.java
@@ -44,7 +44,7 @@ public abstract class OSpatialFunctionAbstract extends OSQLFunctionAbstract {
   protected Shape toShape(Object param) {
     final Object singleItem = getSingleItem(param);
     if (singleItem != null) {
-      final Object singleProp = getSingleProperty(singleItem);
+      final Object singleProp = getSingleProperty(singleItem, false);
       if (singleProp != null) {
         return factory.fromObject(singleProp);
       }

--- a/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstractIndexable.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/functions/OSpatialFunctionAbstractIndexable.java
@@ -28,7 +28,6 @@ import com.orientechnologies.orient.core.sql.executor.OResultInternal;
 import com.orientechnologies.orient.core.sql.functions.OIndexableSQLFunction;
 import com.orientechnologies.orient.core.sql.parser.*;
 import com.orientechnologies.spatial.index.OLuceneSpatialIndex;
-import com.orientechnologies.spatial.shape.OShapeFactory;
 import com.orientechnologies.spatial.strategy.SpatialQueryBuilderAbstract;
 
 import java.util.*;
@@ -38,8 +37,6 @@ import java.util.stream.Collectors;
  * Created by Enrico Risa on 31/08/15.
  */
 public abstract class OSpatialFunctionAbstractIndexable extends OSpatialFunctionAbstract implements OIndexableSQLFunction {
-
-  protected OShapeFactory factory = OShapeFactory.INSTANCE;
 
   public OSpatialFunctionAbstractIndexable(String iName, int iMinParams, int iMaxParams) {
     super(iName, iMinParams, iMaxParams);
@@ -175,5 +172,4 @@ public abstract class OSpatialFunctionAbstractIndexable extends OSpatialFunction
 
     return false;
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/spatial/shape/OPointShapeBuilder.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/shape/OPointShapeBuilder.java
@@ -49,7 +49,7 @@ public class OPointShapeBuilder extends OShapeBuilder<Point> {
     OClass point = schema.createAbstractClass(getName(), superClass(db));
     OProperty coordinates = point.createProperty(COORDINATES, OType.EMBEDDEDLIST, OType.DOUBLE);
     coordinates.setMin("2");
-    coordinates.setMin("2");
+    coordinates.setMax("2");
   }
 
   @Override


### PR DESCRIPTION
This fixes is something I need so t would be great to have it.

The idea is that now we can execute a query with distance function the same way I did with shortestPath. Example:

```
SELECT shortestPath(other.@RID, (SELECT FROM user WHERE userId='msh'), null, "Like", {"maxDepth": 4}) as path, st_distance(other.locationCoordinates, (SELECT locationCoordinates FROM user WHERE userId='msh')) as distance FROM (SELECT out as other FROM Like where in.userId = 'msh')
```
In it you can see both the use of shortestPath (which is currently working) and the use of st_distance (which will currently result in an exception this will fix).

Commit message:
```
- extracted OSQLFunctionShortestPath code to a common function 'getSingleItem' in parent class
- Also aded 'getSingleProperty' on the same idea
- Moved 'OShapeFactory factory' from class 'OSpatialFunctionAbstractIndexable' to parent 'OSpatialFunctionAbstract'
- OSTDistanceFunction now inherts from 'OSpatialFunctionAbstract' instead of 'OSQLFunctionAbstract'
- Added 'toShape' method in OSpatialFunctionAbstract to ease the conversion from a param to a shape. It follows the idea of what is done in OSQLFunctionShortestPath::execute
- OSTDistanceFunction and OSTDistanceSphereFunction use new 'toShape' method
```