### PR TITLE
Fix eval with result and variable

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/LetExpressionStep.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/LetExpressionStep.java
@@ -40,6 +40,7 @@ public class LetExpressionStep extends AbstractExecutionStep {
       public OResult next() {
         OResultInternal result = (OResultInternal) source.next();
         Object value = expression.execute(result, ctx);
+        ctx.setVariable(varname.getStringValue(), value);
         result.setMetadata(varname.getStringValue(), value);
         return result;
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OSelectExecutionPlanner.java
@@ -726,7 +726,7 @@ public class OSelectExecutionPlanner {
       Iterator<OLetItem> iterator = info.perRecordLetClause.getItems().iterator();
       while (iterator.hasNext()) {
         OLetItem item = iterator.next();
-        if (item.getExpression() != null && (item.getExpression().isEarlyCalculated(ctx) || isUnionAllOfQueries(info,
+        if (item.getExpression() != null && (item.getExpression().isEarlyCalculated(item.getVarName(), ctx) || isUnionAllOfQueries(info,
             item.getVarName(), item.getExpression()))) {
           iterator.remove();
           addGlobalLet(info, item.getVarName(), item.getExpression());
@@ -2332,7 +2332,7 @@ public class OSelectExecutionPlanner {
             String fieldName = left.getDefaultAlias().getStringValue();
             if (indexField.equals(fieldName)) {
               OBinaryCompareOperator operator = ((OBinaryCondition) singleExp).getOperator();
-              if (!((OBinaryCondition) singleExp).getRight().isEarlyCalculated(ctx)) {
+              if (!((OBinaryCondition) singleExp).getRight().isEarlyCalculated(null, ctx)) {
                 continue; //this cannot be used because the value depends on single record
               }
               if (operator instanceof OEqualsCompareOperator) {
@@ -2400,7 +2400,7 @@ public class OSelectExecutionPlanner {
           if (left.isBaseIdentifier()) {
             String fieldName = left.getDefaultAlias().getStringValue();
             if (indexField.equals(fieldName)) {
-              if (!((OContainsAnyCondition) singleExp).getRight().isEarlyCalculated(ctx)) {
+              if (!((OContainsAnyCondition) singleExp).getRight().isEarlyCalculated(null, ctx)) {
                 continue; //this cannot be used because the value depends on single record
               }
               found = true;
@@ -2420,7 +2420,7 @@ public class OSelectExecutionPlanner {
             if (indexField.equals(fieldName)) {
               if (((OInCondition) singleExp).getRightMathExpression() != null) {
 
-                if (!((OInCondition) singleExp).getRightMathExpression().isEarlyCalculated(ctx)) {
+                if (!((OInCondition) singleExp).getRightMathExpression().isEarlyCalculated(null, ctx)) {
                   continue; //this cannot be used because the value depends on single record
                 }
                 found = true;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OArrayConcatExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OArrayConcatExpression.java
@@ -93,9 +93,9 @@ public class OArrayConcatExpression extends SimpleNode {
     return result;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     for (OArrayConcatExpressionElement element : childExpressions) {
-      if (!element.isEarlyCalculated(ctx)) {
+      if (!element.isEarlyCalculated(varName, ctx)) {
         return false;
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBaseExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBaseExpression.java
@@ -223,11 +223,11 @@ public class OBaseExpression extends OMathExpression {
     return identifier != null && modifier == null ? identifier.getCollate(currentRecord, ctx) : null;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     if (number != null || inputParam != null || string != null) {
       return true;
     }
-    if (identifier != null && identifier.isEarlyCalculated(ctx)) {
+    if (identifier != null && identifier.isEarlyCalculated(varName, ctx)) {
       return true;
     }
     return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBaseIdentifier.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBaseIdentifier.java
@@ -200,11 +200,11 @@ public class OBaseIdentifier extends SimpleNode {
     return false;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
-    if (levelZero != null && levelZero.isEarlyCalculated(ctx)) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
+    if (levelZero != null && levelZero.isEarlyCalculated(varName, ctx)) {
       return true;
     }
-    if (suffix != null && suffix.isEarlyCalculated(ctx)) {
+    if (suffix != null && suffix.isEarlyCalculated(varName, ctx)) {
       return true;
     }
     return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBinaryCondition.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OBinaryCondition.java
@@ -397,7 +397,7 @@ public class OBinaryCondition extends OBooleanExpression {
 
   @Override
   public OBooleanExpression rewriteIndexChainsAsSubqueries(OCommandContext ctx, OClass clazz) {
-    if (operator instanceof OEqualsCompareOperator && right.isEarlyCalculated(ctx) && left.isIndexChain(ctx, clazz)) {
+    if (operator instanceof OEqualsCompareOperator && right.isEarlyCalculated(null, ctx) && left.isIndexChain(ctx, clazz)) {
       OInCondition result = new OInCondition(-1);
 
       result.left = new OExpression(-1);

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OCollection.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OCollection.java
@@ -88,7 +88,7 @@ public class OCollection extends SimpleNode {
     if (isAggregate()) {
       OCollection result = new OCollection(-1);
       for (OExpression exp : this.expressions) {
-        if (exp.isAggregate() || exp.isEarlyCalculated(ctx)) {
+        if (exp.isAggregate() || exp.isEarlyCalculated(null, ctx)) {
           result.expressions.add(exp.splitForAggregation(aggregateProj, ctx));
         } else {
           throw new OCommandExecutionException("Cannot mix aggregate and non-aggregate operations in a collection: " + toString());
@@ -100,9 +100,9 @@ public class OCollection extends SimpleNode {
     }
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     for (OExpression exp : expressions) {
-      if (!exp.isEarlyCalculated(ctx)) {
+      if (!exp.isEarlyCalculated(varName, ctx)) {
         return false;
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OExpression.java
@@ -145,12 +145,12 @@ public class OExpression extends SimpleNode {
     return false;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     if (this.mathExpression != null) {
-      return this.mathExpression.isEarlyCalculated(ctx);
+      return this.mathExpression.isEarlyCalculated(varName, ctx);
     }
     if (this.arrayConcatExpression != null) {
-      return this.arrayConcatExpression.isEarlyCalculated(ctx);
+      return this.arrayConcatExpression.isEarlyCalculated(varName, ctx);
     }
 
     if (booleanValue != null) {
@@ -166,7 +166,7 @@ public class OExpression extends SimpleNode {
       return true;
     }
     if (value instanceof OMathExpression) {
-      return ((OMathExpression) value).isEarlyCalculated(ctx);
+      return ((OMathExpression) value).isEarlyCalculated(varName, ctx);
     }
 
     return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OIdentifier.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OIdentifier.java
@@ -166,7 +166,7 @@ public class OIdentifier extends SimpleNode {
     return result;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     if (internalAlias) {
       return true;
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OLevelZeroIdentifier.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OLevelZeroIdentifier.java
@@ -184,14 +184,14 @@ public class OLevelZeroIdentifier extends SimpleNode {
     return functionCall != null && functionCall.name.getStringValue().equalsIgnoreCase("count");
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
-    if (functionCall != null && functionCall.isEarlyCalculated(ctx)) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
+    if (functionCall != null && functionCall.isEarlyCalculated(varName, ctx)) {
       return true;
     }
     if (Boolean.TRUE.equals(self)) {
       return false;
     }
-    if (collection != null && collection.isEarlyCalculated(ctx)) {
+    if (collection != null && collection.isEarlyCalculated(varName, ctx)) {
       return true;
     }
     return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OMathExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OMathExpression.java
@@ -873,9 +873,9 @@ public class OMathExpression extends SimpleNode {
     return null;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     for (OMathExpression exp : childExpressions) {
-      if (!exp.isEarlyCalculated(ctx)) {
+      if (!exp.isEarlyCalculated(varName, ctx)) {
         return false;
       }
     }
@@ -930,7 +930,7 @@ public class OMathExpression extends SimpleNode {
         SimpleNode splitResult = expr.splitForAggregation(aggregateProj, ctx);
         if (splitResult instanceof OMathExpression) {
           OMathExpression res = (OMathExpression) splitResult;
-          if (res.isEarlyCalculated(ctx) || res.isAggregate()) {
+          if (res.isEarlyCalculated(null, ctx) || res.isAggregate()) {
             result.childExpressions.add(res);
           } else {
             throw new OCommandExecutionException("Cannot mix aggregate and single record attribute values in the same projection");

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OParenthesisExpression.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OParenthesisExpression.java
@@ -91,9 +91,9 @@ public class OParenthesisExpression extends OMathExpression {
   }
 
   @Override
-  public boolean isEarlyCalculated(OCommandContext ctx) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
     // TODO implement query execution and early calculation;
-    return expression != null && expression.isEarlyCalculated(ctx);
+    return expression != null && expression.isEarlyCalculated(varName, ctx);
   }
 
   public boolean needsAliases(Set<String> aliases) {

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OSuffixIdentifier.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OSuffixIdentifier.java
@@ -261,8 +261,8 @@ public class OSuffixIdentifier extends SimpleNode {
     return this;
   }
 
-  public boolean isEarlyCalculated(OCommandContext ctx) {
-    if (identifier != null && identifier.isEarlyCalculated(ctx)) {
+  public boolean isEarlyCalculated(OIdentifier varName, OCommandContext ctx) {
+    if (identifier != null && identifier.isEarlyCalculated(varName, ctx)) {
       return true;
     }
     return false;

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OWhereClause.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OWhereClause.java
@@ -237,7 +237,7 @@ public class OWhereClause extends SimpleNode {
       if (expression instanceof OBinaryCondition) {
         OBinaryCondition b = (OBinaryCondition) expression;
         if (b.operator instanceof OEqualsCompareOperator) {
-          if (b.left.isBaseIdentifier() && b.right.isEarlyCalculated(ctx)) {
+          if (b.left.isBaseIdentifier() && b.right.isEarlyCalculated(null, ctx)) {
             result.put(b.left.toString(), b.right.execute((OResult) null, ctx));
           }
         }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/parser/OSelectStatementTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/parser/OSelectStatementTest.java
@@ -601,8 +601,8 @@ public class OSelectStatementTest {
     List<OAndBlock> flattended = stm.whereClause.flatten();
     assertTrue(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).left.isBaseIdentifier());
     assertFalse(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).right.isBaseIdentifier());
-    assertFalse(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).left.isEarlyCalculated(new OBasicCommandContext()));
-    assertTrue(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).right.isEarlyCalculated(new OBasicCommandContext()));
+    assertFalse(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).left.isEarlyCalculated(null, new OBasicCommandContext()));
+    assertTrue(((OBinaryCondition) flattended.get(0).subBlocks.get(0)).right.isEarlyCalculated(null, new OBasicCommandContext()));
 
   }
 


### PR DESCRIPTION
- OFunctionCall:isEarlyCalculate - if eval function, check if string
contains the varName.
- Let expression step: save the result in the context (where it will be
taken again in the next row)
- isEarlyCalculate: also get the variable name the result is put in.

resolves #9240 

Notes:
- I've looked and tested what I can, but I'm not familiar enough with the area of the code changes, so a thorough review should be done to verify this code is valid in all cases