### PR TITLE
use /dev/urandom in tests

### DIFF
--- a/distributed/src/test/resources/kubernetes/manifests/orientdb-statefulset.template.yaml
+++ b/distributed/src/test/resources/kubernetes/manifests/orientdb-statefulset.template.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: orientdb
-          command: ["dserver.sh", "-DkubernetesNamespace=${testNamespace}"]
+          command: ["sh", "-c", "rm /dev/random; mknod /dev/random c 1 9; dserver.sh -DkubernetesNamespace=${testNamespace}"]
           image: ${orientdbDockerImage}
           imagePullPolicy: Always
           env:


### PR DESCRIPTION
SecureRandom will block when using /dev/random (the default). This makes sure the tests don't get stuck on startup when running on Kubernetes.