### PR TITLE
create a separate role for auditing

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/security/ODefaultSecuritySystem.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/security/ODefaultSecuritySystem.java
@@ -125,6 +125,9 @@ public class ODefaultSecuritySystem implements OSecuritySystem {
       for (ORule.ResourceGeneric resource : ORule.ResourceGeneric.values()) {
         root.addRule(resource, null, ORole.PERMISSION_ALL);
       }
+      // Do not allow root to have access to audit log class by default.
+      root.addRule(ORule.ResourceGeneric.CLASS, "OAuditingLog", ORole.PERMISSION_NONE);
+      root.addRule(ORule.ResourceGeneric.CLUSTER, "oauditinglog", ORole.PERMISSION_NONE);
       root.save();
     }
     if (security.getRole("guest") == null) {
@@ -145,6 +148,22 @@ public class ODefaultSecuritySystem implements OSecuritySystem {
       guest.addRule(ResourceGeneric.DATABASE, null, ORole.PERMISSION_READ);
       guest.addRule(ResourceGeneric.SERVER, null, ORole.PERMISSION_READ);
       guest.save();
+    }
+    // a separate role for accessing the auditing logs
+    if (security.getRole("auditor") == null) {
+      ORole auditor = security.createRole("auditor", OSecurityRole.ALLOW_MODES.DENY_ALL_BUT);
+      auditor.addRule(ORule.ResourceGeneric.DATABASE, null, ORole.PERMISSION_READ);
+      auditor.addRule(ORule.ResourceGeneric.SCHEMA, null, ORole.PERMISSION_READ);
+      auditor.addRule(ORule.ResourceGeneric.CLASS, null, ORole.PERMISSION_READ);
+      auditor.addRule(ORule.ResourceGeneric.CLUSTER, null, ORole.PERMISSION_READ);
+      auditor.addRule(ORule.ResourceGeneric.CLUSTER, "orole", ORole.PERMISSION_NONE);
+      auditor.addRule(ORule.ResourceGeneric.CLUSTER, "ouser", ORole.PERMISSION_NONE);
+      auditor.addRule(ORule.ResourceGeneric.CLASS, "OUser", ORole.PERMISSION_NONE);
+      auditor.addRule(ORule.ResourceGeneric.CLASS, "orole", ORole.PERMISSION_NONE);
+      auditor.addRule(ORule.ResourceGeneric.SYSTEM_CLUSTERS, null, ORole.PERMISSION_NONE);
+      auditor.addRule(ORule.ResourceGeneric.CLASS, "OAuditingLog", ORole.PERMISSION_ALL);
+      auditor.addRule(ORule.ResourceGeneric.CLUSTER, "oauditinglog", ORole.PERMISSION_ALL);
+      auditor.save();
     }
   }
 


### PR DESCRIPTION
A separate 'auditor' system role, which is not assigned to any system user by default.