### PR TITLE
Regression on SQL range queries with indexes

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
@@ -378,7 +378,6 @@ public final class OCellBTreeMultiValueIndexEngine
       if (lastKey == null) {
         return emptyStream();
       }
-
       return mvTree.iterateEntriesMinor(lastKey, true, false);
     } else {
       assert svTree != null;
@@ -449,12 +448,22 @@ public final class OCellBTreeMultiValueIndexEngine
           rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder);
     }
     assert svTree != null;
-    
+
+    // "from", "to" are null, then scan whole tree as for infinite range or return empty stream
+    if (rangeFrom == null && rangeTo == null) {
+      return emptyStream();
+    }
+
+    // "from" could be null, then "to" is not (minor)
+    final OCompositeKey toKey = convertToCompositeKey(rangeTo);
+    if (rangeFrom == null) {
+      return mapSVStream(svTree.iterateEntriesMinor(toKey, toInclusive, ascSortOrder));
+    }
     final OCompositeKey fromKey = convertToCompositeKey(rangeFrom);
+    // "to" could be null, then "from" is not (major)
     if (rangeTo == null) {
       return mapSVStream(svTree.iterateEntriesMajor(fromKey, fromInclusive, ascSortOrder));
     }
-    final OCompositeKey toKey = convertToCompositeKey(rangeTo);
     return mapSVStream(
         svTree.iterateEntriesBetween(fromKey, fromInclusive, toKey, toInclusive, ascSortOrder));
   }
@@ -487,7 +496,6 @@ public final class OCellBTreeMultiValueIndexEngine
     if (mvTree != null) {
       return mvTree.iterateEntriesMinor(toKey, isInclusive, ascSortOrder);
     }
-
     assert svTree != null;
 
     final OCompositeKey lastKey = convertToCompositeKey(toKey);
@@ -506,7 +514,7 @@ public final class OCellBTreeMultiValueIndexEngine
     return svTreeEntries();
   }
 
-  private long mvTreeSize(ValuesTransformer transformer) {
+  private long mvTreeSize(final ValuesTransformer transformer) {
     assert mvTree != null;
 
     // calculate amount of keys
@@ -537,10 +545,8 @@ public final class OCellBTreeMultiValueIndexEngine
                   .count();
         }
       }
-
       return counter;
     }
-
     // calculate amount of entries
     return mvTree.size();
   }
@@ -548,7 +554,6 @@ public final class OCellBTreeMultiValueIndexEngine
   private long svTreeEntries() {
     assert svTree != null;
     assert nullTree != null;
-
     return svTree.size() + nullTree.size();
   }
 
@@ -562,13 +567,11 @@ public final class OCellBTreeMultiValueIndexEngine
     if (mvTree != null) {
       mvTree.acquireAtomicExclusiveLock();
     }
-
     assert svTree != null;
     assert nullTree != null;
 
     svTree.acquireAtomicExclusiveLock();
     nullTree.acquireAtomicExclusiveLock();
-
     return true;
   }
 
@@ -577,7 +580,7 @@ public final class OCellBTreeMultiValueIndexEngine
     return name;
   }
 
-  private static OType[] calculateTypes(OType[] keyTypes) {
+  private static OType[] calculateTypes(final OType[] keyTypes) {
     final OType[] sbTypes;
     if (keyTypes != null) {
       sbTypes = new OType[keyTypes.length + 1];
@@ -589,7 +592,7 @@ public final class OCellBTreeMultiValueIndexEngine
     return sbTypes;
   }
 
-  private static OCompositeKey createCompositeKey(Object key, ORID value) {
+  private static OCompositeKey createCompositeKey(final Object key, final ORID value) {
     final OCompositeKey compositeKey = new OCompositeKey(key);
     compositeKey.addKey(value);
     return compositeKey;
@@ -599,7 +602,6 @@ public final class OCellBTreeMultiValueIndexEngine
     if (compositeKey == null) {
       return null;
     }
-
     final List<Object> keys = compositeKey.getKeys();
 
     final Object key;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
@@ -449,15 +449,14 @@ public final class OCellBTreeMultiValueIndexEngine
           rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder);
     }
     assert svTree != null;
+    
     final OCompositeKey fromKey = convertToCompositeKey(rangeFrom);
-    final OCompositeKey toKey = convertToCompositeKey(rangeTo);
-
-    if (toKey == null || (toKey.getKeys().size() == 1 && toKey.getKeys().get(0) == null)) {
+    if (rangeTo == null) {
       return mapSVStream(svTree.iterateEntriesMajor(fromKey, fromInclusive, ascSortOrder));
-    } else {
-      return mapSVStream(
-          svTree.iterateEntriesBetween(fromKey, fromInclusive, toKey, toInclusive, ascSortOrder));
     }
+    final OCompositeKey toKey = convertToCompositeKey(rangeTo);
+    return mapSVStream(
+        svTree.iterateEntriesBetween(fromKey, fromInclusive, toKey, toInclusive, ascSortOrder));
   }
 
   private static OCompositeKey convertToCompositeKey(Object rangeFrom) {

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
@@ -387,7 +387,6 @@ public final class OCellBTreeMultiValueIndexEngine
       if (lastKey == null) {
         return emptyStream();
       }
-
       return mapSVStream(svTree.iterateEntriesMinor(lastKey, true, false));
     }
   }
@@ -449,12 +448,11 @@ public final class OCellBTreeMultiValueIndexEngine
       return mvTree.iterateEntriesBetween(
           rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder);
     }
