### PR TITLE
Fixed the usage of the shortestPath function for multiple edge types

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.sql.functions.graph;
 
+import static java.util.stream.Collectors.toList;
+
 import com.orientechnologies.common.collection.OMultiCollectionIterator;
 import com.orientechnologies.common.util.ORawPair;
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -18,6 +20,7 @@ import com.orientechnologies.orient.core.sql.OSQLHelper;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -129,7 +132,14 @@ public class OSQLFunctionShortestPath extends OSQLFunctionMathAbstract {
     if (iParams.length > 3) {
       ctx.edgeType = iParams[3] == null ? null : "" + iParams[3];
     }
-    ctx.edgeTypeParam = new String[] {ctx.edgeType};
+
+    if (iParams.length > 2 && iParams[3] instanceof Collection) {
+      Collection<?> coll = (Collection<?>) iParams[3];
+      ctx.edgeTypeParam =
+          coll.stream().map(String::valueOf).collect(toList()).toArray(new String[] {});
+    } else {
+      ctx.edgeTypeParam = new String[] {ctx.edgeType};
+    }
 
     if (iParams.length > 4) {
       bindAdditionalParams(iParams[4], ctx);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -6507,6 +6507,9 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
       } else if (walRecord instanceof OAtomicUnitEndRecord) {
         //noinspection UnnecessaryContinue
         continue;
+      } else if (walRecord instanceof OHighLevelTransactionChangeRecord) {
+        //noinspection UnnecessaryContinue
+        continue;
       } else {
         OLogManager.instance()
             .error(

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPathTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPathTest.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.sql.functions.graph;
 
+import static java.util.Arrays.asList;
+
 import com.orientechnologies.orient.core.command.OBasicCommandContext;
 import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.OrientDB;
@@ -118,6 +120,22 @@ public class OSQLFunctionShortestPathTest {
     Assert.assertEquals(vertices.get(2).getIdentity(), result.get(1));
     Assert.assertEquals(vertices.get(3).getIdentity(), result.get(2));
     Assert.assertEquals(vertices.get(4).getIdentity(), result.get(3));
+  }
+
+  @Test
+  public void testExecuteOnlyEdge1AndEdge2() throws Exception {
+    final List<ORID> result =
+        function.execute(
+            null,
+            null,
+            null,
+            new Object[] {vertices.get(1), vertices.get(4), "BOTH", asList("Edge1", "Edge2")},
+            new OBasicCommandContext());
+
+    Assert.assertEquals(3, result.size());
+    Assert.assertEquals(vertices.get(1).getIdentity(), result.get(0));
+    Assert.assertEquals(vertices.get(3).getIdentity(), result.get(1));
+    Assert.assertEquals(vertices.get(4).getIdentity(), result.get(2));
   }
 
   @Test

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
@@ -414,7 +414,6 @@ public class ODistributedDatabaseImpl implements ODistributedDatabase {
     ORemoteTask task = request.getTask();
     try {
       manager.messageProcessStart(request);
-      waitIsReady(task);
       Object response;
       if (task.isUsingDatabase()) {
         try (ODatabaseDocumentInternal db =

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
@@ -1,21 +1,36 @@
 package com.orientechnologies.orient.server.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.orientechnologies.common.types.OModifiableInteger;
 import com.orientechnologies.orient.server.distributed.ODistributedLockManager;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class OHazelcastLockManager implements ODistributedLockManager {
+  private HazelcastInstance hazelcast;
+  private Set<String> lockedResurces = new HashSet<>();
+
+  private static final ThreadLocal<Map<String, OModifiableInteger>> ACQUIRED_REENTRANT =
+      ThreadLocal.withInitial(
+          () -> {
+            return new HashMap<>();
+          });
+
   public OHazelcastLockManager(HazelcastInstance hazelcast) {
     this.hazelcast = hazelcast;
   }
 
-  private HazelcastInstance hazelcast;
-  private Set<String> lockedResurces = new HashSet<>();
-
   @Override
   public void acquireExclusiveLock(String resource, String nodeSource, long timeout) {
+    OModifiableInteger counter;
+    if ((counter = ACQUIRED_REENTRANT.get().get(resource)) != null) {
+      counter.increment();
+      return;
+    }
+
     if (timeout != 0) {
       try {
         hazelcast.getLock(resource).tryLock(timeout, TimeUnit.MILLISECONDS);
@@ -28,10 +43,22 @@ public class OHazelcastLockManager implements ODistributedLockManager {
     synchronized (this) {
       lockedResurces.add(resource);
     }
+    ACQUIRED_REENTRANT.get().put(resource, new OModifiableInteger(0));
   }
 
   @Override
   public void releaseExclusiveLock(String resource, String nodeSource) {
+    OModifiableInteger counter = ACQUIRED_REENTRANT.get().get(resource);
+    if (counter == null)
+      // DO NOTHING BECAUSE THE ACQUIRE DIDN'T HAPPEN IN DISTRIBUTED
+      return;
+
+    if (counter.getValue() > 0) {
+      counter.decrement();
+      return;
+    }
+
+    ACQUIRED_REENTRANT.get().remove(resource);
     hazelcast.getLock(resource).unlock();
     synchronized (this) {
       lockedResurces.remove(resource);
@@ -44,10 +71,10 @@ public class OHazelcastLockManager implements ODistributedLockManager {
   @Override
   public void shutdown() {
     synchronized (this) {
-      HashSet<String> res = new HashSet<>(lockedResurces);
-      for (String resource : res) {
-        releaseExclusiveLock(resource, null);
+      for (String resource : lockedResurces) {
+        hazelcast.getLock(resource).unlock();
       }
+      lockedResurces.clear();
     }
   }
 }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -284,8 +284,6 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
 
       messageService = new ODistributedMessageServiceImpl(this);
 
-      initSystemDatabase();
-
       ODistributedServerLog.info(
           this,
           localNodeName,
@@ -369,20 +367,6 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
     }
 
     dumpServersStatus();
-  }
-
-  /** Protecte system database from being replicated */
-  protected void initSystemDatabase() {
-    final ODocument defaultCfg =
-        getStorage(OSystemDatabase.SYSTEM_DB_NAME)
-            .loadDatabaseConfiguration(getDefaultDatabaseConfigFile());
-    defaultCfg.field("autoDeploy", false);
-    final OModifiableDistributedConfiguration sysCfg =
-        new OModifiableDistributedConfiguration(defaultCfg);
-    sysCfg.removeServer("<NEW_NODE>");
-
-    messageService.registerDatabase(OSystemDatabase.SYSTEM_DB_NAME, sysCfg);
-    sysCfg.addNewNodeInServerList(getLocalNodeName());
   }
 
   private void initRegisteredNodeIds() {

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/DistributedSuperNodeIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/DistributedSuperNodeIT.java
@@ -28,13 +28,11 @@ import com.orientechnologies.orient.core.record.OVertex;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.server.OServer;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /** Distributed TX test against "plocal" protocol. */
 public class DistributedSuperNodeIT extends AbstractServerClusterGraphTest {
   @Test
-  @Ignore
   public void test() throws Exception {
     final long timeout = OGlobalConfiguration.DISTRIBUTED_ATOMIC_LOCK_TIMEOUT.getValueAsLong();
     OGlobalConfiguration.DISTRIBUTED_ATOMIC_LOCK_TIMEOUT.setValue(1);

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/HARemoteGraphIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/HARemoteGraphIT.java
@@ -2,7 +2,6 @@ package com.orientechnologies.orient.server.distributed;
 
 import com.orientechnologies.orient.core.db.ODatabasePool;
 import com.orientechnologies.orient.core.db.OrientDBConfig;
-import org.junit.Ignore;
 
 /**
  * Test case to check the right management of distributed exception while a server is starting.
@@ -13,7 +12,6 @@ import org.junit.Ignore;
  *
  * @author Luca Garulli (l.garulli--(at)--orientdb.com)
  */
-@Ignore
 public class HARemoteGraphIT extends HALocalGraphIT {
   @Override
   protected String getDatabaseURL(final ServerRun server) {

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/OneNodeFrozenIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/OneNodeFrozenIT.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -37,7 +36,6 @@ public class OneNodeFrozenIT extends AbstractServerClusterTxTest {
   final AtomicInteger nodeLefts = new AtomicInteger();
 
   @Test
-  @Ignore
   public void test() throws Exception {
     startupNodesInSequence = true;
     count = 1500;


### PR DESCRIPTION
The commit 3b660af55ee8f6fa34336a47fde71c9e93504175 suggests a solution to a problem where the shortestPath function can take an array of labels that the function should only traverse. In version 3.X the fix is not present.