### PR TITLE
NPE in write buffer capacity limit during int type overflow

### DIFF
--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/OCASDiskWriteAheadLogIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/OCASDiskWriteAheadLogIT.java
@@ -3699,6 +3699,38 @@ public class OCASDiskWriteAheadLogIT {
     wal.close();
   }
 
+  @Test
+  public void testIntegerOverflowNoException() throws Exception {
+    final OCASDiskWriteAheadLog wal = new OCASDiskWriteAheadLog("walTest", testDirectory, testDirectory,
+        Integer.MAX_VALUE, 64, Integer.MAX_VALUE-1, Integer.MAX_VALUE, 20,
+        true, Locale.US, -1, -1, 1000, true, false,
+        false, true, 10);
+    wal.close();
+    Assert.assertEquals("Integer.MAX overflow must be reset to Integer.MAX.",
+        OCASDiskWriteAheadLog.DEFAULT_MAX_CACHE_SIZE, wal.maxCacheSize());
+  }
+
+  @Test
+  public void testIntegerNegativeNoException() throws Exception {
+    final OCASDiskWriteAheadLog wal = new OCASDiskWriteAheadLog("walTest", testDirectory, testDirectory,
+        -27, 64, Integer.MAX_VALUE-1, Integer.MAX_VALUE, 20,
+        true, Locale.US, -1, -1, 1000, true, false,
+        false, true, 10);
+    wal.close();
+    Assert.assertTrue("Negative int must not produce exception in `doFlush`", 0 > wal.maxCacheSize());
+  }
+
+  @Test
+  public void testIntegerNegativeOverflowNoException() throws Exception {
+    final OCASDiskWriteAheadLog wal = new OCASDiskWriteAheadLog("walTest", testDirectory, testDirectory,
+        Integer.MIN_VALUE, 64, Integer.MAX_VALUE-1, Integer.MAX_VALUE, 20,
+        true, Locale.US, -1, -1, 1000, true, false,
+        false, true, 10);
+    wal.close();
+    Assert.assertEquals("Integer.MIN overflow must be reset to Integer.MAX.",
+        OCASDiskWriteAheadLog.DEFAULT_MAX_CACHE_SIZE, wal.maxCacheSize());
+  }
+
   private void checkThatSegmentsBellowAreRemoved(OCASDiskWriteAheadLog wal) {
     final OLogSequenceNumber begin = wal.begin();
 


### PR DESCRIPTION
During construction of OCASDiskWriteAheadLog, method log(new OEmptyWALRecord()) was called before write buffers writeBufferOne and writeBufferTwo were initialized. In the case that maxCacheSize is smaller than qsize (e.g. after integer type overflow like maxPagesCacheSize * pageSize with maxPagesCacheSize = Integer.MAX). This led to a subsequent doFlush and caused a NPE. Added a test as well.