-
     assert svTree != null;
     final OCompositeKey fromKey = convertToCompositeKey(rangeFrom);
     final OCompositeKey toKey = convertToCompositeKey(rangeTo);
 
-    if (toKey.getKeys().size() == 1 && toKey.getKeys().get(0) == null) {
+    if (toKey == null || (toKey.getKeys().size() == 1 && toKey.getKeys().get(0) == null)) {
       return mapSVStream(svTree.iterateEntriesMajor(fromKey, fromInclusive, ascSortOrder));
     } else {
       return mapSVStream(

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
@@ -449,9 +449,9 @@ public final class OCellBTreeMultiValueIndexEngine
     }
     assert svTree != null;
 
-    // "from", "to" are null, then scan whole tree as for infinite range or return empty stream
+    // "from", "to" are null, then scan whole tree as for infinite range
     if (rangeFrom == null && rangeTo == null) {
-      return emptyStream();
+      return mapSVStream(svTree.allEntries());
     }
 
     // "from" could be null, then "to" is not (minor)

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeMultiValueIndexEngine.java
@@ -451,11 +451,15 @@ public final class OCellBTreeMultiValueIndexEngine
     }
 
     assert svTree != null;
-    final OCompositeKey firstKey = convertToCompositeKey(rangeFrom);
-    final OCompositeKey lastKey = convertToCompositeKey(rangeTo);
+    final OCompositeKey fromKey = convertToCompositeKey(rangeFrom);
+    final OCompositeKey toKey = convertToCompositeKey(rangeTo);
 
-    return mapSVStream(
-        svTree.iterateEntriesBetween(firstKey, fromInclusive, lastKey, toInclusive, ascSortOrder));
+    if (toKey.getKeys().size() == 1 && toKey.getKeys().get(0) == null) {
+      return mapSVStream(svTree.iterateEntriesMajor(fromKey, fromInclusive, ascSortOrder));
+    } else {
+      return mapSVStream(
+          svTree.iterateEntriesBetween(fromKey, fromInclusive, toKey, toInclusive, ascSortOrder));
+    }
   }
 
   private static OCompositeKey convertToCompositeKey(Object rangeFrom) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/OCellBTreeSingleValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/OCellBTreeSingleValue.java
@@ -55,6 +55,8 @@ public interface OCellBTreeSingleValue<K> {
 
   Stream<K> keyStream();
 
+  Stream<ORawPair<K, ORID>> allEntries();
+
   Stream<ORawPair<K, ORID>> iterateEntriesBetween(
       K keyFrom, boolean fromInclusive, K keyTo, boolean toInclusive, boolean ascSortOrder);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v1/CellBTreeSingleValueV1.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v1/CellBTreeSingleValueV1.java
@@ -45,6 +45,8 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoper
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationsManager;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurableComponent;
 import com.orientechnologies.orient.core.storage.index.sbtree.singlevalue.OCellBTreeSingleValue;
+import com.orientechnologies.orient.core.storage.index.sbtree.singlevalue.v3.CellBTreeSingleValueV3;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -728,6 +730,22 @@ public final class CellBTreeSingleValueV1<K> extends ODurableComponent
           new OCellBTreeSingleValueV1Exception(
               "Error during finding first key in sbtree [" + getName() + "]", this),
           e);
