### PR TITLE
minor changes lucene index and engine

### DIFF
--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -186,6 +186,19 @@
             <version>2.2.4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.22</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -35,8 +35,8 @@
 
     <properties>
         <orientdb.version>${project.version}</orientdb.version>
-        <lucene.version>7.3.0</lucene.version>
-        <geotools.version>13.2</geotools.version>
+        <lucene.version>7.3.0</lucene.version> <!-- latest version 8.5.1+ -->
+        <!--<geotools.version>13.2</geotools.version>-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine>-ea
             -Xmx${heapSize}

--- a/lucene/src/main/assembly/assembly.xml
+++ b/lucene/src/main/assembly/assembly.xml
@@ -14,8 +14,6 @@
                 <include>com.spatial4j:*</include>
                 <include>com.vividsolutions:*</include>
             </includes>
-
         </dependencySet>
     </dependencySets>
-
 </assembly>

--- a/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactory.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactory.java
@@ -27,39 +27,31 @@ public class OLuceneDirectoryFactory {
 
   public static final String DIRECTORY_PATH = "directory_path";
 
-  public OLuceneDirectory createDirectory(ODatabaseDocumentInternal database, String indexName, ODocument metadata) {
-
-    String luceneType = metadata.containsField(DIRECTORY_TYPE) ? metadata.<String>field(DIRECTORY_TYPE) : DIRECTORY_MMAP;
-
+  public OLuceneDirectory createDirectory(final ODatabaseDocumentInternal database, final String indexName, final ODocument metadata) {
+    final String luceneType = metadata.containsField(DIRECTORY_TYPE) ? metadata.<String>field(DIRECTORY_TYPE) : DIRECTORY_MMAP;
     if (database.getStorage().getType().equals("memory") || DIRECTORY_RAM.equals(luceneType)) {
-      Directory dir = new RAMDirectory();
+      final Directory dir = new RAMDirectory();
       return new OLuceneDirectory(dir, null);
     }
-
     return createDirectory(database, indexName, metadata, luceneType);
   }
 
-  private OLuceneDirectory createDirectory(ODatabaseDocumentInternal database, String indexName, ODocument metadata,
-      String luceneType) {
-    String luceneBasePath = metadata.containsField(DIRECTORY_PATH) ? metadata.<String>field(DIRECTORY_PATH) : OLUCENE_BASE_DIR;
-
-    Path luceneIndexPath = Paths.get(database.getStorage().getConfiguration().getDirectory(), luceneBasePath, indexName);
+  private OLuceneDirectory createDirectory(final ODatabaseDocumentInternal database, final String indexName, final ODocument metadata,
+      final String luceneType) {
+    final String luceneBasePath = metadata.containsField(DIRECTORY_PATH) ? metadata.<String>field(DIRECTORY_PATH) : OLUCENE_BASE_DIR;
+    final Path luceneIndexPath = Paths.get(database.getStorage().getConfiguration().getDirectory(), luceneBasePath, indexName);
     try {
-
       Directory dir = null;
       if (DIRECTORY_NIO.equals(luceneType)) {
         dir = new NIOFSDirectory(luceneIndexPath);
       } else if (DIRECTORY_MMAP.equals(luceneType)) {
         dir = new MMapDirectory(luceneIndexPath);
       }
-
       return new OLuceneDirectory(dir, luceneIndexPath.toString());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       OLogManager.instance().error(this, "unable to create Lucene Directory with type " + luceneType, e);
     }
-
     OLogManager.instance().warn(this, "unable to create Lucene Directory, FALL BACK to ramDir");
     return new OLuceneDirectory(new RAMDirectory(), null);
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactory.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactory.java
@@ -2,6 +2,7 @@ package com.orientechnologies.lucene.engine;
 
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
+import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
@@ -29,7 +30,7 @@ public class OLuceneDirectoryFactory {
 
   public OLuceneDirectory createDirectory(final ODatabaseDocumentInternal database, final String indexName, final ODocument metadata) {
     final String luceneType = metadata.containsField(DIRECTORY_TYPE) ? metadata.<String>field(DIRECTORY_TYPE) : DIRECTORY_MMAP;
-    if (database.getStorage().getType().equals("memory") || DIRECTORY_RAM.equals(luceneType)) {
+    if (database.getStorage().getType().equals(ODatabaseType.MEMORY.name().toLowerCase()) || DIRECTORY_RAM.equals(luceneType)) {
       final Directory dir = new RAMDirectory();
       return new OLuceneDirectory(dir, null);
     }

--- a/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineAbstract.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineAbstract.java
@@ -201,14 +201,12 @@ public abstract class OLuceneIndexEngineAbstract extends OSharedResourceAdaptive
   }
 
   private void reOpen() throws IOException {
-
     //noinspection resource
     if (indexWriter != null && indexWriter.isOpen() && directory.getDirectory() instanceof RAMDirectory) {
       // don't waste time reopening an in memory index
       return;
     }
     open();
-
   }
 
   protected static ODatabaseDocumentInternal getDatabase() {
@@ -433,9 +431,8 @@ public abstract class OLuceneIndexEngineAbstract extends OSharedResourceAdaptive
     if (closed.get()) {
       try {
         reOpen();
-      } catch (IOException e) {
+      } catch (final IOException e) {
         OLogManager.instance().error(this, "error while opening closed index:: " + indexName(), e);
-
       }
     }
   }

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
@@ -12,25 +12,22 @@ import org.apache.lucene.index.memory.MemoryIndex;
  * Created by frank on 13/02/2017.
  */
 public class OLuceneFunctionsUtils {
-
   public static final String MEMORY_INDEX = "_memoryIndex";
 
   protected static OLuceneFullTextIndex searchForIndex(OExpression[] args, OCommandContext ctx) {
-    String indexName = (String) args[0].execute((OIdentifiable) null, ctx);
-
+    final String indexName = (String) args[0].execute((OIdentifiable) null, ctx);
     return getLuceneFullTextIndex(ctx, indexName);
   }
 
-  protected static OLuceneFullTextIndex getLuceneFullTextIndex(OCommandContext ctx, String indexName) {
-    final ODatabaseDocumentInternal database = (ODatabaseDocumentInternal) ctx.getDatabase();
-    database.activateOnCurrentThread();
-    OMetadataInternal metadata = database.getMetadata();
+  protected static OLuceneFullTextIndex getLuceneFullTextIndex(final OCommandContext ctx, final String indexName) {
+    final ODatabaseDocumentInternal documentDatabase = (ODatabaseDocumentInternal) ctx.getDatabase();
+    documentDatabase.activateOnCurrentThread();
+    final OMetadataInternal metadata = documentDatabase.getMetadata();
 
-    OLuceneFullTextIndex index = (OLuceneFullTextIndex) metadata.getIndexManagerInternal().getIndex(database, indexName);
+    final OLuceneFullTextIndex index = (OLuceneFullTextIndex) metadata.getIndexManagerInternal().getIndex(documentDatabase, indexName);
     if (!(index instanceof OLuceneFullTextIndex)) {
       throw new IllegalArgumentException("Not a valid Lucene index:: " + indexName);
     }
-
     return index;
   }
 
@@ -40,26 +37,21 @@ public class OLuceneFunctionsUtils {
       memoryIndex = new MemoryIndex();
       ctx.setVariable(MEMORY_INDEX, memoryIndex);
     }
-
     memoryIndex.reset();
     return memoryIndex;
   }
 
-  public static String doubleEscape(String s) {
-    StringBuilder sb = new StringBuilder();
-
+  public static String doubleEscape(final String s) {
+    final StringBuilder sb = new StringBuilder();
     for (int i = 0; i < s.length(); ++i) {
-      char c = s.charAt(i);
+      final char c = s.charAt(i);
       if (c == 92 || c == 43 || c == 45 || c == 33 || c == 40 || c == 41 || c == 58 || c == 94 || c == 91 || c == 93 || c == 34
           || c == 123 || c == 125 || c == 126 || c == 42 || c == 63 || c == 124 || c == 38 || c == 47) {
         sb.append('\\');
         sb.append('\\');
       }
-
       sb.append(c);
     }
-
     return sb.toString();
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneFullTextIndex.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneFullTextIndex.java
@@ -64,7 +64,7 @@ public class OLuceneFullTextIndex extends OLuceneIndexNotUnique {
           OLuceneIndexEngine indexEngine = (OLuceneIndexEngine) engine;
           return indexEngine.queryAnalyzer();
         });
-      } catch (OInvalidIndexEngineIdException e) {
+      } catch (final OInvalidIndexEngineIdException e) {
         doReloadIndexEngine();
       }
   }

--- a/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
@@ -461,10 +461,10 @@ public class OLuceneIndexNotUnique extends OIndexAbstract implements OLuceneInde
     while (true) {
       try {
         return storage.callIndexEngine(false, indexId, engine -> {
-          OLuceneIndexEngine indexEngine = (OLuceneIndexEngine) engine;
+          final OLuceneIndexEngine indexEngine = (OLuceneIndexEngine) engine;
           return indexEngine.searcher();
         });
-      } catch (OInvalidIndexEngineIdException e) {
+      } catch (final OInvalidIndexEngineIdException e) {
         doReloadIndexEngine();
       }
     }
@@ -474,5 +474,4 @@ public class OLuceneIndexNotUnique extends OIndexAbstract implements OLuceneInde
   public boolean canBeUsedInEqualityOperators() {
     return false;
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/query/OLuceneKeyAndMetadata.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/query/OLuceneKeyAndMetadata.java
@@ -8,13 +8,11 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
  * Created by frank on 08/06/2017.
  */
 public class OLuceneKeyAndMetadata {
-
   public final OLuceneCompositeKey key;
   public final ODocument           metadata;
 
-  public OLuceneKeyAndMetadata(OLuceneCompositeKey key, ODocument metadata) {
+  public OLuceneKeyAndMetadata(final OLuceneCompositeKey key, final ODocument metadata) {
     this.key = key;
     this.metadata = metadata;
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/query/OLuceneQueryContext.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/query/OLuceneQueryContext.java
@@ -32,16 +32,12 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.highlight.TextFragment;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Created by Enrico Risa on 08/01/15.
  */
 public class OLuceneQueryContext {
-
   private final OCommandContext                 context;
   private final IndexSearcher                   searcher;
   private final Query                           query;
@@ -49,21 +45,20 @@ public class OLuceneQueryContext {
   private       Optional<OLuceneTxChanges>      changes;
   private       HashMap<String, TextFragment[]> fragments;
 
-  public OLuceneQueryContext(OCommandContext context, IndexSearcher searcher, Query query) {
+  public OLuceneQueryContext(final OCommandContext context, final IndexSearcher searcher, final Query query) {
     this(context, searcher, query, Collections.emptyList());
   }
 
-  public OLuceneQueryContext(OCommandContext context, IndexSearcher searcher, Query query, List<SortField> sortFields) {
+  public OLuceneQueryContext(final OCommandContext context, final IndexSearcher searcher, final Query query,
+                             final List<SortField> sortFields) {
     this.context = context;
     this.searcher = searcher;
     this.query = query;
-
     if (sortFields.isEmpty()) {
       sort = null;
     } else {
       sort = new Sort(sortFields.toArray(new SortField[] {}));
     }
-
     changes = Optional.empty();
     fragments = new HashMap<>();
   }
@@ -72,14 +67,13 @@ public class OLuceneQueryContext {
     return changes.isPresent();
   }
 
-  public OLuceneQueryContext withChanges(OLuceneTxChanges changes) {
+  public OLuceneQueryContext withChanges(final OLuceneTxChanges changes) {
     this.changes = Optional.ofNullable(changes);
     return this;
   }
 
-  public OLuceneQueryContext addHighlightFragment(String field, TextFragment[] fieldFragment) {
+  public OLuceneQueryContext addHighlightFragment(final String field, final TextFragment[] fieldFragment) {
     fragments.put(field, fieldFragment);
-
     return this;
   }
 
@@ -100,38 +94,31 @@ public class OLuceneQueryContext {
   }
 
   public IndexSearcher getSearcher() {
-
     return changes.map(c -> new IndexSearcher(multiReader(c)))
         .orElse(searcher);
-
   }
 
-  private MultiReader multiReader(OLuceneTxChanges c) {
+  private MultiReader multiReader(final OLuceneTxChanges luceneTxChanges) {
     try {
-      return new MultiReader(searcher.getIndexReader(), c.searcher().getIndexReader());
-    } catch (IOException e) {
+      return new MultiReader(searcher.getIndexReader(), luceneTxChanges.searcher().getIndexReader());
+    } catch (final IOException e) {
       throw OException.wrapException(new OLuceneIndexException("unable to create reader on changes"), e);
     }
   }
 
-  public long deletedDocs(Query query) {
-
+  public long deletedDocs(final Query query) {
     return changes.map(c -> c.deletedDocs(query)).orElse(0l);
   }
 
-  public boolean isUpdated(Document doc, Object key, OIdentifiable value) {
-
+  public boolean isUpdated(final Document doc, final Object key, final OIdentifiable value) {
     return changes.map(c -> c.isUpdated(doc, key, value)).orElse(false);
-
   }
 
-  public boolean isDeleted(Document doc, Object key, OIdentifiable value) {
-
+  public boolean isDeleted(final Document doc, final Object key, final OIdentifiable value) {
     return changes.map(c -> c.isDeleted(doc, key, value)).orElse(false);
-
   }
 
-  public HashMap<String, TextFragment[]> getFragments() {
+  public Map<String, TextFragment[]> getFragments() {
     return fragments;
   }
 

--- a/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesAbstract.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesAbstract.java
@@ -34,14 +34,13 @@ import java.io.IOException;
  * Created by Enrico Risa on 28/09/15.
  */
 public abstract class OLuceneTxChangesAbstract implements OLuceneTxChanges {
-
   public static final String TMP = "_tmp_rid";
 
   protected final OLuceneIndexEngine engine;
   protected final IndexWriter        writer;
   protected final IndexWriter        deletedIdx;
 
-  public OLuceneTxChangesAbstract(OLuceneIndexEngine engine, IndexWriter writer, IndexWriter deletedIdx) {
+  public OLuceneTxChangesAbstract(final OLuceneIndexEngine engine, final IndexWriter writer, final IndexWriter deletedIdx) {
     this.engine = engine;
     this.writer = writer;
     this.deletedIdx = deletedIdx;
@@ -60,16 +59,13 @@ public abstract class OLuceneTxChangesAbstract implements OLuceneTxChanges {
 
   @Override
   public long deletedDocs(Query query) {
-
     try {
-      IndexSearcher indexSearcher = new IndexSearcher(DirectoryReader.open(deletedIdx, true, true));
-
-      TopDocs search = indexSearcher.search(query, Integer.MAX_VALUE);
+      final IndexSearcher indexSearcher = new IndexSearcher(DirectoryReader.open(deletedIdx, true, true));
+      final TopDocs search = indexSearcher.search(query, Integer.MAX_VALUE);
       return search.totalHits;
     } catch (IOException e) {
       OLogManager.instance().error(this, "Error during searcher index instantiation on deleted documents ", e);
     }
-
     return 0;
   }
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesMultiRid.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesMultiRid.java
@@ -39,11 +39,11 @@ public class OLuceneTxChangesMultiRid extends OLuceneTxChangesAbstract {
   private final Map<String, List<String>> deleted     = new HashMap<String, List<String>>();
   private final Set<Document>             deletedDocs = new HashSet<Document>();
 
-  public OLuceneTxChangesMultiRid(OLuceneIndexEngine engine, IndexWriter writer, IndexWriter deletedIdx) {
+  public OLuceneTxChangesMultiRid(final OLuceneIndexEngine engine, final IndexWriter writer, final IndexWriter deletedIdx) {
     super(engine, writer, deletedIdx);
   }
 
-  public void put(Object key, OIdentifiable value, Document doc) {
+  public void put(final Object key, final OIdentifiable value, final Document doc) {
     try {
       writer.addDocument(doc);
     } catch (IOException e) {
@@ -51,21 +51,19 @@ public class OLuceneTxChangesMultiRid extends OLuceneTxChangesAbstract {
     }
   }
 
-  public void remove(Object key, OIdentifiable value) {
-
+  public void remove(final Object key, final OIdentifiable value) {
     try {
       if (value.getIdentity().isTemporary()) {
         writer.deleteDocuments(engine.deleteQuery(key, value));
       } else {
-
         deleted.putIfAbsent(value.getIdentity().toString(), new ArrayList<>());
         deleted.get(value.getIdentity().toString()).add(key.toString());
 
-        Document doc = engine.buildDocument(key, value);
+        final Document doc = engine.buildDocument(key, value);
         deletedDocs.add(doc);
         deletedIdx.addDocument(doc);
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw OException
           .wrapException(new OLuceneIndexException("Error while deleting documents in transaction from lucene index"), e);
     }
@@ -79,15 +77,15 @@ public class OLuceneTxChangesMultiRid extends OLuceneTxChangesAbstract {
     return deletedDocs;
   }
 
-  public boolean isDeleted(Document document, Object key, OIdentifiable value) {
+  public boolean isDeleted(final Document document, final Object key, final OIdentifiable value) {
     boolean match = false;
-    List<String> strings = deleted.get(value.getIdentity().toString());
+    final List<String> strings = deleted.get(value.getIdentity().toString());
     if (strings != null) {
-      MemoryIndex memoryIndex = new MemoryIndex();
-      for (String string : strings) {
-        Query q = engine.deleteQuery(string, value);
+      final MemoryIndex memoryIndex = new MemoryIndex();
+      for (final String string : strings) {
+        final Query q = engine.deleteQuery(string, value);
         memoryIndex.reset();
-        for (IndexableField field : document.getFields()) {
+        for (final IndexableField field : document.getFields()) {
           memoryIndex.addField(field.name(), field.stringValue(), new KeywordAnalyzer());
         }
         match = match || (memoryIndex.search(q) > 0.0f);
@@ -98,8 +96,7 @@ public class OLuceneTxChangesMultiRid extends OLuceneTxChangesAbstract {
   }
 
   // TODO is this valid?
-  public boolean isUpdated(Document document, Object key, OIdentifiable value) {
+  public boolean isUpdated(final Document document, final Object key, final OIdentifiable value) {
     return false;
   }
-
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesSingleRid.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/tx/OLuceneTxChangesSingleRid.java
@@ -35,16 +35,15 @@ import java.util.Set;
  * Created by Enrico Risa on 15/09/15.
  */
 public class OLuceneTxChangesSingleRid extends OLuceneTxChangesAbstract {
-
   private final Set<String>   deleted     = new HashSet<String>();
   private final Set<String>   updated     = new HashSet<String>();
   private final Set<Document> deletedDocs = new HashSet<Document>();
 
-  public OLuceneTxChangesSingleRid(OLuceneIndexEngine engine, IndexWriter writer, IndexWriter deletedIdx) {
+  public OLuceneTxChangesSingleRid(final OLuceneIndexEngine engine, final IndexWriter writer, final IndexWriter deletedIdx) {
     super(engine, writer, deletedIdx);
   }
 
-  public void put(Object key, OIdentifiable value, Document doc) {
+  public void put(final Object key, final OIdentifiable value, final Document doc) {
     if (deleted.remove(value.getIdentity().toString())) {
       doc.add(OLuceneIndexType.createField(TMP, value.getIdentity().toString(), Field.Store.YES));
       updated.add(value.getIdentity().toString());
@@ -56,8 +55,7 @@ public class OLuceneTxChangesSingleRid extends OLuceneTxChangesAbstract {
     }
   }
 
-  public void remove(Object key, OIdentifiable value) {
-
+  public void remove(final Object key, final OIdentifiable value) {
     try {
       if (value.getIdentity().isTemporary()) {
         writer.deleteDocuments(engine.deleteQuery(key, value));
@@ -66,9 +64,8 @@ public class OLuceneTxChangesSingleRid extends OLuceneTxChangesAbstract {
         Document doc = engine.buildDocument(key, value);
         deletedDocs.add(doc);
         deletedIdx.addDocument(doc);
-
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw OException
           .wrapException(new OLuceneIndexException("Error while deleting documents in transaction from lucene index"), e);
     }
@@ -89,5 +86,4 @@ public class OLuceneTxChangesSingleRid extends OLuceneTxChangesAbstract {
   public boolean isUpdated(Document document, Object key, OIdentifiable value) {
     return updated.contains(value.getIdentity().toString());
   }
-
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/benchmark/FulltextIndexFunctionBenchmark.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/benchmark/FulltextIndexFunctionBenchmark.java
@@ -1,4 +1,106 @@
 package com.orientechnologies.lucene.benchmark;
 
+import com.orientechnologies.common.io.OIOUtils;
+import com.orientechnologies.orient.core.db.*;
+import com.orientechnologies.orient.core.sql.executor.OResultSet;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 3, batchSize = 1)
+@Warmup(iterations = 3, batchSize = 1)
+@Fork(3)
 public class FulltextIndexFunctionBenchmark {
+  public static void main(String[] args) throws RunnerException {
+    final Options opt = new OptionsBuilder().include("FulltextIndexFunctionBenchmark.*")
+        // .addProfiler(StackProfiler.class, "detailLine=true;excludePackages=true;period=1")
+        .jvmArgs("-server", "-XX:+UseConcMarkSweepGC", "-Xmx4G", "-Xms1G")
+        // .result("target" + "/" + "results.csv")
+        // .param("offHeapMessages", "true""
+        // .resultFormat(ResultFormatType.CSV)
+        .build();
+    new Runner(opt).run();
+  }
+
+  private ODatabaseDocumentInternal db;
+  private OrientDB                  context;
+  private ODatabaseType             type;
+
+  private String name = "lucene-benchmark";
+
+  @Setup(Level.Iteration)
+  public void setup() {
+    this.setupDatabase();
+
+    final InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
+    db.execute("sql", getScriptFromStream(stream));
+    db.command("create index Song.title on Song (title) FULLTEXT ENGINE LUCENE ");
+    db.command("create index Song.author on Song (author) FULLTEXT ENGINE LUCENE ");
+    db.command("create index Song.lyrics_description on Song (lyrics,description) FULLTEXT ENGINE LUCENE ");
+  }
+
+  private void setupDatabase() {
+    final String config = System.getProperty("orientdb.test.env", ODatabaseType.MEMORY.name().toLowerCase());
+    String path;
+    if ("ci".equals(config) || "release".equals(config)) {
+      type = ODatabaseType.PLOCAL;
+      path = "embedded:./target/databases";
+    } else {
+      type = ODatabaseType.MEMORY;
+      path = "embedded:.";
+    }
+    context = new OrientDB(path, OrientDBConfig.defaultConfig());
+
+    if (context.exists(name)) {
+      context.drop(name);
+    }
+    context.create(name, type);
+
+    db = (ODatabaseDocumentInternal) context.open(name, "admin", "admin");
+    db.set(ODatabase.ATTRIBUTES.MINIMUMCLUSTERS, 8);
+  }
+
+  private String getScriptFromStream(final InputStream scriptStream) {
+    try {
+      return OIOUtils.readStreamAsString(scriptStream);
+    } catch (final IOException e) {
+      throw new RuntimeException("Could not read script stream.", e);
+    }
+  }
+
+  @TearDown(Level.Iteration)
+  public void tearDown() {
+    db.activateOnCurrentThread();
+    context.drop(name);
+  }
+
+  @Benchmark
+  public void searchOnSingleField() {
+    final OResultSet resultSet = db.query("SELECT from Song where SEARCH_FIELDS(['title'], 'BELIEVE') = true");
+    resultSet.close();
+  }
+
+  @Benchmark
+  public void searhOnTwoFieldsInOR() {
+    final OResultSet resultSet = db
+        .query("SELECT from Song where SEARCH_FIELDS(['title'], 'BELIEVE') = true OR SEARCH_FIELDS(['author'], 'Bob') = true ");
+    resultSet.close();
+  }
+
+  @Benchmark
+  public void searhOnTwoFieldsInAND() throws Exception {
+    final OResultSet resultSet = db
+        .query("SELECT from Song where SEARCH_FIELDS(['title'], 'tambourine') = true AND SEARCH_FIELDS(['author'], 'Bob') = true ");
+    resultSet.close();
+  }
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/benchmark/FulltextIndexFunctionBenchmark.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/benchmark/FulltextIndexFunctionBenchmark.java
@@ -1,0 +1,4 @@
+package com.orientechnologies.lucene.benchmark;
+
+public class FulltextIndexFunctionBenchmark {
+}

--- a/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
@@ -1,6 +1,7 @@
 package com.orientechnologies.lucene.engine;
 
 import com.orientechnologies.lucene.test.BaseLuceneTest;
+import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.index.OIndexDefinition;
 import com.orientechnologies.orient.core.record.impl.ODocument;
@@ -68,7 +69,7 @@ public class OLuceneDirectoryFactoryTest extends BaseLuceneTest {
   @Test
   public void shouldCreateRamDirectoryOnMemoryDatabase() throws Exception {
     meta.field(DIRECTORY_TYPE, DIRECTORY_RAM);
-    final ODatabaseDocumentTx db = dropOrCreate("memory:" + name.getMethodName(), true);
+    final ODatabaseDocumentTx db = dropOrCreate(ODatabaseType.MEMORY.name().toLowerCase() + ":" + name.getMethodName(), true);
     final Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
     // 'memory:' determines RAMDirectory and not DIRECTORY_MMAP or DIRECTORY_RAM.
     // In fact, they lead to the same result regarding this test

--- a/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
@@ -67,12 +67,20 @@ public class OLuceneDirectoryFactoryTest extends BaseLuceneTest {
   }
 
   @Test
-  public void shouldCreateRamDirectoryOnMemoryDatabase() throws Exception {
+  public void shouldCreateRamDirectoryOnMemoryDatabase() {
     meta.field(DIRECTORY_TYPE, DIRECTORY_RAM);
     final ODatabaseDocumentTx db = dropOrCreate(ODatabaseType.MEMORY.name().toLowerCase() + ":" + name.getMethodName(), true);
     final Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
-    // 'memory:' determines RAMDirectory and not DIRECTORY_MMAP or DIRECTORY_RAM.
-    // In fact, they lead to the same result regarding this test
+    // 'ODatabaseType.MEMORY' and 'DIRECTORY_RAM' determines the RAMDirectory.
+    assertThat(directory).isInstanceOf(RAMDirectory.class);
+  }
+
+  @Test
+  public void shouldCreateRamDirectoryOnMemoryFromMmapDatabase() {
+    meta.field(DIRECTORY_TYPE, DIRECTORY_MMAP);
+    final ODatabaseDocumentTx db = dropOrCreate(ODatabaseType.MEMORY.name().toLowerCase() + ":" + name.getMethodName(), true);
+    final Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
+    // 'ODatabaseType.MEMORY' plus 'DIRECTORY_MMAP' leads to the same result as just 'DIRECTORY_RAM'.
     assertThat(directory).isInstanceOf(RAMDirectory.class);
   }
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/engine/OLuceneDirectoryFactoryTest.java
@@ -23,83 +23,55 @@ import static org.mockito.Mockito.when;
  * Created by frank on 03/03/2016.
  */
 public class OLuceneDirectoryFactoryTest extends BaseLuceneTest {
-
   private OLuceneDirectoryFactory fc;
   private ODocument               meta;
   private OIndexDefinition        indexDef;
 
   @Before
   public void setUp() throws Exception {
-
     meta = new ODocument();
     indexDef = Mockito.mock(OIndexDefinition.class);
     when(indexDef.getFields()).thenReturn(Collections.<String>emptyList());
     when(indexDef.getClassName()).thenReturn("Song");
-
     fc = new OLuceneDirectoryFactory();
-
   }
 
   @Test
   public void shouldCreateNioFsDirectory() throws Exception {
-
     meta.field(DIRECTORY_TYPE, DIRECTORY_NIO);
-
     ODatabaseDocumentTx db = dropOrCreate("plocal:./target/testDatabase/" + name.getMethodName(), true);
-
     Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
-
     assertThat(directory).isInstanceOf(NIOFSDirectory.class);
-
     assertThat(new File("./target/testDatabase/" + name.getMethodName() + "/luceneIndexes/index.name")).exists();
-
     db.drop();
-
   }
 
   @Test
   public void shouldCreateMMapFsDirectory() throws Exception {
-
     meta.field(DIRECTORY_TYPE, DIRECTORY_MMAP);
-
     ODatabaseDocumentTx db = dropOrCreate("plocal:./target/testDatabase/" + name.getMethodName(), true);
-
     Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
-
     assertThat(directory).isInstanceOf(MMapDirectory.class);
-
     assertThat(new File("./target/testDatabase/" + name.getMethodName() + "/luceneIndexes/index.name")).exists();
-
     db.drop();
-
   }
 
   @Test
   public void shouldCreateRamDirectory() throws Exception {
-
     meta.field(DIRECTORY_TYPE, DIRECTORY_RAM);
-
     ODatabaseDocumentTx db = dropOrCreate("plocal:./target/testDatabase/" + name.getMethodName(), true);
-
     Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
-
     assertThat(directory).isInstanceOf(RAMDirectory.class);
-
     db.drop();
-
   }
 
   @Test
   public void shouldCreateRamDirectoryOnMemoryDatabase() throws Exception {
-
-    //WRONG type!!!
-    meta.field(DIRECTORY_TYPE, DIRECTORY_MMAP);
-
-    ODatabaseDocumentTx db = dropOrCreate("memory:" + name.getMethodName(), true);
-
-    Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
-
+    meta.field(DIRECTORY_TYPE, DIRECTORY_RAM);
+    final ODatabaseDocumentTx db = dropOrCreate("memory:" + name.getMethodName(), true);
+    final Directory directory = fc.createDirectory(db, "index.name", meta).getDirectory();
+    // 'memory:' determines RAMDirectory and not DIRECTORY_MMAP or DIRECTORY_RAM.
+    // In fact, they lead to the same result regarding this test
     assertThat(directory).isInstanceOf(RAMDirectory.class);
   }
-
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunctionTest.java
@@ -17,12 +17,9 @@ public class OLuceneSearchOnClassFunctionTest extends OLuceneBaseTest {
 
   @Before
   public void setUp() throws Exception {
-    InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
-
+    final InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
     db.execute("sql", getScriptFromStream(stream));
-
     db.command("create index Song.title on Song (title) FULLTEXT ENGINE LUCENE ");
-
   }
 
   @Test

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
@@ -34,55 +34,41 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
 
   @Test
   public void shouldSearchOnSingleFieldWithLeadingWildcard() throws Exception {
-
     //TODO: metadata still not used
-    OResultSet resultSet = db
+    final OResultSet resultSet = db
         .query("SELECT from Song where SEARCH_INDEX('Song.title', '*EVE*', {'allowLeadingWildcard': true}) = true");
-
     assertThat(resultSet).hasSize(14);
-
     resultSet.close();
   }
 
   @Test
   public void shouldSearhOnTwoFieldsInOR() throws Exception {
-
-    OResultSet resultSet = db
+    final OResultSet resultSet = db
         .query("SELECT from Song where SEARCH_FIELDS(['title'], 'BELIEVE') = true OR SEARCH_FIELDS(['author'], 'Bob') = true ");
-
     assertThat(resultSet).hasSize(41);
     resultSet.close();
-
   }
 
   @Test
   public void shouldSearhOnTwoFieldsInAND() throws Exception {
-
-    OResultSet resultSet = db
+    final OResultSet resultSet = db
         .query("SELECT from Song where SEARCH_FIELDS(['title'], 'tambourine') = true AND SEARCH_FIELDS(['author'], 'Bob') = true ");
-
     assertThat(resultSet).hasSize(1);
     resultSet.close();
-
   }
 
   @Test
   public void shouldSearhOnTwoFieldsWithLeadingWildcardInAND() throws Exception {
-
-    OResultSet resultSet = db.query(
+    final OResultSet resultSet = db.query(
         "SELECT from Song where SEARCH_FIELDS(['title'], 'tambourine') = true AND SEARCH_FIELDS(['author'], 'Bob', {'allowLeadingWildcard': true}) = true ");
-
     assertThat(resultSet).hasSize(1);
     resultSet.close();
-
   }
 
   @Test
   public void shouldSearchOnMultiFieldIndex() throws Exception {
-
     OResultSet resultSet = db
         .query("SELECT from Song where SEARCH_FIELDS(['lyrics','description'], '(description:happiness) (lyrics:sad)  ') = true ");
-
     assertThat(resultSet).hasSize(2);
     resultSet.close();
 
@@ -93,37 +79,28 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
     resultSet.close();
 
     resultSet = db.query("SELECT from Song where SEARCH_FIELDS(['description'], '(description:happiness) (lyrics:sad)  ') = true ");
-
     assertThat(resultSet).hasSize(2);
     resultSet.close();
-
   }
 
   @Test(expected = OCommandExecutionException.class)
   public void shouldFailWithWrongFieldName() throws Exception {
-
     db.query("SELECT from Song where SEARCH_FIELDS(['wrongName'], '(description:happiness) (lyrics:sad)  ') = true ");
-
   }
 
   @Test
   public void shouldSearchWithHesitance() throws Exception {
-
     db.command("create class RockSong extends Song");
     db.command("create vertex RockSong set title=\"This is only rock\", author=\"A cool rocker\"");
-
-    OResultSet resultSet = db.query("SELECT from RockSong where SEARCH_FIELDS(['title'], '+only +rock') = true ");
-
+    final OResultSet resultSet = db.query("SELECT from RockSong where SEARCH_FIELDS(['title'], '+only +rock') = true ");
     assertThat(resultSet).hasSize(1);
     resultSet.close();
-
   }
 
   @Test
   public void testSquareBrackets() throws Exception {
-
-    String className = "testSquareBrackets";
-    String classNameE = "testSquareBracketsE";
+    final String className = "testSquareBrackets";
+    final String classNameE = "testSquareBracketsE";
 
     db.command("create class " + className + " extends V;");
     db.command("create property " + className + ".id Integer;");
@@ -140,13 +117,12 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
     db.command("CREATE EDGE " + classNameE + " FROM (SELECT FROM " + className + " WHERE id = 1) to (SELECT FROM " + className
         + " WHERE id IN [2, 3, 4]);");
 
-    OResultSet result = db.query(
+    final OResultSet result = db.query(
         "SELECT out('" + classNameE + "')[SEARCH_FIELDS(['name'], 'A*') = true] as theList FROM " + className + " WHERE id = 1;");
     assertThat(result.hasNext());
-    OResult item = result.next();
+    final OResult item = result.next();
     assertThat((Object) item.getProperty("theList")).isInstanceOf(List.class);
     assertThat((List) item.getProperty("theList")).hasSize(3);
     result.close();
-
   }
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
@@ -16,27 +16,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by frank on 15/01/2017.
  */
 public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
-
   @Before
   public void setUp() throws Exception {
-    InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
-
+    final InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
     db.execute("sql", getScriptFromStream(stream));
-
     db.command("create index Song.title on Song (title) FULLTEXT ENGINE LUCENE ");
     db.command("create index Song.author on Song (author) FULLTEXT ENGINE LUCENE ");
-
     db.command("create index Song.lyrics_description on Song (lyrics,description) FULLTEXT ENGINE LUCENE ");
-
   }
 
   @Test
   public void shouldSearchOnSingleField() throws Exception {
-
-    OResultSet resultSet = db.query("SELECT from Song where SEARCH_FIELDS(['title'], 'BELIEVE') = true");
-
+    final OResultSet resultSet = db.query("SELECT from Song where SEARCH_FIELDS(['title'], 'BELIEVE') = true");
     assertThat(resultSet).hasSize(2);
-
     resultSet.close();
   }
 

--- a/lucene/src/test/java/com/orientechnologies/lucene/integration/LuceneDropIndexIntegrationTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/integration/LuceneDropIndexIntegrationTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class LuceneDropIndexIntegrationTest {
-
   private OServer server0;
   private OServer server1;
 
@@ -28,7 +27,7 @@ public class LuceneDropIndexIntegrationTest {
   public void before() throws Exception {
     server0 = OServer.startFromClasspathConfig("com/orientechnologies/lucene/integration/orientdb-simple-dserver-config-0.xml");
     server1 = OServer.startFromClasspathConfig("com/orientechnologies/lucene/integration/orientdb-simple-dserver-config-1.xml");
-    OrientDB remote = new OrientDB("remote:localhost", "root", "test", OrientDBConfig.defaultConfig());
+    final OrientDB remote = new OrientDB("remote:localhost", "root", "test", OrientDBConfig.defaultConfig());
     remote.create("LuceneDropIndexIntegrationTest", ODatabaseType.PLOCAL);
     ODatabaseSession session = remote.open("LuceneDropIndexIntegrationTest", "admin", "admin");
 

--- a/lucene/src/test/java/com/orientechnologies/lucene/test/BaseLuceneTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/test/BaseLuceneTest.java
@@ -44,7 +44,7 @@ public abstract class BaseLuceneTest {
 
   @Before
   public void setupDatabase() throws Throwable {
-    final String config = System.getProperty("orientdb.test.env", "memory");
+    final String config = System.getProperty("orientdb.test.env", ODatabaseType.MEMORY.name().toLowerCase());
     String path;
 
     if ("ci".equals(config) || "release".equals(config)) {

--- a/lucene/src/test/java/com/orientechnologies/lucene/test/BaseLuceneTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/test/BaseLuceneTest.java
@@ -33,7 +33,6 @@ import java.io.InputStream;
  * Created by enricorisa on 19/09/14.
  */
 public abstract class BaseLuceneTest {
-
   @Rule
   public TestName name = new TestName();
 

--- a/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneBaseTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneBaseTest.java
@@ -43,11 +43,8 @@ public abstract class OLuceneBaseTest {
 
   @Before
   public void setupDatabase() {
-
-    String config = System.getProperty("orientdb.test.env", "memory");
-
+    final String config = System.getProperty("orientdb.test.env", ODatabaseType.MEMORY.name().toLowerCase());
     setupDatabase(config);
-
   }
 
   protected void setupDatabase(String config) {


### PR DESCRIPTION
Mainly changes to engine and index, plus tests
- lucene used not the latest version
- resolved ram vs mmap test question
- added first fulltext index micro-benchmark (remember: the numbers below are just data.)

Benchmark                      Mode  Cnt    Score     Error     Units
searchOnSingleField         avgt    9  177,222 ±  74,125  us/op
searhOnTwoFieldsInAND  avgt    9  688,765 ± 175,903  us/op
searhOnTwoFieldsInOR     avgt    9  171,380 ±  33,513  us/op