### PR TITLE
Fix OETLProcessorConfigurator SPI by returning createDefaultContext()

### DIFF
--- a/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessorConfigurator.java
+++ b/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessorConfigurator.java
@@ -59,6 +59,10 @@ public class OETLProcessorConfigurator {
     context.setVariable("dumpEveryMs", 1000);
     return context;
   }
+  
+  protected OCommandContext createDefaultContext() {
+	  return createDefaultContext(null);
+  }
 
   public OETLProcessor parseConfigAndParameters(String[] args) {
     return parseConfigAndParametersWithContext(null, args);


### PR DESCRIPTION
Small fix of SPI of OETLProcessorConfigurator to avoid breaking of backward compatibility