+    } finally {
+      atomicOperationsManager.releaseReadLock(this);
+    }
+  }
+
+  public Stream<ORawPair<K, ORID>> allEntries() {
+    atomicOperationsManager.acquireReadLock(this);
+    try {
+      acquireSharedLock();
+      try {
+        //noinspection resource
+        return StreamSupport.stream(
+            new CellBTreeSpliteratorForward(null, null, false, false), false);
+      } finally {
+        releaseSharedLock();
+      }
     } finally {
       atomicOperationsManager.releaseReadLock(this);
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v1/CellBTreeSingleValueV1.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v1/CellBTreeSingleValueV1.java
@@ -45,8 +45,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoper
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationsManager;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.base.ODurableComponent;
 import com.orientechnologies.orient.core.storage.index.sbtree.singlevalue.OCellBTreeSingleValue;
-import com.orientechnologies.orient.core.storage.index.sbtree.singlevalue.v3.CellBTreeSingleValueV3;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3.java
@@ -698,6 +698,21 @@ public final class CellBTreeSingleValueV3<K> extends ODurableComponent
     }
   }
 
+  public Stream<ORawPair<K, ORID>> allEntries() {
+    atomicOperationsManager.acquireReadLock(this);
+    try {
+      acquireSharedLock();
+      try {
+        //noinspection resource
+        return StreamSupport.stream(new SpliteratorForward(null, null, false, false), false);
+      } finally {
+        releaseSharedLock();
+      }
+    } finally {
+      atomicOperationsManager.releaseReadLock(this);
+    }
+  }
+
   public Stream<ORawPair<K, ORID>> iterateEntriesBetween(
       final K keyFrom,
       final boolean fromInclusive,

--- a/core/src/test/java/com/orientechnologies/common/comparator/DefaultComparatorTest.java
+++ b/core/src/test/java/com/orientechnologies/common/comparator/DefaultComparatorTest.java
@@ -1,0 +1,33 @@
+package com.orientechnologies.common.comparator;
+
+import com.orientechnologies.orient.core.index.OAlwaysLessKey;
+import com.orientechnologies.orient.core.index.OCompositeKey;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Comparator;
+
+/**
+ * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
+ * @author Daniel Ritter
+ * @since 11.07.12
+ */
+public class DefaultComparatorTest {
+  private ODefaultComparator comparator = ODefaultComparator.INSTANCE;
+
+  @Test
+  public void testCompareStrings() {
+    final OCompositeKey keyOne = new OCompositeKey("name4", OType.STRING);
+    final OCompositeKey keyTwo = new OCompositeKey("name5", OType.STRING);
+
+    assertCompareTwoKeys(comparator, keyOne, keyTwo);
+  }
+
+  private void assertCompareTwoKeys(
+      final Comparator<Object> comparator, final Object keyOne, final Object keyTwo) {
+    Assert.assertTrue(comparator.compare(keyOne, keyTwo) < 0);
+    Assert.assertTrue(comparator.compare(keyTwo, keyOne) > 0);
+    Assert.assertTrue(comparator.compare(keyTwo, keyTwo) == 0);
+  }
+}

--- a/core/src/test/java/com/orientechnologies/common/comparator/DefaultComparatorTest.java
+++ b/core/src/test/java/com/orientechnologies/common/comparator/DefaultComparatorTest.java
@@ -1,12 +1,10 @@
 package com.orientechnologies.common.comparator;
 
-import com.orientechnologies.orient.core.index.OAlwaysLessKey;
 import com.orientechnologies.orient.core.index.OCompositeKey;
 import com.orientechnologies.orient.core.metadata.schema.OType;
+import java.util.Comparator;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Comparator;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)

--- a/core/src/test/java/com/orientechnologies/orient/core/index/OCompositeKeyTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/index/OCompositeKeyTest.java
@@ -163,6 +163,15 @@ public class OCompositeKeyTest {
   }
 
   @Test
