### PR TITLE
Timeline issue during edge creation

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -1271,7 +1271,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
 
   public List<ORecordOperation> commit(final OTransactionInternal iTx) {
     unstickToSession();
-    OCommit38Request request =
+    final OCommit38Request request =
         new OCommit38Request(
             iTx.getId(),
             true,
@@ -1279,7 +1279,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
             iTx.getRecordOperations(),
             iTx.getIndexOperations());
 
-    OCommit37Response response = networkOperationNoRetry(request, "Error on commit");
+    final OCommit37Response response = networkOperationNoRetry(request, "Error on commit");
     for (OCommit37Response.OCreatedRecordResponse created : response.getCreated()) {
       iTx.updateIdentityAfterCommit(created.getCurrentRid(), created.getCreatedRid());
       ORecordOperation rop = iTx.getRecordEntry(created.getCurrentRid());

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/ORidBag.java
@@ -580,7 +580,7 @@ public class ORidBag
     return true;
   }
 
-  //  @Override
+  @Override
   public void enableTracking(ORecordElement parent) {
     delegate.enableTracking(parent);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -575,7 +575,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     }
   }
 
-  public void disableTracking(ORecordElement document) {
+  public void disableTracking(final ORecordElement document) {
     if (tracker.isEnabled()) {
       tracker.disable();
       this.dirty = false;

--- a/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/record/ridbag/embedded/OEmbeddedRidBag.java
@@ -242,9 +242,9 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
 
   @Override
   public void add(final OIdentifiable identifiable) {
-    if (identifiable == null)
+    if (identifiable == null) {
       throw new IllegalArgumentException("Impossible to add a null identifiable in a ridbag");
-
+    }
     addEntry(identifiable);
 
     size++;
@@ -539,7 +539,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     // do nothing not needed
   }
 
-  private void addEvent(OIdentifiable key, OIdentifiable identifiable) {
+  private void addEvent(final OIdentifiable key, final OIdentifiable identifiable) {
     if (this.owner != null) ORecordInternal.track(this.owner, identifiable);
 
     if (tracker.isEnabled()) {
@@ -569,7 +569,7 @@ public class OEmbeddedRidBag implements ORidBagDelegate {
     }
   }
 
-  public void enableTracking(ORecordElement parent) {
+  public void enableTracking(final ORecordElement parent) {
     if (!tracker.isEnabled()) {
       tracker.enable();
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
@@ -132,8 +132,9 @@ public class ODocumentEntry {
 
   public boolean isTxTrackedModified() {
     if (value instanceof OTrackedMultiValue) {
-      return ((OTrackedMultiValue) value).isTransactionModified()
-          && ((OTrackedMultiValue) value).getTransactionTimeLine() != null;
+      return ((OTrackedMultiValue) value).isTransactionModified();
+      // TODO: dirty fix for timeline issue: && ((OTrackedMultiValue)
+      // value).getTransactionTimeLine() != null;
     }
     if (value instanceof ODocument && ((ODocument) value).isEmbedded()) {
       return ((ODocument) value).isDirty();

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
@@ -132,7 +132,8 @@ public class ODocumentEntry {
 
   public boolean isTxTrackedModified() {
     if (value instanceof OTrackedMultiValue) {
-      return ((OTrackedMultiValue) value).isTransactionModified();
+      return ((OTrackedMultiValue) value).isTransactionModified()
+          && ((OTrackedMultiValue) value).getTransactionTimeLine() != null;
     }
     if (value instanceof ODocument && ((ODocument) value).isEmbedded()) {
       return ((ODocument) value).isDirty();

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocumentEntry.java
@@ -133,8 +133,6 @@ public class ODocumentEntry {
   public boolean isTxTrackedModified() {
     if (value instanceof OTrackedMultiValue) {
       return ((OTrackedMultiValue) value).isTransactionModified();
-      // TODO: dirty fix for timeline issue: && ((OTrackedMultiValue)
-      // value).getTransactionTimeLine() != null;
     }
     if (value instanceof ODocument && ((ODocument) value).isEmbedded()) {
       return ((ODocument) value).isDirty();

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OSimpleMultiValueTracker.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OSimpleMultiValueTracker.java
@@ -75,12 +75,11 @@ public final class OSimpleMultiValueTracker<K, V> {
   }
 
   public void onAfterRecordChanged(final OMultiValueChangeEvent<K, V> event, boolean changeOwner) {
-
     if (!enabled) {
       return;
     }
 
-    ORecordElement document = this.element.get();
+    final ORecordElement document = this.element.get();
     if (document == null) {
       // doc not alive anymore, do nothing.
       return;

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/OSimpleMultiValueTracker.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/OSimpleMultiValueTracker.java
@@ -95,13 +95,11 @@ public final class OSimpleMultiValueTracker<K, V> {
     if (timeLine == null) {
       timeLine = new OMultiValueChangeTimeLine<Object, Object>();
     }
-
     timeLine.addCollectionChangeEvent((OMultiValueChangeEvent<Object, Object>) event);
 
     if (transactionTimeLine == null) {
       transactionTimeLine = new OMultiValueChangeTimeLine<K, V>();
     }
-
     transactionTimeLine.addCollectionChangeEvent(event);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
@@ -656,7 +656,7 @@ public class ODocumentSerializerDelta {
 
     final OMultiValueChangeTimeLine<OIdentifiable, OIdentifiable> timeline =
         value.getTransactionTimeLine();
-    assert timeline != null : "Cx ollection timeline required for link types serialization";
+    assert timeline != null : "Collection timeline required for link types serialization";
     OVarIntSerializer.write(bytes, timeline.getMultiValueChangeEvents().size());
     for (OMultiValueChangeEvent<OIdentifiable, OIdentifiable> event :
         timeline.getMultiValueChangeEvents()) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
@@ -576,8 +576,8 @@ public class ODocumentSerializerDelta {
     Set<Map.Entry<String, ODocumentEntry>> entries = ODocumentInternal.rawEntries(document);
 
     OVarIntSerializer.write(bytes, count);
-    for (Map.Entry<String, ODocumentEntry> entry : entries) {
-      ODocumentEntry docEntry = entry.getValue();
+    for (final Map.Entry<String, ODocumentEntry> entry : entries) {
+      final ODocumentEntry docEntry = entry.getValue();
       if (!docEntry.isTxExists()) {
         serializeByte(bytes, REMOVED);
         writeString(bytes, entry.getKey());
@@ -589,7 +589,7 @@ public class ODocumentSerializerDelta {
         serializeFullEntry(bytes, oClass, entry.getKey(), docEntry);
       } else if (docEntry.isTxTrackedModified()) {
         serializeByte(bytes, CHANGED);
-        // TODO: Timeline must not be NULL here
+        // timeline must not be NULL here. Else check that tracker is enabled
         serializeDeltaEntry(bytes, oClass, entry.getKey(), docEntry);
       } else {
         continue;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
@@ -654,7 +654,7 @@ public class ODocumentSerializerDelta {
     int uuidPos = bytes.alloc(OUUIDSerializer.UUID_SIZE);
     OUUIDSerializer.INSTANCE.serialize(uuid, bytes.bytes, uuidPos);
 
-    OMultiValueChangeTimeLine<OIdentifiable, OIdentifiable> timeline =
+    final OMultiValueChangeTimeLine<OIdentifiable, OIdentifiable> timeline =
         value.getTransactionTimeLine();
     assert timeline != null : "Cx ollection timeline required for link types serialization";
     OVarIntSerializer.write(bytes, timeline.getMultiValueChangeEvents().size());

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
@@ -589,6 +589,7 @@ public class ODocumentSerializerDelta {
         serializeFullEntry(bytes, oClass, entry.getKey(), docEntry);
       } else if (docEntry.isTxTrackedModified()) {
         serializeByte(bytes, CHANGED);
+        // TODO: Timeline must not be NULL here
         serializeDeltaEntry(bytes, oClass, entry.getKey(), docEntry);
       } else {
         continue;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ODocumentSerializerDelta.java
@@ -657,7 +657,7 @@ public class ODocumentSerializerDelta {
 
     final OMultiValueChangeTimeLine<OIdentifiable, OIdentifiable> timeline =
         value.getTransactionTimeLine();
-    assert timeline != null : "Collection timeline required for link types serialization";
+    assert timeline != null : "Collection timeline required for serialization of link types";
     OVarIntSerializer.write(bytes, timeline.getMultiValueChangeEvents().size());
     for (OMultiValueChangeEvent<OIdentifiable, OIdentifiable> event :
         timeline.getMultiValueChangeEvents()) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
@@ -392,12 +392,16 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
     bytes.skip(1);
     if (b == 1) {
       ORidBag bag = new ORidBag(uuid);
+      // TODO: enable tracking for timeline issue
+      bag.enableTracking(null);
       int size = OVarIntSerializer.readAsInteger(bytes);
       for (int i = 0; i < size; i++) {
         OIdentifiable id = readOptimizedLink(bytes);
         if (id.equals(NULL_RECORD_ID)) bag.add(null);
         else bag.add(id);
       }
+      bag.disableTracking(null);
+      bag.transactionClear();
       return bag;
     } else {
       long fileId = OVarIntSerializer.readAsLong(bytes);
@@ -442,7 +446,6 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
       if (value.equals(NULL_RECORD_ID)) result.putInternal(key, null);
       else result.putInternal(key, value);
     }
-
     return result;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37.java
@@ -392,7 +392,7 @@ public class ORecordSerializerNetworkV37 implements ORecordSerializer {
     bytes.skip(1);
     if (b == 1) {
       ORidBag bag = new ORidBag(uuid);
-      // TODO: enable tracking for timeline issue
+      // enable tracking due to timeline issue, which must not be NULL (i.e. tracker.isEnabled()).
       bag.enableTracking(null);
       int size = OVarIntSerializer.readAsInteger(bytes);
       for (int i = 0; i < size; i++) {

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37Client.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/binary/ORecordSerializerNetworkV37Client.java
@@ -34,14 +34,13 @@ public class ORecordSerializerNetworkV37Client extends ORecordSerializerNetworkV
           if (id.equals(NULL_RECORD_ID)) bag.add(null);
           else bag.add(id);
         }
-
         // The bag will mark the elements we just added as new events
         // and marking the entire bag as a dirty transaction {@link
         // OEmbeddedRidBag#transactionDirty}
         // although we just deserialized it so there are no changes and the transaction isn't dirty
+        bag.enableTracking(null);
         bag.transactionClear();
       }
-
       return bag;
     } else {
       long fileId = OVarIntSerializer.readAsLong(bytes);

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraph.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientGraph.java
@@ -280,10 +280,10 @@ public class OrientGraph extends OrientTransactionalGraph {
           currentVertex.getIdentity(),
           "The vertex " + currentVertex.getIdentity() + " has been deleted");
 
-    if (inVertex.checkDeletedInTx())
+    if (inVertex.checkDeletedInTx()) {
       throw new ORecordNotFoundException(
           inVertex.getIdentity(), "The vertex " + inVertex.getIdentity() + " has been deleted");
-
+    }
     autoStartTransaction();
 
     // TEMPORARY STATIC LOCK TO AVOID MT PROBLEMS AGAINST OMVRBTreeRID

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientVertex.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientVertex.java
@@ -680,12 +680,13 @@ public class OrientVertex extends OrientElement implements OrientExtendedVertex 
       final String iClassName,
       final String iClusterName,
       final Object... fields) {
-
-    if (inVertex == null) throw new IllegalArgumentException("destination vertex is null");
-
+    if (inVertex == null) {
+      throw new IllegalArgumentException("destination vertex is null");
+    }
     final OrientBaseGraph graph = getGraph();
-    if (graph != null)
+    if (graph != null) {
       return graph.addEdgeInternal(this, label, inVertex, iClassName, iClusterName, fields);
+    }
 
     // IN MEMORY CHANGES ONLY: USE NOTX CLASS
     return OrientGraphNoTx.addEdgeInternal(

--- a/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientVertex.java
+++ b/graphdb/src/main/java/com/tinkerpop/blueprints/impls/orient/OrientVertex.java
@@ -78,6 +78,7 @@ public class OrientVertex extends OrientElement implements OrientExtendedVertex 
     if (className != null)
       className = checkForClassInSchema(OrientBaseGraph.encodeClassName(className));
 
+    // TODO: should it rather be an OVertexDocument?
     rawElement = new ODocument(className == null ? OrientVertexType.CLASS_NAME : className);
     setPropertiesInternal(fields);
   }

--- a/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/EdgeCreationRemoteTest.java
+++ b/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/EdgeCreationRemoteTest.java
@@ -147,18 +147,18 @@ public class EdgeCreationRemoteTest {
 
     // APP1 and aAPP2 will fail. APP3 will be successfully committed.
     final String targetAppId = "APP1";
-    Vertex target = g.getVertices("LID", targetAppId).iterator().next();
+    final Vertex target = g.getVertices("LID", targetAppId).iterator().next();
     System.out.println(target.getProperty("ID").toString());
 
     long currentTime = System.currentTimeMillis();
-    OrientVertex v1 = g.addVertex("class:KEYDOK");
+    final OrientVertex v1 = g.addVertex("class:KEYDOK");
     v1.setProperty("ID", UUID.randomUUID().toString());
     v1.setProperty("LID", UUID.randomUUID().toString());
     v1.setProperty("current", true);
     v1.setProperty("insertedOn", currentTime);
     v1.setProperty("version", 1);
 
-    Edge e1 = v1.addEdge("HAS_AS_FAVORITE", target);
+    final Edge e1 = v1.addEdge("HAS_AS_FAVORITE", target);
     e1.setProperty("insertedOn", currentTime);
     e1.setProperty("isActive", true);
     e1.setProperty("isCurrent", true);

--- a/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/EdgeCreationRemoteTest.java
+++ b/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/EdgeCreationRemoteTest.java
@@ -19,96 +19,21 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.management.InstanceAlreadyExistsException;
-import javax.management.MBeanRegistrationException;
-import javax.management.MalformedObjectNameException;
-import javax.management.NotCompliantMBeanException;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Iterator;
 import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class EdgeCreationRemoteTest {
   private OServer server;
-
-  /*@Before
-  public void before()
-      throws ClassNotFoundException, MalformedObjectNameException, InstanceAlreadyExistsException,
-          NotCompliantMBeanException, MBeanRegistrationException, InvocationTargetException,
-          NoSuchMethodException, InstantiationException, IOException, IllegalAccessException {
-    server = new OServer(false);
-    server.startup(
-        OrientGraphRemoteTest.class.getResourceAsStream("/embedded-server-config-single-run.xml"));
-    server.activate();
-    OServerAdmin admin = new OServerAdmin("remote:localhost:3064");
-    admin.connect("root", "root");
-    admin.createDatabase(EdgeCreationRemoteTest.class.getSimpleName(), "graph", "memory");
-    admin.close();
-  }
-
-  @After
-  public void after() {
-    server.shutdown();
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    Orient.instance().shutdown();
-    Orient.instance().startup();
-  }
-
-  @Test
-  public void test() {
-    OrientGraph graph =
-        new OrientGraph(
-            "remote:localhost:3064/" + EdgeCreationRemoteTest.class.getSimpleName());
-    try {
-      graph.createVertexType("VertA");
-      graph.createVertexType("VertB");
-      graph.createEdgeType("AtoB");
-      OrientVertex root = graph.addVertex("class:VertA");
-      graph.commit();
-
-      for (int i = 0; i < 2; i++) {
-        OrientVertex v = graph.addVertex("class:VertB");
-        root.addEdge("AtoB", v);
-      }
-      graph.commit();
-
-      String query =
-          "SELECT $res as val LET $res = (SELECT @rid AS refId, out('AtoB') AS vertices FROM VertA) FETCHPLAN val:2";
-
-      Iterable<OrientVertex> results = graph.command(new OCommandSQL(query)).execute();
-      final Iterator<OrientVertex> iterator = results.iterator();
-      assertTrue(iterator.hasNext());
-      OrientVertex result = iterator.next();
-
-      Iterable<OrientVertex> vertices = result.getProperty("val");
-      for (OrientVertex vertex : vertices) {
-        assertEquals(
-            ((OIdentifiable) vertex.getProperty("refId")).getIdentity(), root.getIdentity());
-      }
-    } finally {
-      graph.shutdown();
-    }
-  }*/
-
   private final String dbName = "MAPP";
   private ORID app1Id;
 
   @Before
-  public void setup() throws IOException, InstantiationException, IllegalAccessException, ClassNotFoundException {
+  public void setup()
+      throws IOException, InstantiationException, IllegalAccessException, ClassNotFoundException {
     server = new OServer(false);
     server.startup(
         OrientGraphRemoteTest.class.getResourceAsStream("/embedded-server-config-single-run.xml"));
     server.activate();
-    //OServerAdmin admin = new OServerAdmin("remote:localhost:3064");
-    //admin.connect("root", "root");
-    //admin.createDatabase(EdgeCreationRemoteTest.class.getSimpleName(), "graph", "memory");
-    //admin.close();
     connect("remote:localhost:3064", dbName, "root", "root", true);
     addPrerequisites();
   }


### PR DESCRIPTION
`assert timeline == null` issue as identified in #9313 starting from 3.1.x.

orientdb-graphdb is TinkerPop version 2.6 and is actually deprecated. It will be removed eventually. It is highly encouraged to use orientdb-gremlin instead (cf. https://github.com/orientechnologies/orientdb-gremlin).