### PR TITLE
Adding vpm support for legacy engines

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/OBaseIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/OBaseIndexEngine.java
@@ -91,11 +91,6 @@ public interface OBaseIndexEngine {
 
   String getIndexNameByKey(Object key);
 
-  int MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS = 1000;
-  int MAGIC_SAFETY_FILL_FACTOR = 10;
-  int DEFAULT_VERSION_ARRAY_SIZE =
-      MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS * MAGIC_SAFETY_FILL_FACTOR;
-
   void updateUniqueIndexVersion(Object key);
 
   int getUniqueIndexVersion(Object key);

--- a/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeSingleValueIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/engine/v1/OCellBTreeSingleValueIndexEngine.java
@@ -260,21 +260,13 @@ public final class OCellBTreeSingleValueIndexEngine
 
   @Override
   public void updateUniqueIndexVersion(final Object key) {
-    final int keyHash = getKeyHash(key);
+    final int keyHash = versionPositionMap.getKeyHash(key);
     versionPositionMap.updateVersion(keyHash);
   }
 
   @Override
   public int getUniqueIndexVersion(final Object key) {
-    final int keyHash = getKeyHash(key);
+    final int keyHash = versionPositionMap.getKeyHash(key);
     return versionPositionMap.getVersion(keyHash);
-  }
-
-  private int getKeyHash(final Object key) {
-    int keyHash = 0; // as for null values in hash map
-    if (key != null) {
-      keyHash = Math.abs(key.hashCode()) % DEFAULT_VERSION_ARRAY_SIZE;
-    }
-    return keyHash;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/engine/OHashTableIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/engine/OHashTableIndexEngine.java
@@ -44,7 +44,6 @@ import com.orientechnologies.orient.core.storage.index.hashindex.local.v2.LocalH
 import com.orientechnologies.orient.core.storage.index.hashindex.local.v3.OLocalHashTableV3;
 import com.orientechnologies.orient.core.storage.index.versionmap.OVersionPositionMap;
 import com.orientechnologies.orient.core.storage.index.versionmap.OVersionPositionMapV0;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/engine/OSBTreeIndexEngine.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/engine/OSBTreeIndexEngine.java
@@ -38,7 +38,6 @@ import com.orientechnologies.orient.core.storage.index.sbtree.local.v1.OSBTreeV1
 import com.orientechnologies.orient.core.storage.index.sbtree.local.v2.OSBTreeV2;
 import com.orientechnologies.orient.core.storage.index.versionmap.OVersionPositionMap;
 import com.orientechnologies.orient.core.storage.index.versionmap.OVersionPositionMapV0;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.Spliterators;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMap.java
@@ -8,9 +8,9 @@ import java.io.IOException;
 public abstract class OVersionPositionMap extends ODurableComponent {
   public static final String DEF_EXTENSION = ".vpm";
 
-  int MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS = 1000;
-  int MAGIC_SAFETY_FILL_FACTOR = 10;
-  int DEFAULT_VERSION_ARRAY_SIZE =
+  public static int MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS = 1000;
+  public static int MAGIC_SAFETY_FILL_FACTOR = 10;
+  public static int DEFAULT_VERSION_ARRAY_SIZE =
       MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS * MAGIC_SAFETY_FILL_FACTOR;
 
   public OVersionPositionMap(

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMap.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMap.java
@@ -8,6 +8,11 @@ import java.io.IOException;
 public abstract class OVersionPositionMap extends ODurableComponent {
   public static final String DEF_EXTENSION = ".vpm";
 
+  int MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS = 1000;
+  int MAGIC_SAFETY_FILL_FACTOR = 10;
+  int DEFAULT_VERSION_ARRAY_SIZE =
+      MAX_CONCURRENT_DISTRIBUTED_TRANSACTIONS * MAGIC_SAFETY_FILL_FACTOR;
+
   public OVersionPositionMap(
       OAbstractPaginatedStorage storage, String name, String extension, String lockName) {
     super(storage, name, extension, lockName);
@@ -24,4 +29,6 @@ public abstract class OVersionPositionMap extends ODurableComponent {
   public abstract void updateVersion(int versionHash);
 
   public abstract int getVersion(int versionHash);
+
+  public abstract int getKeyHash(Object key);
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMapV0.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMapV0.java
@@ -23,7 +23,6 @@ package com.orientechnologies.orient.core.storage.index.versionmap;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.orient.core.exception.OStorageException;
-import com.orientechnologies.orient.core.index.engine.OBaseIndexEngine;
 import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperation;
@@ -149,8 +148,13 @@ public final class OVersionPositionMapV0 extends OVersionPositionMap {
     }
   }
 
-  private int calculatePageIndex(final int startPositionWithOffset) {
-    return 0; // (int) Math.ceil(startPositionWithOffset / OVersionPage.PAGE_SIZE) + 1;
+  @Override
+  public int getKeyHash(final Object key) {
+    int keyHash = 0; // as for null values in hash map
+    if (key != null) {
+      keyHash = Math.abs(key.hashCode()) % DEFAULT_VERSION_ARRAY_SIZE;
+    }
+    return keyHash;
   }
 
   private void openVPM(final OAtomicOperation atomicOperation) throws IOException {
@@ -164,7 +168,7 @@ public final class OVersionPositionMapV0 extends OVersionPositionMap {
     final int numberOfPages =
         (int)
                 Math.ceil(
-                    (OBaseIndexEngine.DEFAULT_VERSION_ARRAY_SIZE * sizeOfIntInBytes)
+                    (DEFAULT_VERSION_ARRAY_SIZE * sizeOfIntInBytes)
                         / OVersionPage.PAGE_SIZE)
             + 1;
     final long foundNumberOfPages = getFilledUpTo(atomicOperation, fileId);
@@ -215,5 +219,9 @@ public final class OVersionPositionMapV0 extends OVersionPositionMap {
 
   private void deleteVPM(final OAtomicOperation atomicOperation) throws IOException {
     deleteFile(atomicOperation, fileId);
+  }
+
+  private int calculatePageIndex(final int startPositionWithOffset) {
+    return 0; // (int) Math.ceil(startPositionWithOffset / OVersionPage.PAGE_SIZE) + 1;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMapV0.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/versionmap/OVersionPositionMapV0.java
@@ -166,10 +166,7 @@ public final class OVersionPositionMapV0 extends OVersionPositionMap {
     fileId = addFile(atomicOperation, getFullName());
     final int sizeOfIntInBytes = Integer.SIZE / 8;
     final int numberOfPages =
-        (int)
-                Math.ceil(
-                    (DEFAULT_VERSION_ARRAY_SIZE * sizeOfIntInBytes)
-                        / OVersionPage.PAGE_SIZE)
+        (int) Math.ceil((DEFAULT_VERSION_ARRAY_SIZE * sizeOfIntInBytes) / OVersionPage.PAGE_SIZE)
             + 1;
     final long foundNumberOfPages = getFilledUpTo(atomicOperation, fileId);
     OLogManager.instance()

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/versionmap/VersionPositionMapTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/versionmap/VersionPositionMapTestIT.java
@@ -2,7 +2,6 @@ package com.orientechnologies.orient.core.storage.versionmap;
 
 import com.orientechnologies.common.io.OFileUtils;
 import com.orientechnologies.orient.core.db.*;
-import com.orientechnologies.orient.core.index.engine.OBaseIndexEngine;
 import com.orientechnologies.orient.core.storage.impl.local.OAbstractPaginatedStorage;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperation;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationsManager;
@@ -69,7 +68,7 @@ public class VersionPositionMapTestIT {
 
   @Test
   public void testIncrementVersion() throws Exception {
-    final int maxVPMSize = OBaseIndexEngine.DEFAULT_VERSION_ARRAY_SIZE;
+    final int maxVPMSize = OVersionPositionMap.DEFAULT_VERSION_ARRAY_SIZE;
     for (int hash = 0; hash <= maxVPMSize; hash++) {
       final int version = versionPositionMap.getVersion(hash);
       versionPositionMap.updateVersion(hash);
@@ -79,7 +78,7 @@ public class VersionPositionMapTestIT {
 
   @Test
   public void testMultiIncrementVersion() throws Exception {
-    final int maxVPMSize = OBaseIndexEngine.DEFAULT_VERSION_ARRAY_SIZE;
+    final int maxVPMSize = OVersionPositionMap.DEFAULT_VERSION_ARRAY_SIZE;
     final int maxVersionNumber = 100;
     for (int hash = 0; hash <= maxVPMSize; hash++) {
       for (int j = 0; j < maxVersionNumber; j++) {
@@ -91,7 +90,7 @@ public class VersionPositionMapTestIT {
 
   @Test
   public void testRandomIncrementVersion() throws Exception {
-    final int maxVPMSize = OBaseIndexEngine.DEFAULT_VERSION_ARRAY_SIZE;
+    final int maxVPMSize = OVersionPositionMap.DEFAULT_VERSION_ARRAY_SIZE;
     final long seed = System.nanoTime();
     System.out.printf("incrementVersion seed :%d%n", seed);
     final Random random = new Random(seed);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/versionmap/VersionPositionMapTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/versionmap/VersionPositionMapTestIT.java
@@ -101,4 +101,17 @@ public class VersionPositionMapTestIT {
       Assert.assertEquals(version + 1, versionPositionMap.getVersion(randomNum));
     }
   }
+
+  @Test
+  public void testGetKeyHash() {
+    Assert.assertEquals(0, versionPositionMap.getKeyHash(null));
+    Assert.assertEquals(4659, versionPositionMap.getKeyHash("OrientDB"));
+    Assert.assertEquals(
+        3988,
+        versionPositionMap.getKeyHash("07d_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"));
+
+    Assert.assertEquals(
+        0, versionPositionMap.getKeyHash(OVersionPositionMap.DEFAULT_VERSION_ARRAY_SIZE));
+    Assert.assertEquals(0, versionPositionMap.getKeyHash(0));
+  }
 }


### PR DESCRIPTION
Adding VPM support for legacy engines

- OHashTableIndexEngine
- OSBTreeIndexEngine

Single* engines already support VPM.