### PR TITLE
update hazelcast and plugin to enable hazelcast on k8s

### DIFF
--- a/distributed/config/hazelcast.xml
+++ b/distributed/config/hazelcast.xml
@@ -40,6 +40,7 @@
 			<kubernetes enabled="false">
 				<pod-label-name>orientdb-cluster-member</pod-label-name>
 				<pod-label-value>true</pod-label-value>
+				<service-port>2434</service-port>
 			</kubernetes>
 		</join>
 	</network>

--- a/distributed/config/hazelcast.xml
+++ b/distributed/config/hazelcast.xml
@@ -9,7 +9,7 @@
 	the specific language governing permissions and ~ limitations under the License. -->
 
 <hazelcast
-		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.3.xsd"
+		xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.11.xsd"
 		xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<group>
 		<name>orientdb</name>
@@ -37,6 +37,10 @@
 				<multicast-group>235.1.1.1</multicast-group>
 				<multicast-port>2434</multicast-port>
 			</multicast>
+			<kubernetes enabled="false">
+				<pod-label-name>orientdb-cluster-member</pod-label-name>
+				<pod-label-value>true</pod-label-value>
+			</kubernetes>
 		</join>
 	</network>
 	<executor-service>

--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -37,7 +37,7 @@
     <name>OrientDB Distributed Server</name>
 
     <properties>
-        <hz.version>3.10.6</hz.version>
+        <hz.version>3.11.7</hz.version>
         <javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
@@ -134,6 +134,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${hz.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-kubernetes</artifactId>
+            <version>1.5.3</version>
         </dependency>
     </dependencies>
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -21,6 +21,7 @@ package com.orientechnologies.orient.server.hazelcast;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.Hazelcast;
@@ -36,8 +37,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.config.JoinConfig;
-import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.orientechnologies.common.concur.OOfflineNodeException;
 import com.orientechnologies.common.concur.lock.OInterruptedException;
@@ -854,12 +853,16 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
     if (enableKubernetesDiscoveryEnvVar) {
       JoinConfig joinConfig = hazelcastConfig.getNetworkConfig().getJoin();
       if (joinConfig.getKubernetesConfig() == null) {
-        ODistributedServerLog.warn(this, nodeName, null, DIRECTION.NONE,
-                "No Kubernetes join config found in %s. Ignore enabling Hazelcast Kubernetes discovery.",
-                hazelcastConfigFile);
+        ODistributedServerLog.warn(
+            this,
+            nodeName,
+            null,
+            DIRECTION.NONE,
+            "No Kubernetes join config found in %s. Ignore enabling Hazelcast Kubernetes discovery.",
+            hazelcastConfigFile);
       } else {
-        ODistributedServerLog.info(this, nodeName, null, DIRECTION.NONE,
-                "Enabling Hazelcast Kubernetes discovery.");
+        ODistributedServerLog.info(
+            this, nodeName, null, DIRECTION.NONE, "Enabling Hazelcast Kubernetes discovery.");
         joinConfig.getMulticastConfig().setEnabled(false);
         joinConfig.getKubernetesConfig().setEnabled(true);
       }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -859,12 +859,9 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
                 hazelcastConfigFile);
       } else {
         ODistributedServerLog.info(this, nodeName, null, DIRECTION.NONE,
-                "Enabling Hazelcast Kubernetes discovery. Setting Hazelcast port to %d.",
-                NetworkConfig.DEFAULT_PORT);
+                "Enabling Hazelcast Kubernetes discovery.");
         joinConfig.getMulticastConfig().setEnabled(false);
         joinConfig.getKubernetesConfig().setEnabled(true);
-        // use default port in kubernetes. Hazelcast's pod-label-based discovery allows only default port!
-        hazelcastConfig.getNetworkConfig().setPort(NetworkConfig.DEFAULT_PORT);
       }
     }
     return Hazelcast.newHazelcastInstance(hazelcastConfig);


### PR DESCRIPTION
This will make it possible to deploy OrientDB on K8s in distributed mode by defining the environment variable `ENABLE_KUBERNETES_DISCOVERY` for the pod. All pods with the same label name/value (specified in hazelcast.xml) will form one cluster.