+  public void testCompareStringsToLT() {
+    final OCompositeKey compositeKey = new OCompositeKey();
+    compositeKey.addKey("name4");
+    final OCompositeKey anotherCompositeKey = new OCompositeKey();
+    anotherCompositeKey.addKey("name5");
+    assertEquals(compositeKey.compareTo(anotherCompositeKey), -1);
+  }
+
+  @Test
   public void testCompareToSymmetryOne() {
     final OCompositeKey compositeKeyOne = new OCompositeKey();
     compositeKeyOne.addKey(1);

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ExecutionPlanPrintUtils.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ExecutionPlanPrintUtils.java
@@ -9,9 +9,9 @@ public class ExecutionPlanPrintUtils {
 
   public static void printExecutionPlan(String query, OResultSet result) {
     if (query != null) {
-      // System.out.println(query);
+      System.out.println(query);
     }
-    // result.getExecutionPlan().ifPresent(x -> System.out.println(x.prettyPrint(0, 3)));
-    // System.out.println();
+    result.getExecutionPlan().ifPresent(x -> System.out.println(x.prettyPrint(0, 3)));
+    System.out.println();
   }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -38,6 +38,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Ignore;
 
 /** @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com) */
 public class OSelectStatementExecutionTest {

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -4047,6 +4047,7 @@ public class OSelectStatementExecutionTest {
     }
   }
 
+  @Test
   public void testCountGroupBy() {
     // issue #9288
     String className = "testCountGroupBy";
@@ -4167,5 +4168,52 @@ public class OSelectStatementExecutionTest {
     } catch (OTimeoutException ex) {
       Assert.fail();
     }
+  }
+
+  @Test
+  public void testSimpleRangeQueryWithIndex() {
+    final String className = "testSimpleRangeQueryWithIndex";
+    final OClass clazz = db.getMetadata().getSchema().createClass(className);
+    final OProperty prop = clazz.createProperty("name", OType.STRING);
+    prop.createIndex(OClass.INDEX_TYPE.NOTUNIQUE);
+
+    for (int i = 0; i < 10; i++) {
+      final ODocument doc = db.newInstance(className);
+      doc.setProperty("name", "name" + i);
+      doc.save();
+    }
+    final OResultSet result = db.query("select from " + className + " WHERE name >= 'name5'");
+    printExecutionPlan(result);
+
+    for (int i = 0; i < 5; i++) {
+      Assert.assertTrue(result.hasNext());
+      System.out.println(result.next());
+    }
+    Assert.assertFalse(result.hasNext());
+    result.close();
+  }
+
+  @Test
+  public void testSimpleRangeQueryWithOutIndex() {
+    final String className = "testSimpleRangeQueryWithIndex";
+    final OClass clazz = db.getMetadata().getSchema().createClass(className);
+    final OProperty prop = clazz.createProperty("name", OType.STRING);
+    // Hash Index skipped for range query
+    prop.createIndex(OClass.INDEX_TYPE.NOTUNIQUE_HASH_INDEX);
+
+    for (int i = 0; i < 10; i++) {
+      final ODocument doc = db.newInstance(className);
+      doc.setProperty("name", "name" + i);
+      doc.save();
+    }
+    final OResultSet result = db.query("select from " + className + " WHERE name >= 'name5'");
+    printExecutionPlan(result);
+
+    for (int i = 0; i < 5; i++) {
+      Assert.assertTrue(result.hasNext());
+      System.out.println(result.next());
+    }
+    Assert.assertFalse(result.hasNext());
+    result.close();
   }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -4193,6 +4193,7 @@ public class OSelectStatementExecutionTest {
     result.close();
   }
 
+  @Ignore
   @Test
   public void testSimpleRangeQueryWithOutIndex() {
     final String className = "testSimpleRangeQueryWithIndex";

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -4172,9 +4172,9 @@ public class OSelectStatementExecutionTest {
   }
 
   @Test
-  public void testSimpleRangeQueryWithIndex() {
-    final String className = "testSimpleRangeQueryWithIndex";
-    final OClass clazz = db.getMetadata().getSchema().createClass(className);
+  public void testSimpleRangeQueryWithIndexGTE() {
+    final String className = "testSimpleRangeQueryWithIndexGTE";
+    final OClass clazz = db.getMetadata().getSchema().getOrCreateClass(className);
     final OProperty prop = clazz.createProperty("name", OType.STRING);
     prop.createIndex(OClass.INDEX_TYPE.NOTUNIQUE);
 
@@ -4194,11 +4194,33 @@ public class OSelectStatementExecutionTest {
     result.close();
   }
 
-  @Ignore
+  @Test
+  public void testSimpleRangeQueryWithIndexLTE() {
+    final String className = "testSimpleRangeQueryWithIndexLTE";
+    final OClass clazz = db.getMetadata().getSchema().getOrCreateClass(className);
+    final OProperty prop = clazz.createProperty("name", OType.STRING);
+    prop.createIndex(OClass.INDEX_TYPE.NOTUNIQUE);
+
+    for (int i = 0; i < 10; i++) {
+      final ODocument doc = db.newInstance(className);
+      doc.setProperty("name", "name" + i);
+      doc.save();
+    }
+    final OResultSet result = db.query("select from " + className + " WHERE name <= 'name5'");
+    printExecutionPlan(result);
+
+    for (int i = 0; i < 6; i++) {
+      Assert.assertTrue(result.hasNext());
+      System.out.println(result.next());
+    }
+    Assert.assertFalse(result.hasNext());
+    result.close();
+  }
+
   @Test
   public void testSimpleRangeQueryWithOutIndex() {
-    final String className = "testSimpleRangeQueryWithIndex";
-    final OClass clazz = db.getMetadata().getSchema().createClass(className);
+    final String className = "testSimpleRangeQueryWithOutIndex";
+    final OClass clazz = db.getMetadata().getSchema().getOrCreateClass(className);
     final OProperty prop = clazz.createProperty("name", OType.STRING);
     // Hash Index skipped for range query
     prop.createIndex(OClass.INDEX_TYPE.NOTUNIQUE_HASH_INDEX);

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -38,7 +38,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 
 /** @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com) */
 public class OSelectStatementExecutionTest {

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
@@ -80,10 +80,8 @@ public class CellBTreeSingleValueV3TestIT {
     String[] lastKey = new String[1];
     for (int i = 0; i < keysCount / rollbackInterval; i++) {
       for (int n = 0; n < 2; n++) {
-
         final int iterationCounter = i;
         final int rollbackCounter = n;
-
         try {
           atomicOperationsManager.executeInsideAtomicOperation(
               null,
@@ -118,7 +116,6 @@ public class CellBTreeSingleValueV3TestIT {
         } catch (RollbackException ignore) {
         }
       }
-
       Assert.assertEquals("0", singleValueTree.firstKey());
       Assert.assertEquals(lastKey[0], singleValueTree.lastKey());
     }
@@ -132,7 +129,6 @@ public class CellBTreeSingleValueV3TestIT {
         System.out.printf("%d items tested out of %d%n", i, keysCount);
       }
     }
-
     for (int i = keysCount; i < 2 * keysCount; i++) {
       Assert.assertNull(singleValueTree.get(Integer.toString(i)));
     }
@@ -155,7 +151,6 @@ public class CellBTreeSingleValueV3TestIT {
                 for (int i = 0; i < rollbackRange; i++) {
                   int val = random.nextInt(Integer.MAX_VALUE);
                   String key = Integer.toString(val);
-
                   singleValueTree.put(atomicOperation, key, new ORecordId(val % 32000, val));
 
                   if (rollbackCounter == 1) {
@@ -174,7 +169,6 @@ public class CellBTreeSingleValueV3TestIT {
 
     Assert.assertEquals(singleValueTree.firstKey(), keys.first());
     Assert.assertEquals(singleValueTree.lastKey(), keys.last());
-
     for (String key : keys) {
       final int val = Integer.parseInt(key);
       Assert.assertEquals(singleValueTree.get(key), new ORecordId(val % 32000, val));
@@ -185,7 +179,6 @@ public class CellBTreeSingleValueV3TestIT {
   public void testKeyPutRandomGaussian() throws Exception {
     NavigableSet<String> keys = new TreeSet<>();
     long seed = System.currentTimeMillis();
-
     System.out.println("testKeyPutRandomGaussian seed : " + seed);
 
     Random random = new Random(seed);
@@ -210,7 +203,6 @@ public class CellBTreeSingleValueV3TestIT {
                   if (rollbackCounter == 1) {
                     keys.add(key);
                   }
-
                   Assert.assertEquals(singleValueTree.get(key), new ORecordId(val % 32000, val));
                 }
                 if (rollbackCounter == 0) {
@@ -221,7 +213,6 @@ public class CellBTreeSingleValueV3TestIT {
         }
       }
     }
-
     Assert.assertEquals(singleValueTree.firstKey(), keys.first());
     Assert.assertEquals(singleValueTree.lastKey(), keys.last());
 
@@ -250,7 +241,6 @@ public class CellBTreeSingleValueV3TestIT {
     Iterator<String> keysIterator = keys.iterator();
     while (keysIterator.hasNext()) {
       String key = keysIterator.next();
-
       if (Integer.parseInt(key) % 3 == 0) {
         atomicOperationsManager.executeInsideAtomicOperation(
             null, atomicOperation -> singleValueTree.remove(atomicOperation, key));
@@ -273,7 +263,6 @@ public class CellBTreeSingleValueV3TestIT {
       } catch (RollbackException ignore) {
       }
     }
-
     Assert.assertEquals(singleValueTree.firstKey(), keys.first());
     Assert.assertEquals(singleValueTree.lastKey(), keys.last());
 
@@ -291,9 +280,7 @@ public class CellBTreeSingleValueV3TestIT {
   public void testKeyDeleteRandomGaussian() throws Exception {
     NavigableSet<String> keys = new TreeSet<>();
     final int keysCount = 1_000_000;
-
     long seed = System.currentTimeMillis();
-
     System.out.println("testKeyDeleteRandomGaussian seed : " + seed);
     Random random = new Random(seed);
 
@@ -302,7 +289,6 @@ public class CellBTreeSingleValueV3TestIT {
       if (val < 0) {
         continue;
       }
-
       String key = Integer.toString(val);
       atomicOperationsManager.executeInsideAtomicOperation(
           null,
@@ -312,7 +298,6 @@ public class CellBTreeSingleValueV3TestIT {
 
       Assert.assertEquals(singleValueTree.get(key), new ORecordId(val % 32000, val));
     }
-
     Iterator<String> keysIterator = keys.iterator();
 
     final int rollbackInterval = 10;
@@ -324,7 +309,6 @@ public class CellBTreeSingleValueV3TestIT {
             null, atomicOperation -> singleValueTree.remove(atomicOperation, key));
         keysIterator.remove();
       }
-
       try {
         atomicOperationsManager.executeInsideAtomicOperation(
             null,
@@ -341,7 +325,6 @@ public class CellBTreeSingleValueV3TestIT {
       } catch (RollbackException ignore) {
       }
     }
-
     Assert.assertEquals(singleValueTree.firstKey(), keys.first());
     Assert.assertEquals(singleValueTree.lastKey(), keys.last());
 
@@ -367,7 +350,6 @@ public class CellBTreeSingleValueV3TestIT {
               singleValueTree.put(
                   atomicOperation, Integer.toString(k), new ORecordId(k % 32000, k)));
     }
-
     final int rollbackInterval = 100;
 
     for (int i = 0; i < keysCount / rollbackInterval; i++) {
@@ -395,7 +377,6 @@ public class CellBTreeSingleValueV3TestIT {
         }
       }
     }
-
     for (int i = 0; i < keysCount; i++) {
       if (i % 3 == 0) {
         Assert.assertNull(singleValueTree.get(Integer.toString(i)));
@@ -419,7 +400,6 @@ public class CellBTreeSingleValueV3TestIT {
 
       Assert.assertEquals(singleValueTree.get(Integer.toString(i)), new ORecordId(i % 32000, i));
     }
-
     final int rollbackInterval = 100;
 
     for (int i = 0; i < keysCount / rollbackInterval; i++) {
@@ -507,13 +487,11 @@ public class CellBTreeSingleValueV3TestIT {
         } catch (RollbackException ignore) {
         }
       }
-
       if (keyValues.size() > printCounter * 100_000) {
         System.out.println(keyValues.size() + " entries were added.");
         printCounter++;
       }
     }
-
     Assert.assertEquals(singleValueTree.firstKey(), keyValues.firstKey());
     Assert.assertEquals(singleValueTree.lastKey(), keyValues.lastKey());
 
@@ -624,7 +602,6 @@ public class CellBTreeSingleValueV3TestIT {
         printCounter++;
       }
     }
-
     assertIterateMinorEntries(keyValues, random, true, true);
     assertIterateMinorEntries(keyValues, random, false, true);
 
@@ -675,7 +652,6 @@ public class CellBTreeSingleValueV3TestIT {
         printCounter++;
       }
     }
-
     assertIterateBetweenEntries(keyValues, random, true, true, true);
     assertIterateBetweenEntries(keyValues, random, true, false, true);
     assertIterateBetweenEntries(keyValues, random, false, true, true);
@@ -685,6 +661,34 @@ public class CellBTreeSingleValueV3TestIT {
     assertIterateBetweenEntries(keyValues, random, true, false, false);
     assertIterateBetweenEntries(keyValues, random, false, true, false);
     assertIterateBetweenEntries(keyValues, random, false, false, false);
+
+    Assert.assertEquals(singleValueTree.firstKey(), keyValues.firstKey());
+    Assert.assertEquals(singleValueTree.lastKey(), keyValues.lastKey());
+  }
+
+  @Test
+  public void testIterateEntriesBetweenString() throws Exception {
+    final int keysCount = 10;
+    final NavigableMap<String, ORID> keyValues = new TreeMap<>();
+    final Random random = new Random();
+    try {
+      atomicOperationsManager.executeInsideAtomicOperation(
+          null,
+          atomicOperation -> {
+            for (int j = 0; j < keysCount; j++) {
+              final String key = "name" + j;
+              final int val = random.nextInt(Integer.MAX_VALUE);
+              final int clusterId = val % 32000;
+              singleValueTree.put(atomicOperation, key, new ORecordId(clusterId, val));
+              System.out.println("Added key=" + key + ", value=" + val);
+
+              keyValues.put(key, new ORecordId(clusterId, val));
+            }
+          });
+    } catch (final RollbackException ignore) {
+      Assert.fail();
+    }
+    assertIterateBetweenEntriesNonRandom("name5", keyValues, true, true, true);
 
     Assert.assertEquals(singleValueTree.firstKey(), keyValues.firstKey());
     Assert.assertEquals(singleValueTree.lastKey(), keyValues.lastKey());
@@ -859,6 +863,32 @@ public class CellBTreeSingleValueV3TestIT {
         //noinspection ConstantConditions
         Assert.assertFalse(iterator.hasNext());
         Assert.assertFalse(indexIterator.hasNext());
+      }
+    }
+  }
+
+  private void assertIterateBetweenEntriesNonRandom(
+      final String fromKey,
+      final NavigableMap<String, ORID> keyValues,
+      final boolean fromInclusive,
+      final boolean toInclusive,
+      final boolean ascSortOrder) {
+    String[] keys = new String[keyValues.size()];
+    int index = 0;
+
+    for (final String key : keyValues.keySet()) {
+      keys[index] = key;
+      index++;
+    }
+
+    for (int i = 0; i < keyValues.size(); i++) {
+      final String toKey = keys[i];
+      final Iterator<ORawPair<String, ORID>> indexIterator;
+      try (final Stream<ORawPair<String, ORID>> stream =
+          singleValueTree.iterateEntriesBetween(
+              fromKey, fromInclusive, toKey, toInclusive, ascSortOrder)) {
+        indexIterator = stream.iterator();
+        Assert.assertTrue(indexIterator.hasNext());
       }
     }
   }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
@@ -872,7 +872,7 @@ public class CellBTreeSingleValueV3TestIT {
       final NavigableMap<String, ORID> keyValues,
       final boolean fromInclusive,
       final boolean toInclusive,
-      final boolean ascSortOrder) 
+      final boolean ascSortOrder,
       final int startFrom) {
     String[] keys = new String[keyValues.size()];
     int index = 0;

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueV3TestIT.java
@@ -688,7 +688,7 @@ public class CellBTreeSingleValueV3TestIT {
     } catch (final RollbackException ignore) {
       Assert.fail();
     }
-    assertIterateBetweenEntriesNonRandom("name5", keyValues, true, true, true);
+    assertIterateBetweenEntriesNonRandom("name5", keyValues, true, true, true, 5);
 
     Assert.assertEquals(singleValueTree.firstKey(), keyValues.firstKey());
     Assert.assertEquals(singleValueTree.lastKey(), keyValues.lastKey());
@@ -872,7 +872,8 @@ public class CellBTreeSingleValueV3TestIT {
       final NavigableMap<String, ORID> keyValues,
       final boolean fromInclusive,
       final boolean toInclusive,
-      final boolean ascSortOrder) {
+      final boolean ascSortOrder) 
+      final int startFrom) {
     String[] keys = new String[keyValues.size()];
     int index = 0;
 
@@ -881,7 +882,7 @@ public class CellBTreeSingleValueV3TestIT {
       index++;
     }
 
-    for (int i = 0; i < keyValues.size(); i++) {
+    for (int i = startFrom; i < keyValues.size(); i++) {
       final String toKey = keys[i];
       final Iterator<ORawPair<String, ORID>> indexIterator;
       try (final Stream<ORawPair<String, ORID>> stream =


### PR DESCRIPTION
Fixes broken range query, e.g., select * from class where something >= "another" due to unsupported NULL values.