### PR TITLE
Integration test and simple benchmark for distributed tx and multi-master setup

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -179,7 +179,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>8.0.2</version>
+            <version>10.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/distributed/src/test/README.md
+++ b/distributed/src/test/README.md
@@ -4,19 +4,21 @@ To run ITs on Kubernetes you need to have kubectl installed, and you must provid
 
 To run the integration tests on Kubernetes you must use the Maven `it-k8s` build profile.
 
-Run a single test:
+Run a single test (e.g. on OrientDB 3.1.3):
 ```
-mvn failsafe:integration-test -Dit.test=BasicSyncIT -P it-k8s -DkubeConfig=/path/to/kubeconfig -DorientdbDockerImage=pxsalehi/orientdb:3.2.0-snapshot
+mvn failsafe:integration-test -Dit.test=BasicSyncIT -P it-k8s -DkubeConfig=/path/to/kubeconfig -DorientdbDockerImage=orientdb:3.1.3
 ```
 
 To run all integration tests that can be run on Kubernetes (defined in the build profile):
 ```
-mvn failsafe:integration-test -P it-k8s -DkubeConfig=/path/to/kubeconfig -DorientdbDockerImage=pxsalehi/orientdb:3.2.0-snapshot
+mvn failsafe:integration-test -P it-k8s -DkubeConfig=/path/to/kubeconfig -DorientdbDockerImage=orientdb:3.1.3
 ```
+
+To run tests on a specific build, you must build a Docker image and pass it via the `-DorientdbDockerImage=repository/image:tag` flag.
 
 The Kubernetes namespace used for the tests, is defined in the build profile and must exist before running the tests. You can use a different namespace by adding `-DkubernetesNamespace=name` to the above commands. The namespace and RBACs created by the tests, are not removed after the tests finish executing.
 
