### PR TITLE
Fixed the usage of the shortestPath function like in the commit 3b660…

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPath.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.sql.functions.graph;
 
+import static java.util.stream.Collectors.toList;
+
 import com.orientechnologies.common.collection.OMultiCollectionIterator;
 import com.orientechnologies.common.util.ORawPair;
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -18,6 +20,7 @@ import com.orientechnologies.orient.core.sql.OSQLHelper;
 import com.orientechnologies.orient.core.sql.functions.math.OSQLFunctionMathAbstract;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -129,7 +132,14 @@ public class OSQLFunctionShortestPath extends OSQLFunctionMathAbstract {
     if (iParams.length > 3) {
       ctx.edgeType = iParams[3] == null ? null : "" + iParams[3];
     }
-    ctx.edgeTypeParam = new String[] {ctx.edgeType};
+
+    if (iParams.length > 2 && iParams[3] instanceof Collection) {
+      Collection<?> coll = (Collection<?>) iParams[3];
+      ctx.edgeTypeParam =
+          coll.stream().map(String::valueOf).collect(toList()).toArray(new String[] {});
+    } else {
+      ctx.edgeTypeParam = new String[] {ctx.edgeType};
+    }
 
     if (iParams.length > 4) {
       bindAdditionalParams(iParams[4], ctx);

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPathTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/graph/OSQLFunctionShortestPathTest.java
@@ -1,5 +1,7 @@
 package com.orientechnologies.orient.core.sql.functions.graph;
 
+import static java.util.Arrays.asList;
+
 import com.orientechnologies.orient.core.command.OBasicCommandContext;
 import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.OrientDB;
@@ -118,6 +120,22 @@ public class OSQLFunctionShortestPathTest {
     Assert.assertEquals(vertices.get(2).getIdentity(), result.get(1));
     Assert.assertEquals(vertices.get(3).getIdentity(), result.get(2));
     Assert.assertEquals(vertices.get(4).getIdentity(), result.get(3));
+  }
+
+  @Test
+  public void testExecuteOnlyEdge1AndEdge2() throws Exception {
+    final List<ORID> result =
+        function.execute(
+            null,
+            null,
+            null,
+            new Object[] {vertices.get(1), vertices.get(4), "BOTH", asList("Edge1", "Edge2")},
+            new OBasicCommandContext());
+
+    Assert.assertEquals(3, result.size());
+    Assert.assertEquals(vertices.get(1).getIdentity(), result.get(0));
+    Assert.assertEquals(vertices.get(3).getIdentity(), result.get(1));
+    Assert.assertEquals(vertices.get(4).getIdentity(), result.get(2));
   }
 
   @Test


### PR DESCRIPTION
…af55ee8f6fa34336a47fde71c9e93504175

In addtion to the comments on https://github.com/orientechnologies/orientdb/pull/9337. This PR only contains the relevant changes.