### PR TITLE
NPE exception in OCASDiskWriteAheadLog due to uninitialized write buffers

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
@@ -58,9 +58,7 @@ import com.orientechnologies.orient.server.distributed.OModifiableDistributedCon
 import com.orientechnologies.orient.server.distributed.ORemoteServerController;
 import com.orientechnologies.orient.server.distributed.impl.task.ODistributedLockTask;
 import com.orientechnologies.orient.server.distributed.impl.task.OUnreachableServerLocalTask;
-import com.orientechnologies.orient.server.distributed.impl.task.OWaitForTask;
 import com.orientechnologies.orient.server.distributed.task.OAbstractRemoteTask;
-import com.orientechnologies.orient.server.distributed.task.ODistributedOperationException;
 import com.orientechnologies.orient.server.distributed.task.ODistributedRecordLockedException;
 import com.orientechnologies.orient.server.distributed.task.ORemoteTask;
 import com.orientechnologies.orient.server.hazelcast.OHazelcastPlugin;
@@ -241,11 +239,11 @@ public class ODistributedDatabaseImpl implements ODistributedDatabase {
   }
 
   public void reEnqueue(final int senderNodeId, final long msgSequence, final String databaseName, final ORemoteTask payload,
-      int retryCount) {
+      int retryCount, int autoRetryDelay) {
 
     Orient.instance().scheduleTask(
         () -> processRequest(new ODistributedRequest(getManager(), senderNodeId, msgSequence, databaseName, payload), false),
-        10 * retryCount, 0);
+        autoRetryDelay * retryCount, 0);
   }
 
   /**

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase1Task.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase1Task.java
@@ -4,8 +4,8 @@ import com.orientechnologies.orient.client.remote.message.OMessageHelper;
 import com.orientechnologies.orient.client.remote.message.tx.ORecordOperationRequest;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandDistributedReplicateRequest;
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.db.OrientDB;
 import com.orientechnologies.orient.core.db.record.ORecordOperation;
 import com.orientechnologies.orient.core.exception.OConcurrentCreateException;
 import com.orientechnologies.orient.core.exception.OConcurrentModificationException;
@@ -118,9 +118,10 @@ public class OTransactionPhase1Task extends OAbstractReplicatedTask {
       throw e;
     }
     if (res1 == null) {
+      final int autoRetryDelay = OGlobalConfiguration.DISTRIBUTED_CONCURRENT_TX_AUTORETRY_DELAY.getValueAsInteger();
       retryCount++;
       ((ODatabaseDocumentDistributed) database).getStorageDistributed().getLocalDistributedDatabase()
-          .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount);
+          .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount, autoRetryDelay);
       hasResponse = false;
       return null;
     }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase2Task.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase2Task.java
@@ -3,6 +3,7 @@ package com.orientechnologies.orient.server.distributed.impl.task;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandDistributedReplicateRequest;
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.server.OServer;
@@ -91,12 +92,13 @@ public class OTransactionPhase2Task extends OAbstractReplicatedTask {
       ODatabaseDocumentInternal database) throws Exception {
     if (success) {
       if (!((ODatabaseDocumentDistributed) database).commit2pc(transactionId, false, requestId)) {
+        final int autoRetryDelay = OGlobalConfiguration.DISTRIBUTED_CONCURRENT_TX_AUTORETRY_DELAY.getValueAsInteger();
         retryCount++;
         if (retryCount < database.getConfiguration().getValueAsInteger(DISTRIBUTED_CONCURRENT_TX_MAX_AUTORETRY)) {
           OLogManager.instance()
               .debug(OTransactionPhase2Task.this, "Received second phase but not yet first phase, re-enqueue second phase");
           ((ODatabaseDocumentDistributed) database).getStorageDistributed().getLocalDistributedDatabase()
-              .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount);
+              .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount, autoRetryDelay);
           hasResponse = false;
         } else {
           Orient.instance().submit(() -> {
@@ -113,12 +115,13 @@ public class OTransactionPhase2Task extends OAbstractReplicatedTask {
       }
     } else {
       if (!((ODatabaseDocumentDistributed) database).rollback2pc(transactionId)) {
+        final int autoRetryDelay = OGlobalConfiguration.DISTRIBUTED_CONCURRENT_TX_AUTORETRY_DELAY.getValueAsInteger();
         retryCount++;
         if (retryCount < database.getConfiguration().getValueAsInteger(DISTRIBUTED_CONCURRENT_TX_MAX_AUTORETRY)) {
           OLogManager.instance()
               .debug(OTransactionPhase2Task.this, "Received second phase but not yet first phase, re-enqueue second phase");
           ((ODatabaseDocumentDistributed) database).getStorageDistributed().getLocalDistributedDatabase()
-              .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount);
+              .reEnqueue(requestId.getNodeId(), requestId.getMessageId(), database.getName(), this, retryCount, autoRetryDelay);
           hasResponse = false;
         } else {
           //ABORT THE OPERATION IF THERE IS A NOT VALID TRANSACTION ACTIVE WILL BE ROLLBACK ON RE-INSTALL

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedDatabase.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ODistributedDatabase.java
@@ -110,7 +110,7 @@ public interface ODistributedDatabase {
   void waitForOnline();
 
   void reEnqueue(final int senderNodeId, final long msgSequence, final String databaseName, final ORemoteTask payload,
-      int retryCount);
+      int retryCount, int autoRetryDelay);
 
   void processRequest(ODistributedRequest request, boolean waitForAcceptingRequests);
 


### PR DESCRIPTION
During construction of OCASDiskWriteAheadLog, method log(new OEmptyWALRecord()) was called before write buffers writeBufferOne and writeBufferTwo were initialized. In the case that maxCacheSize is smaller than qsize (e.g. after integer type overflow like maxPagesCacheSize * pageSize with maxPagesCacheSize = Integer.MAX). This led to a subsequent doFlush and caused a NPE. Added a test as well.