-The current OrientDB Docker image (3.1.2) does not support node discovery on Kubernetes. To run the tests you need to build the Docker image (under `distribution/docker/Dockerfile`) from the [3.2.0-Snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/orientechnologies/orientdb-community/3.2.0-SNAPSHOT/) and provide the image name with `-DorientdbDockerImage=repository/image:tag`. Alternatively, you can use `-DorientdbDockerImage=pxsalehi/orientdb:3.2.0-snapshot` as above.
+OrientDB Docker images before 3.1.3 do not support node discovery on Kubernetes and therefore do not support this setup.
 
 Volume size and storage classes used for the PVs, can also be configured via the `it-k8s` build profile properties.
 

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/ClusterGraphTxWriteIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/ClusterGraphTxWriteIT.java
@@ -1,0 +1,266 @@
+package com.orientechnologies.orient.server.distributed.tx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.orientechnologies.orient.core.config.OGlobalConfiguration;
+import com.orientechnologies.orient.core.db.ODatabaseSession;
+import com.orientechnologies.orient.core.db.ODatabaseType;
+import com.orientechnologies.orient.core.db.OrientDB;
+import com.orientechnologies.orient.core.db.OrientDBConfig;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
+import com.orientechnologies.orient.core.metadata.schema.OClass;
+import com.orientechnologies.orient.core.metadata.schema.OType;
+import com.orientechnologies.orient.core.sql.executor.OResultSet;
+import com.orientechnologies.orient.setup.SetupConfig;
+import com.orientechnologies.orient.setup.TestSetup;
+import com.orientechnologies.orient.setup.TestSetupUtil;
+import com.orientechnologies.orient.setup.configs.SimpleDServerConfig;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A basic benchmark that measures latency, throughput and retries in case of conflicting
+ * distributed txs.
+ *
+ * <p>For N servers, we have M >= N groups. In each group there are V vertices. Each group is
+ * processed by one thread. Each thread, goes through the vertices and for each vertex i, it tries
+ * to connect it to one vertex from the other groups (chosen to have same i in the group, or
+ * randomly) by creating a link called 'knows-group-<GroupID>'.
+ *
+ * <p>The TxWriters could be connected to only one server (single-master) or distributed among the
+ * servers (multi-master).
+ *
+ * <p>If CREATE_EDGES_RANDOMLY is false, txs updating vertex i in each group will conflict. However,
+ * contention happens only between txs that are connecting vertices of the same id. Another way to
+ * increase contention is to batch together B rounds of connecting vertices in one tx, and slide the
+ * range of vertex IDs for next rounds. This way txs across the next B rounds also conflict.
+ */
+public class ClusterGraphTxWriteIT {
+  private TestSetup setup;
+  private SetupConfig config;
+  private String server0;
+  private List<String> edgeClassNames;
+  private Map<String, OrientDB> serverRemotes = new HashMap<>();
+  // configs
+  private static final boolean MULTI_MASTER_WRITE = true;
+  // whether to connect vertices with the same id across groups or not.
+  private static final boolean CREATE_EDGES_RANDOMLY = false;
+  // number of vertices in each group
+  private static final int GROUP_SIZE = 100;
+  // Number of vertices in the group to connect with the other groups, in each tx.
+  // cannot be more than number of vertices in a group.
+  private static final int TX_BATCH_SIZE = 1;
+  private static final int NO_OF_GROUPS = 3;
+  private static final int TX_MAX_RETRIES = 25;
+
+  @Before
+  public void before() throws Exception {
+    config = new SimpleDServerConfig();
+    server0 = SimpleDServerConfig.SERVER0;
+    setup = TestSetupUtil.create(config);
+    setup.setup();
+
+    edgeClassNames = new ArrayList<>(NO_OF_GROUPS);
+    for (int i = 0; i < NO_OF_GROUPS; i++) {
+      edgeClassNames.add(String.format("knows-group-%d", i));
+    }
+
+    try (OrientDB remote =
+        setup.createRemote(server0, "root", "test", OrientDBConfig.defaultConfig())) {
+      System.out.println("Creating database and schema...");
+      remote.create("test", ODatabaseType.PLOCAL);
+      try (ODatabaseSession session = remote.open("test", "root", "test")) {
+        /* Create schema */
+        OClass personClass = session.createVertexClass("Person");
+        personClass.createProperty("id", OType.STRING);
+
+        OClass person = session.getClass("Person");
+        person.createIndex("Person.id", OClass.INDEX_TYPE.UNIQUE, "id");
+
+        for (String edgeClassName : edgeClassNames) {
+          session.createEdgeClass(edgeClassName);
+        }
+      }
+    }
+
+    OrientDBConfig orientDBConfig = OrientDBConfig.defaultConfig();
+    // Do reties in the code, so we can count the conflicts/rollbacks.
+    orientDBConfig
+        .getConfigurations()
+        .setValue(OGlobalConfiguration.DISTRIBUTED_CONCURRENT_TX_MAX_AUTORETRY, 1);
+    // make sure we always use embedded edges, otherwise connecting edges doesn't necessarily
+    // conflict with each other.
+    orientDBConfig
+        .getConfigurations()
+        .setValue(
+            OGlobalConfiguration.RID_BAG_EMBEDDED_TO_SBTREEBONSAI_THRESHOLD, Integer.MAX_VALUE);
+
+    for (String server : config.getServerIds()) {
+      serverRemotes.put(server, setup.createRemote(server, "root", "test", orientDBConfig));
+    }
+  }
+
+  @Test
+  public void test() throws InterruptedException {
+    List<TxWriter> txWriters = new LinkedList<>();
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch finished = new CountDownLatch(NO_OF_GROUPS);
+    CountDownLatch verticesCreated = new CountDownLatch(NO_OF_GROUPS);
+
+    List<String> serverNameList = new ArrayList<>(config.getServerIds());
+    for (int groupId = 0; groupId < NO_OF_GROUPS; groupId++) {
+      // assign which server will receive writes/updates for the group
+      final String server = getServerForGroup(groupId, serverNameList);
+      final String workerId = "Writer" + groupId;
+      TxWriterConfig writerConfig =
+          new TxWriterConfig(
+              workerId,
+              groupId,
+              GROUP_SIZE,
+              TX_MAX_RETRIES,
+              TX_BATCH_SIZE,
+              NO_OF_GROUPS,
+              CREATE_EDGES_RANDOMLY);
+      TxWriter txWriter = new TxWriter(server, serverRemotes.get(server), writerConfig);
+      txWriters.add(txWriter);
+      new Thread(() -> txWriter.start(start, verticesCreated, finished)).start();
+    }
+
+    start.countDown();
+
+    if (!verticesCreated.await(180, TimeUnit.SECONDS)) {
+      fail("Timed out waiting for vertices to be created!");
+    }
+    long startTimeSec = System.currentTimeMillis() / 1000;
+    System.out.println("Waiting for writers...");
+
+    finished.await();
+    long finishTimeSec = System.currentTimeMillis() / 1000;
+
+    for (String server : serverRemotes.keySet()) {
+      OrientDB remote = serverRemotes.get(server);
+      try (ODatabaseSession session = remote.open("test", "root", "test")) {
+        verifyAndPrintDBStats(session, server);
+      }
+    }
+
+    verifyAndPrintTxStats(txWriters, startTimeSec, finishTimeSec);
+  }
+
+  private void verifyAndPrintDBStats(final ODatabaseSession session, String server) {
+    List<Integer> outEdgePerVertex = null;
+    try (OResultSet rset = session.query("select outE().size() as outCount from Person")) {
+      outEdgePerVertex =
+          rset.stream()
+              .map(res -> (Integer) res.getProperty("outCount"))
+              .collect(Collectors.toList());
+    }
+    int noOfVertices = outEdgePerVertex.size();
+    assertEquals(GROUP_SIZE * NO_OF_GROUPS, noOfVertices);
+
+    int totalNoOfEdges = outEdgePerVertex.stream().mapToInt(Integer::intValue).sum();
+    assertEquals(GROUP_SIZE * NO_OF_GROUPS * (NO_OF_GROUPS - 1) * TX_BATCH_SIZE, totalNoOfEdges);
+
+    if (!CREATE_EDGES_RANDOMLY) {
+      outEdgePerVertex.forEach(
+          count -> assertEquals((NO_OF_GROUPS - 1) * TX_BATCH_SIZE, count.intValue()));
+    }
+
+    System.out.printf(
+        "* On server %s: vertex count: %d, edge count: %d.\n",
+        server, noOfVertices, totalNoOfEdges);
+  }
+
+  private void verifyAndPrintTxStats(List<TxWriter> txWriters, long startSec, long finishSec) {
+    List<List<TxStat>> txStatsList = new ArrayList<>();
+    assertEquals(NO_OF_GROUPS, txWriters.size());
+    for (TxWriter txWriter : txWriters) {
+      List<TxStat> txStats = txWriter.getTxStats();
+      assertEquals(GROUP_SIZE, txStats.size());
+      txStatsList.add(txStats);
+    }
+
+    long committed =
+        txStatsList.stream().flatMap(Collection::stream).filter(TxStat::isCommitted).count();
+
+    double commitRate = (double) committed / (GROUP_SIZE * NO_OF_GROUPS);
+
+    int retries =
+        txStatsList.stream()
+            .flatMap(Collection::stream)
+            .filter(TxStat::isCommitted)
+            .map(txStat -> txStat.retries)
+            .mapToInt(Integer::intValue)
+            .sum();
+
+    double averageLatency =
+        txStatsList.stream()
+            .flatMap(Collection::stream)
+            .filter(TxStat::isCommitted)
+            .map(TxStat::getLatency)
+            .mapToLong(Long::longValue)
+            .average()
+            .getAsDouble();
+
+    int percentile99Index = (int) (committed * 0.99) - 1;
+    long percentile99 =
+        txStatsList.stream()
+            .flatMap(Collection::stream)
+            .filter(TxStat::isCommitted)
+            .map(TxStat::getLatency)
+            .sorted()
+            .skip(percentile99Index - 1)
+            .findFirst()
+            .get();
+
+    int size = (int) (finishSec - startSec);
+    int[] throughput = new int[size + 1];
+    txStatsList.stream()
+        .flatMap(Collection::stream)
+        .filter(TxStat::isCommitted)
+        .forEach(
+            txStat -> {
+              int idx = (int) ((txStat.commitTimestamp / 1000) - startSec);
+              if (idx >= throughput.length) {
+                System.out.println("WARNING: commit timestamp is greater than throughput array!");
+              } else {
+                throughput[idx]++;
+              }
+            });
+    System.out.printf("Throughput per sec.: %s\n", Arrays.toString(throughput));
+
+    System.out.printf(
+        "* Total time: %d s, \n  committed txs: %d, \n  commit rate: %f, \n  "
+            + "retries: %d, \n  average latency: %f ms, \n  99%% latency: %d ms.\n",
+        finishSec - startSec, committed, commitRate, retries, averageLatency, percentile99);
+  }
+
+  private String getServerForGroup(int groupId, List<String> servers) {
+    if (!MULTI_MASTER_WRITE) {
+      return servers.get(0);
+    }
+    return servers.get(groupId % servers.size());
+  }
+
+  @After
+  public void after() {
+    try {
+      OrientDB remote = serverRemotes.get(server0);
+      if (remote != null) {
+        remote.drop("test");
+      }
+      for (OrientDB r : serverRemotes.values()) {
+        r.close();
+      }
+    } finally {
+      setup.teardown();
+      ODatabaseDocumentTx.closeAll();
+    }
+  }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxStat.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxStat.java
@@ -1,0 +1,21 @@
+package com.orientechnologies.orient.server.distributed.tx;
+
+public class TxStat {
+  public final long beginTimestamp;
+  public final long commitTimestamp; // -1 means never committed.
+  public final int retries;
+
+  public TxStat(long beginTimestamp, long commitTimestamp, int retries) {
+    this.beginTimestamp = beginTimestamp;
+    this.commitTimestamp = commitTimestamp;
+    this.retries = retries;
+  }
+
+  public boolean isCommitted() {
+    return commitTimestamp != -1;
+  }
+
+  public long getLatency() {
+    return commitTimestamp - beginTimestamp;
+  }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxWriter.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxWriter.java
@@ -1,0 +1,160 @@
+package com.orientechnologies.orient.server.distributed.tx;
+
+import com.orientechnologies.common.concur.ONeedRetryException;
+import com.orientechnologies.common.util.OPair;
+import com.orientechnologies.orient.core.db.ODatabaseSession;
+import com.orientechnologies.orient.core.db.OrientDB;
+import com.orientechnologies.orient.core.record.OEdge;
+import com.orientechnologies.orient.core.record.OVertex;
+import com.orientechnologies.orient.core.sql.executor.OResultSet;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** TxWriter issues transactions to only one server. */
+public class TxWriter {
+  private final TxWriterConfig config;
+  private final List<TxStat> txStats = new LinkedList<>();
+  private final Random random;
+  private final String writerId;
+  private final OrientDB remote;
+  private final String serverName;
+
+  public TxWriter(String serverName, OrientDB remote, TxWriterConfig config) {
+    this.config = config;
+    writerId = config.writerId;
+    random = new Random();
+    this.remote = remote;
+    this.serverName = serverName;
+  }
+
+  private void createVertices(ODatabaseSession session) {
+    for (int i = 0; i < config.groupSize; i++) {
+      final int vertexId = i;
+      session.executeWithRetry(
+          10,
+          (Function<ODatabaseSession, Void>)
+              oDatabaseSession -> {
+                createVertex(oDatabaseSession, createId(config.vertexGroupId, vertexId));
+                return null;
+              });
+    }
+  }
+
+  public void start(CountDownLatch start, CountDownLatch verticesCreated, CountDownLatch finished) {
+    try {
+      start.await();
+
+      try (ODatabaseSession session = remote.open("test", "root", "test")) {
+        System.out.printf("%s: creating vertices...\n", config.writerId);
+        createVertices(session);
+        verticesCreated.countDown();
+        verticesCreated.await();
+
+        System.out.printf("%s: connecting vertices.\n", config.writerId);
+        connectVertices(session);
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } finally {
+      System.out.printf("%s (%s) finished.\n", config.writerId, serverName);
+      finished.countDown();
+    }
+  }
+
+  private Map<Integer, OVertex> chooseDestVertexPerGroup(
+      ODatabaseSession session, int fromVertexId, List<Integer> allGroupIds) {
+    // find a vertex in each group to connect to the vertex in this group
+    return allGroupIds.stream()
+        .map(
+            targetGroupId -> {
+              int vertexToConnect =
+                  config.createEdgesRandomly ? random.nextInt(config.groupSize) : fromVertexId;
+              OResultSet result =
+                  session.query(
+                      "select from person where id = ?", createId(targetGroupId, vertexToConnect));
+              OVertex vertex = result.next().getVertex().get();
+              result.close();
+              return new OPair<>(targetGroupId, vertex);
+            })
+        .collect(Collectors.toMap(OPair::getKey, OPair::getValue));
+  }
+
+  private void connectVertices(ODatabaseSession session) {
+    // connect vertices of the same id/worker across servers
+    List<String> edgeClassNames = generateEdgeClassNames(config.noOfGroups);
+    List<Integer> allGroupIds =
+        IntStream.range(0, config.noOfGroups).boxed().collect(Collectors.toList());
+
+    for (int startVertex = 0; startVertex < config.groupSize; startVertex++) {
+      int retry;
+      // consider latency with all retries together.
+      long startTimestamp = System.currentTimeMillis();
+      for (retry = 0; retry < config.txMaxRetries; retry++) {
+        try {
+          session.begin();
+          // Each tx creates links between vertices with the same id (or random ids)
+          // across groups. Depending on tx batch size, this is done for more than one id at a time.
+          for (int batch = 0; batch < config.txBatchSize; batch++) {
+            int currentVertex = (startVertex + batch) % config.groupSize;
+            // connect it with vertices (of the same ID or randomly chosen) in the other groups
+            Map<Integer, OVertex> targetPerGroup =
+                chooseDestVertexPerGroup(session, currentVertex, allGroupIds);
+
+            OVertex myVertex = targetPerGroup.get(config.vertexGroupId);
+            for (Integer gId : allGroupIds) {
+              if (!gId.equals(config.vertexGroupId)) {
+                createEdge(myVertex, targetPerGroup.get(gId), edgeClassNames.get(gId));
+              }
+            }
+          }
+          session.commit();
+          long finishTimestamp = System.currentTimeMillis();
+          txStats.add(new TxStat(startTimestamp, finishTimestamp, retry));
+          break;
+        } catch (ONeedRetryException ex) {
+          session.rollback();
+          System.out.printf("Exception while connecting vertices: %s.\n", ex.getClass().toString());
+        }
+      }
+      if (retry >= config.txMaxRetries) {
+        txStats.add(new TxStat(startTimestamp, -1, retry - 1));
+      }
+    }
+  }
+
+  public List<TxStat> getTxStats() {
+    return txStats;
+  }
+
+  public String getWriterId() {
+    return writerId;
+  }
+
+  private List<String> generateEdgeClassNames(int noOfGroups) {
+    List<String> edgeClassNames = new ArrayList<>(noOfGroups);
+    for (int i = 0; i < noOfGroups; i++) {
+      edgeClassNames.add(String.format("knows-group-%d", i));
+    }
+    return edgeClassNames;
+  }
+
+  private String createId(int groupId, int vertexId) {
+    return String.format("v-%d-%d", groupId, vertexId);
+  }
+
+  private static OVertex createVertex(ODatabaseSession graph, String id) {
+    OVertex v = graph.newVertex("Person");
+    v.setProperty("id", id);
+    v.save();
+    return v;
+  }
+
+  private static OEdge createEdge(OVertex v1, OVertex v2, String edgeClassname) {
+    OEdge e = v1.addEdge(v2, edgeClassname);
+    e.save();
+    return e;
+  }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxWriterConfig.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/tx/TxWriterConfig.java
@@ -1,0 +1,28 @@
+package com.orientechnologies.orient.server.distributed.tx;
+
+public class TxWriterConfig {
+  public final String writerId;
+  public final int vertexGroupId;
+  public final int groupSize;
+  public final int txMaxRetries;
+  public final int txBatchSize;
+  public final int noOfGroups;
+  public final boolean createEdgesRandomly;
+
+  public TxWriterConfig(
+      String writerId,
+      int vertexGroupId,
+      int groupSize,
+      int txMaxRetries,
+      int txBatchSize,
+      int noOfGroups,
+      boolean createEdgesRandomly) {
+    this.writerId = writerId;
+    this.vertexGroupId = vertexGroupId;
+    this.groupSize = groupSize;
+    this.txMaxRetries = txMaxRetries;
+    this.txBatchSize = txBatchSize;
+    this.noOfGroups = noOfGroups;
+    this.createEdgesRandomly = createEdgesRandomly;
+  }
+}

--- a/distributed/src/test/java/com/orientechnologies/orient/setup/SetupConfig.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/setup/SetupConfig.java
@@ -11,4 +11,8 @@ public interface SetupConfig {
 
   // Used for deploying the config in a Kubernetes setup.
   K8sServerConfig getK8sConfigs(String serverId);
+
+  String getServerRootUsername(String serverId);
+
+  String getServerRootPassword(String serverId);
 }

--- a/distributed/src/test/java/com/orientechnologies/orient/setup/configs/SimpleDServerConfig.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/setup/configs/SimpleDServerConfig.java
@@ -10,6 +10,10 @@ public class SimpleDServerConfig implements SetupConfig {
   public static final String SERVER1 = "server1";
   public static final String SERVER2 = "server2";
 
+  // following username, password must exist on both setups!
+  public static final String rootUsername = "root";
+  public static final String rootPassword = "test";
+
   // Server config files used for each instance when using a local setup.
   private static Map<String, String> localServerConfigFiles =
       new HashMap<String, String>() {
@@ -43,10 +47,20 @@ public class SimpleDServerConfig implements SetupConfig {
       config.setDistributedDBConfig("/kubernetes/default-distributed-db-config.json");
       config.setServerLogConfig("/kubernetes/orientdb-server-log.properties");
       config.setClientLogConfig("/kubernetes/orientdb-client-log.properties");
-      config.setServerUser("root");
-      config.setServerPass("test");
+      config.setServerUser(rootUsername);
+      config.setServerPass(rootPassword);
       serverK8sConfigs.put(serverId, config);
     }
     return config;
+  }
+
+  @Override
+  public String getServerRootUsername(String serverId) {
+    return rootUsername;
+  }
+
+  @Override
+  public String getServerRootPassword(String serverId) {
+    return rootPassword;
   }
 }


### PR DESCRIPTION
Not the only test for multi-master write, but this one can run on a cluster and also doubles as a simple benchmark, producing some basic statistics. The contention between concurrent txs can also be partially adjusted.