### PR TITLE
Reject opening distributed DB which is not online!

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
@@ -181,11 +181,13 @@ public class OrientDBDistributed extends OrientDBEmbedded implements OServerAwar
   }
 
   private void checkDbAvailable(String name) {
-    if (OSystemDatabase.SYSTEM_DB_NAME.equals(name))
-      return;
-    ODistributedServerManager.DB_STATUS dbStatus = plugin.getDatabaseStatus(plugin.getLocalNodeName(), name);
-    if (dbStatus != ODistributedServerManager.DB_STATUS.ONLINE && dbStatus != ODistributedServerManager.DB_STATUS.BACKUP) {
-      throw new OOfflineNodeException("database " + name + " not online on " + plugin.getLocalNodeName());
+    if (OSystemDatabase.SYSTEM_DB_NAME.equals(name)) return;
+    ODistributedServerManager.DB_STATUS dbStatus =
+        plugin.getDatabaseStatus(plugin.getLocalNodeName(), name);
+    if (dbStatus != ODistributedServerManager.DB_STATUS.ONLINE
+        && dbStatus != ODistributedServerManager.DB_STATUS.BACKUP) {
+      throw new OOfflineNodeException(
+          "database " + name + " not online on " + plugin.getLocalNodeName());
     }
   }
 
@@ -196,7 +198,8 @@ public class OrientDBDistributed extends OrientDBEmbedded implements OServerAwar
   }
 
   @Override
-  public ODatabaseDocumentInternal open(String name, String user, String password, OrientDBConfig config) {
+  public ODatabaseDocumentInternal open(
+      String name, String user, String password, OrientDBConfig config) {
     checkDbAvailable(name);
     return super.open(name, user, password, config);
   }

--- a/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
@@ -1,5 +1,6 @@
 package com.orientechnologies.orient.core.db;
 
+import com.orientechnologies.common.concur.OOfflineNodeException;
 import com.orientechnologies.common.concur.lock.OModificationOperationProhibitedException;
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.orient.core.Orient;
@@ -14,6 +15,7 @@ import com.orientechnologies.orient.server.OClientConnection;
 import com.orientechnologies.orient.server.OServer;
 import com.orientechnologies.orient.server.OServerAware;
 import com.orientechnologies.orient.server.OSystemDatabase;
+import com.orientechnologies.orient.server.distributed.ODistributedServerManager;
 import com.orientechnologies.orient.server.distributed.impl.ODatabaseDocumentDistributed;
 import com.orientechnologies.orient.server.distributed.impl.ODatabaseDocumentDistributedPooled;
 import com.orientechnologies.orient.server.distributed.impl.ODistributedStorage;
@@ -176,6 +178,27 @@ public class OrientDBDistributed extends OrientDBEmbedded implements OServerAwar
         sharedContexts.remove(name);
       }
     }
+  }
+
+  private void checkDbAvailable(String name) {
+    if (OSystemDatabase.SYSTEM_DB_NAME.equals(name))
+      return;
+    ODistributedServerManager.DB_STATUS dbStatus = plugin.getDatabaseStatus(plugin.getLocalNodeName(), name);
+    if (dbStatus != ODistributedServerManager.DB_STATUS.ONLINE && dbStatus != ODistributedServerManager.DB_STATUS.BACKUP) {
+      throw new OOfflineNodeException("database " + name + " not online on " + plugin.getLocalNodeName());
+    }
+  }
+
+  @Override
+  public ODatabaseDocumentInternal open(String name, String user, String password) {
+    checkDbAvailable(name);
+    return super.open(name, user, password);
+  }
+
+  @Override
+  public ODatabaseDocumentInternal open(String name, String user, String password, OrientDBConfig config) {
+    checkDbAvailable(name);
+    return super.open(name, user, password, config);
   }
 
   @Override

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/BasicSyncIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/BasicSyncIT.java
@@ -30,6 +30,18 @@ public class BasicSyncIT {
     remote.close();
   }
 
+  private void waitForDbOnlineStatus(String dbName) throws InterruptedException {
+    server0
+        .getDistributedManager()
+        .waitUntilNodeOnline(server0.getDistributedManager().getLocalNodeName(), dbName);
+    server1
+        .getDistributedManager()
+        .waitUntilNodeOnline(server1.getDistributedManager().getLocalNodeName(), dbName);
+    server2
+        .getDistributedManager()
+        .waitUntilNodeOnline(server2.getDistributedManager().getLocalNodeName(), dbName);
+  }
+
   @Test
   public void sync()
       throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException,
@@ -51,6 +63,7 @@ public class BasicSyncIT {
     server0 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-0.xml");
     server1 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-1.xml");
     server2 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-2.xml");
+    waitForDbOnlineStatus("test");
     // Test server 0
     try (OrientDB remote = new OrientDB("remote:localhost", OrientDBConfig.defaultConfig())) {
       try (ODatabaseSession session = remote.open("test", "admin", "admin")) {
@@ -92,6 +105,7 @@ public class BasicSyncIT {
     server2 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-2.xml");
     server1 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-1.xml");
     server0 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-0.xml");
+    waitForDbOnlineStatus("test");
     // Test server 0
     try (OrientDB remote = new OrientDB("remote:localhost", OrientDBConfig.defaultConfig())) {
       try (ODatabaseSession session = remote.open("test", "admin", "admin")) {

--- a/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ConnectionStrategiesIT.java
+++ b/distributed/src/test/java/com/orientechnologies/orient/server/distributed/ConnectionStrategiesIT.java
@@ -33,8 +33,22 @@ public class ConnectionStrategiesIT {
     server2 = OServer.startFromClasspathConfig("orientdb-simple-dserver-config-2.xml");
     OrientDB remote =
         new OrientDB("remote:localhost", "root", "test", OrientDBConfig.defaultConfig());
-    remote.create(ConnectionStrategiesIT.class.getSimpleName(), ODatabaseType.PLOCAL);
+    String dbName = ConnectionStrategiesIT.class.getSimpleName();
+    remote.create(dbName, ODatabaseType.PLOCAL);
     remote.close();
+    waitForDbOnlineStatus(dbName);
+  }
+
+  private void waitForDbOnlineStatus(String dbName) throws InterruptedException {
+    server0
+        .getDistributedManager()
+        .waitUntilNodeOnline(server0.getDistributedManager().getLocalNodeName(), dbName);
+    server1
+        .getDistributedManager()
+        .waitUntilNodeOnline(server1.getDistributedManager().getLocalNodeName(), dbName);
+    server2
+        .getDistributedManager()
+        .waitUntilNodeOnline(server2.getDistributedManager().getLocalNodeName(), dbName);
   }
 
   @Test


### PR DESCRIPTION
Couldn't really create a test case to explicitly reproduce the stalling open issue. However, I think the fact that the `ConnectionStrategiesIT` test had to be adapted to wait for online status to be able to hit all servers, shows that sync'ing DBs now handle openDB requests better.