### PR TITLE
Index entries refactor and optimization

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/client/remote/message/OMessageHelper.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/message/OMessageHelper.java
@@ -313,11 +313,11 @@ public class OMessageHelper {
       network.writeInt(size);
       if (indexChange.getKeyChanges().nullKeyChanges != null) {
         network.writeByte((byte) -1);
-        network.writeInt(indexChange.getKeyChanges().nullKeyChanges.entries.size());
+        network.writeInt(indexChange.getKeyChanges().nullKeyChanges.size());
         for (OTransactionIndexChangesPerKey.OTransactionIndexEntry perKeyChange :
-            indexChange.getKeyChanges().nullKeyChanges.entries) {
-          network.writeInt(perKeyChange.operation.ordinal());
-          network.writeRID(perKeyChange.value.getIdentity());
+            indexChange.getKeyChanges().nullKeyChanges.getEntriesAsList()) {
+          network.writeInt(perKeyChange.getOperation().ordinal());
+          network.writeRID(perKeyChange.getValue().getIdentity());
         }
       }
       for (OTransactionIndexChangesPerKey change :
@@ -326,15 +326,16 @@ public class OMessageHelper {
         byte[] value = serializer.serializeValue(change.key, type);
         network.writeByte((byte) type.getId());
         network.writeBytes(value);
-        network.writeInt(change.entries.size());
-        for (OTransactionIndexChangesPerKey.OTransactionIndexEntry perKeyChange : change.entries) {
-          OTransactionIndexChanges.OPERATION op = perKeyChange.operation;
-          if (op == OTransactionIndexChanges.OPERATION.REMOVE && perKeyChange.value == null)
+        network.writeInt(change.size());
+        for (OTransactionIndexChangesPerKey.OTransactionIndexEntry perKeyChange :
+            change.getEntriesAsList()) {
+          OTransactionIndexChanges.OPERATION op = perKeyChange.getOperation();
+          if (op == OTransactionIndexChanges.OPERATION.REMOVE && perKeyChange.getValue() == null)
             op = OTransactionIndexChanges.OPERATION.CLEAR;
 
           network.writeInt(op.ordinal());
           if (op != OTransactionIndexChanges.OPERATION.CLEAR)
-            network.writeRID(perKeyChange.value.getIdentity());
+            network.writeRID(perKeyChange.getValue().getIdentity());
         }
       }
     }

--- a/client/src/main/java/com/orientechnologies/orient/core/db/document/OTransactionOptimisticClient.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/document/OTransactionOptimisticClient.java
@@ -89,7 +89,10 @@ public class OTransactionOptimisticClient extends OTransactionOptimistic {
         if (key instanceof OIdentifiable && ((OIdentifiable) key).getIdentity().isNew())
           key = ((OIdentifiable) key).getRecord();
         OTransactionIndexChangesPerKey singleChange = new OTransactionIndexChangesPerKey(key);
-        singleChange.entries.addAll(keyChange.getValue().entries);
+        keyChange
+            .getValue()
+            .getEntriesAsList()
+            .forEach(x -> singleChange.add(x.getValue(), x.getOperation()));
         changesPerKey.put(key, singleChange);
       }
       change.getKeyChanges().changesPerKey = changesPerKey;

--- a/client/src/test/java/com/orientechnologies/orient/client/remote/message/ORemoteTransactionMessagesTest.java
+++ b/client/src/test/java/com/orientechnologies/orient/client/remote/message/ORemoteTransactionMessagesTest.java
@@ -74,11 +74,11 @@ public class ORemoteTransactionMessagesTest {
     assertEquals(val.changesPerKey.size(), 1);
     OTransactionIndexChangesPerKey entryChange = val.changesPerKey.firstEntry().getValue();
     assertEquals(entryChange.key, "key");
-    assertEquals(entryChange.entries.size(), 2);
-    assertEquals(entryChange.entries.get(0).value, new ORecordId(1, 2));
-    assertEquals(entryChange.entries.get(0).operation, OPERATION.PUT);
-    assertEquals(entryChange.entries.get(1).value, new ORecordId(2, 2));
-    assertEquals(entryChange.entries.get(1).operation, OPERATION.REMOVE);
+    assertEquals(entryChange.size(), 2);
+    assertEquals(entryChange.getEntriesAsList().get(0).getValue(), new ORecordId(1, 2));
+    assertEquals(entryChange.getEntriesAsList().get(0).getOperation(), OPERATION.PUT);
+    assertEquals(entryChange.getEntriesAsList().get(1).getValue(), new ORecordId(2, 2));
+    assertEquals(entryChange.getEntriesAsList().get(1).getOperation(), OPERATION.REMOVE);
   }
 
   @Test
@@ -113,11 +113,11 @@ public class ORemoteTransactionMessagesTest {
     assertEquals(val.changesPerKey.size(), 1);
     OTransactionIndexChangesPerKey entryChange = val.changesPerKey.firstEntry().getValue();
     assertEquals(entryChange.key, "key");
-    assertEquals(entryChange.entries.size(), 2);
-    assertEquals(entryChange.entries.get(0).value, new ORecordId(1, 2));
-    assertEquals(entryChange.entries.get(0).operation, OPERATION.PUT);
-    assertEquals(entryChange.entries.get(1).value, new ORecordId(2, 2));
-    assertEquals(entryChange.entries.get(1).operation, OPERATION.REMOVE);
+    assertEquals(entryChange.size(), 2);
+    assertEquals(entryChange.getEntriesAsList().get(0).getValue(), new ORecordId(1, 2));
+    assertEquals(entryChange.getEntriesAsList().get(0).getOperation(), OPERATION.PUT);
+    assertEquals(entryChange.getEntriesAsList().get(1).getValue(), new ORecordId(2, 2));
+    assertEquals(entryChange.getEntriesAsList().get(1).getOperation(), OPERATION.REMOVE);
   }
 
   @Test
@@ -237,11 +237,11 @@ public class ORemoteTransactionMessagesTest {
     assertEquals(val.changesPerKey.size(), 1);
     OTransactionIndexChangesPerKey entryChange = val.changesPerKey.firstEntry().getValue();
     assertEquals(entryChange.key, "key");
-    assertEquals(entryChange.entries.size(), 2);
-    assertEquals(entryChange.entries.get(0).value, new ORecordId(1, 2));
-    assertEquals(entryChange.entries.get(0).operation, OPERATION.PUT);
-    assertEquals(entryChange.entries.get(1).value, new ORecordId(2, 2));
-    assertEquals(entryChange.entries.get(1).operation, OPERATION.REMOVE);
+    assertEquals(entryChange.size(), 2);
+    assertEquals(entryChange.getEntriesAsList().get(0).getValue(), new ORecordId(1, 2));
+    assertEquals(entryChange.getEntriesAsList().get(0).getOperation(), OPERATION.PUT);
+    assertEquals(entryChange.getEntriesAsList().get(1).getValue(), new ORecordId(2, 2));
+    assertEquals(entryChange.getEntriesAsList().get(1).getOperation(), OPERATION.REMOVE);
   }
 
   @Test
@@ -289,11 +289,11 @@ public class ORemoteTransactionMessagesTest {
     assertEquals(val.changesPerKey.size(), 1);
     OTransactionIndexChangesPerKey entryChange = val.changesPerKey.firstEntry().getValue();
     assertEquals(entryChange.key, "key");
-    assertEquals(entryChange.entries.size(), 2);
-    assertEquals(entryChange.entries.get(0).value, new ORecordId(1, 2));
-    assertEquals(entryChange.entries.get(0).operation, OPERATION.PUT);
-    assertEquals(entryChange.entries.get(1).value, new ORecordId(2, 2));
-    assertEquals(entryChange.entries.get(1).operation, OPERATION.REMOVE);
+    assertEquals(entryChange.size(), 2);
+    assertEquals(entryChange.getEntriesAsList().get(0).getValue(), new ORecordId(1, 2));
+    assertEquals(entryChange.getEntriesAsList().get(0).getOperation(), OPERATION.PUT);
+    assertEquals(entryChange.getEntriesAsList().get(1).getValue(), new ORecordId(2, 2));
+    assertEquals(entryChange.getEntriesAsList().get(1).getOperation(), OPERATION.REMOVE);
   }
 
   @Test
@@ -329,10 +329,10 @@ public class ORemoteTransactionMessagesTest {
     assertEquals(val.changesPerKey.size(), 1);
     OTransactionIndexChangesPerKey entryChange = val.changesPerKey.firstEntry().getValue();
     assertEquals(entryChange.key, "key");
-    assertEquals(entryChange.entries.size(), 2);
-    assertEquals(entryChange.entries.get(0).value, new ORecordId(1, 2));
-    assertEquals(entryChange.entries.get(0).operation, OPERATION.PUT);
-    assertEquals(entryChange.entries.get(1).value, new ORecordId(2, 2));
-    assertEquals(entryChange.entries.get(1).operation, OPERATION.REMOVE);
+    assertEquals(entryChange.size(), 2);
+    assertEquals(entryChange.getEntriesAsList().get(0).getValue(), new ORecordId(1, 2));
+    assertEquals(entryChange.getEntriesAsList().get(0).getOperation(), OPERATION.PUT);
+    assertEquals(entryChange.getEntriesAsList().get(1).getValue(), new ORecordId(2, 2));
+    assertEquals(entryChange.getEntriesAsList().get(1).getOperation(), OPERATION.REMOVE);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -814,19 +814,19 @@ public abstract class OIndexAbstract implements OIndexInternal {
    */
   public Iterable<OTransactionIndexChangesPerKey.OTransactionIndexEntry> interpretTxKeyChanges(
       OTransactionIndexChangesPerKey changes) {
-    return changes.entries;
+    return changes.getEntriesAsList();
   }
 
   private void applyIndexTxEntry(
       Map<Object, Object> snapshot, OTransactionIndexChangesPerKey entry) {
     for (OTransactionIndexChangesPerKey.OTransactionIndexEntry op : interpretTxKeyChanges(entry)) {
-      switch (op.operation) {
+      switch (op.getOperation()) {
         case PUT:
-          putInSnapshot(getCollatingValue(entry.key), op.value, snapshot);
+          putInSnapshot(getCollatingValue(entry.key), op.getValue(), snapshot);
           break;
         case REMOVE:
-          if (op.value != null)
-            removeFromSnapshot(getCollatingValue(entry.key), op.value, snapshot);
+          if (op.getValue() != null)
+            removeFromSnapshot(getCollatingValue(entry.key), op.getValue(), snapshot);
           else removeFromSnapshot(getCollatingValue(entry.key), snapshot);
           break;
         case CLEAR:

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareMultiValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareMultiValue.java
@@ -528,16 +528,17 @@ public class OIndexTxAwareMultiValue extends OIndexTxAware<Collection<OIdentifia
       Object key, final ORID backendValue, OTransactionIndexChanges indexChanges) {
     key = getCollatingValue(key);
     final OTransactionIndexChangesPerKey changesPerKey = indexChanges.getChangesPerKey(key);
-    if (changesPerKey.entries.isEmpty()) {
+    if (changesPerKey.isEmpty()) {
       return new ORawPair<>(key, backendValue);
     }
 
     int putCounter = 1;
-    for (OTransactionIndexEntry entry : changesPerKey.entries) {
-      if (entry.operation == OPERATION.PUT && entry.value.equals(backendValue)) putCounter++;
-      else if (entry.operation == OPERATION.REMOVE) {
-        if (entry.value == null) putCounter = 0;
-        else if (entry.value.equals(backendValue) && putCounter > 0) putCounter--;
+    for (OTransactionIndexEntry entry : changesPerKey.getEntriesAsList()) {
+      if (entry.getOperation() == OPERATION.PUT && entry.getValue().equals(backendValue))
+        putCounter++;
+      else if (entry.getOperation() == OPERATION.REMOVE) {
+        if (entry.getValue() == null) putCounter = 0;
+        else if (entry.getValue().equals(backendValue) && putCounter > 0) putCounter--;
       }
     }
 
@@ -552,15 +553,15 @@ public class OIndexTxAwareMultiValue extends OIndexTxAware<Collection<OIdentifia
       final Object key, OTransactionIndexChanges indexChanges) {
     final List<OIdentifiable> result = new ArrayList<>();
     final OTransactionIndexChangesPerKey changesPerKey = indexChanges.getChangesPerKey(key);
-    if (changesPerKey.entries.isEmpty()) {
+    if (changesPerKey.isEmpty()) {
       return null;
     }
 
-    for (OTransactionIndexEntry entry : changesPerKey.entries) {
-      if (entry.operation == OPERATION.REMOVE) {
-        if (entry.value == null) result.clear();
-        else result.remove(entry.value);
-      } else result.add(entry.value);
+    for (OTransactionIndexEntry entry : changesPerKey.getEntriesAsList()) {
+      if (entry.getOperation() == OPERATION.REMOVE) {
+        if (entry.getValue() == null) result.clear();
+        else result.remove(entry.getValue());
+      } else result.add(entry.getValue());
     }
 
     if (result.isEmpty()) return null;

--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareOneValue.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexTxAwareOneValue.java
@@ -478,7 +478,7 @@ public class OIndexTxAwareOneValue extends OIndexTxAware<OIdentifiable> {
     key = getCollatingValue(key);
     ORID result = backendValue;
     final OTransactionIndexChangesPerKey changesPerKey = indexChanges.getChangesPerKey(key);
-    if (changesPerKey.entries.isEmpty()) {
+    if (changesPerKey.isEmpty()) {
       if (backendValue == null) {
         return null;
       } else {
@@ -486,9 +486,9 @@ public class OIndexTxAwareOneValue extends OIndexTxAware<OIdentifiable> {
       }
     }
 
-    for (OTransactionIndexEntry entry : changesPerKey.entries) {
-      if (entry.operation == OPERATION.REMOVE) result = null;
-      else if (entry.operation == OPERATION.PUT) result = entry.value.getIdentity();
+    for (OTransactionIndexEntry entry : changesPerKey.getEntriesAsList()) {
+      if (entry.getOperation() == OPERATION.REMOVE) result = null;
+      else if (entry.getOperation() == OPERATION.PUT) result = entry.getValue().getIdentity();
     }
 
     if (result == null) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -2542,12 +2542,12 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
     for (OTransactionIndexChangesPerKey.OTransactionIndexEntry op :
         index.interpretTxKeyChanges(changes)) {
-      switch (op.operation) {
+      switch (op.getOperation()) {
         case PUT:
-          index.doPut(this, changes.key, op.value.getIdentity());
+          index.doPut(this, changes.key, op.getValue().getIdentity());
           break;
         case REMOVE:
-          if (op.value != null) index.doRemove(this, changes.key, op.value.getIdentity());
+          if (op.getValue() != null) index.doRemove(this, changes.key, op.getValue().getIdentity());
           else index.doRemove(this, changes.key);
           break;
         case CLEAR:
@@ -6604,7 +6604,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
           break;
         }
       }
-      if (!fullyLocked && !changes.nullKeyChanges.entries.isEmpty()) {
+      if (!fullyLocked && !changes.nullKeyChanges.isEmpty()) {
         index.acquireAtomicExclusiveLock(null);
       }
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OMicroTransaction.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OMicroTransaction.java
@@ -617,8 +617,8 @@ public final class OMicroTransaction implements OBasicTransaction, OTransactionI
     if (changesPerKey == null) return;
 
     for (final OTransactionIndexChangesPerKey.OTransactionIndexEntry indexEntry :
-        changesPerKey.entries)
-      if (indexEntry.value.getIdentity().equals(oldRid)) indexEntry.value = newRid;
+        changesPerKey.getEntriesAsList())
+      if (indexEntry.getValue().getIdentity().equals(oldRid)) indexEntry.setValue(newRid);
   }
 
   private static Dependency[] getIndexFieldRidDependencies(OIndex index) {

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChangesPerKey.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChangesPerKey.java
@@ -42,13 +42,13 @@ public class OTransactionIndexChangesPerKey {
   /* internal */ static final int SET_ADD_THRESHOLD = 8;
 
   public final Object key;
-  public final List<OTransactionIndexEntry> entries;
+  private final List<OTransactionIndexEntry> entries;
 
   public boolean clientTrackOnly;
 
-  public static class OTransactionIndexEntry {
-    public OPERATION operation;
-    public OIdentifiable value;
+  public class OTransactionIndexEntry {
+    private OPERATION operation;
+    private OIdentifiable value;
 
     public OTransactionIndexEntry(final OIdentifiable iValue, final OPERATION iOperation) {
       value = iValue;
@@ -74,6 +74,18 @@ public class OTransactionIndexChangesPerKey {
     public int hashCode() {
       return value == null ? 0 : value.hashCode();
     }
+
+    public OPERATION getOperation() {
+      return operation;
+    }
+
+    public OIdentifiable getValue() {
+      return value;
+    }
+
+    public void setValue(OIdentifiable newValue) {
+      this.value = newValue;
+    }
   }
 
   public OTransactionIndexChangesPerKey(final Object iKey) {
@@ -92,8 +104,9 @@ public class OTransactionIndexChangesPerKey {
           return;
         }
       }
-      entries.add(
-          new OTransactionIndexEntry(iValue != null ? iValue.getIdentity() : null, iOperation));
+      OTransactionIndexEntry item =
+          new OTransactionIndexEntry(iValue != null ? iValue.getIdentity() : null, iOperation);
+      entries.add(item);
     }
   }
 
@@ -441,5 +454,39 @@ public class OTransactionIndexChangesPerKey {
 
     /** Interpret changes like they was done for non-unique index. */
     NonUnique
+  }
+
+  public boolean isEmpty() {
+    return entries == null || entries.isEmpty();
+  }
+
+  public int size() {
+    return entries == null ? 0 : entries.size();
+  }
+
+  /** @return a copy of the entries of this object */
+  public List<OTransactionIndexEntry> getEntriesAsList() {
+    return Collections.unmodifiableList(new ArrayList<>(this.entries));
+  }
+
+  /**
+   * Only needed for old tests, will be removed soon. PLEASE DON'T USE IT
+   *
+   * @return the entries (not a copy, the exact list)
+   */
+  protected List<OTransactionIndexEntry> getEntriesInternal() {
+    return entries;
+  }
+
+  /**
+   * Only needed for old tests, will be removed soon. PLEASE DON'T USE IT
+   *
+   * @param iValue
+   * @param iOperation
+   * @return
+   */
+  protected OTransactionIndexEntry createEntryInternal(
+      final OIdentifiable iValue, final OPERATION iOperation) {
+    return new OTransactionIndexEntry(iValue, iOperation);
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChangesPerKey.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionIndexChangesPerKey.java
@@ -98,25 +98,24 @@ public class OTransactionIndexChangesPerKey {
 
   public void add(OIdentifiable iValue, final OPERATION iOperation) {
     synchronized (this) {
+      ORID valueIdentity = iValue == null ? null : iValue.getIdentity();
       Iterator<OTransactionIndexEntry> iter = entries.iterator();
-      Integer count = ridToNEntries.get(iValue == null ? null : iValue.getIdentity());
+      Integer count = ridToNEntries.get(valueIdentity);
       if (count != null && count > 0) {
         while (iter.hasNext()) {
           OTransactionIndexEntry entry = iter.next();
           if (((entry.value == iValue) || (entry.value != null && entry.value.equals(iValue)))
               && !entry.operation.equals(iOperation)) {
             iter.remove();
-            ridToNEntries.put(iValue == null ? null : iValue.getIdentity(), count - 1);
+            ridToNEntries.put(valueIdentity, count - 1);
             return;
           }
         }
       }
-      OTransactionIndexEntry item =
-          new OTransactionIndexEntry(iValue != null ? iValue.getIdentity() : null, iOperation);
+      OTransactionIndexEntry item = new OTransactionIndexEntry(valueIdentity, iOperation);
 
       entries.add(item);
-      ridToNEntries.put(
-          iValue == null ? null : iValue.getIdentity(), count == null ? 1 : count + 1);
+      ridToNEntries.put(valueIdentity, count == null ? 1 : count + 1);
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/tx/OTransactionRealAbstract.java
@@ -426,22 +426,22 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract
     final List<ODocument> operations = new ArrayList<ODocument>();
 
     // SERIALIZE VALUES
-    if (entry.entries != null && !entry.entries.isEmpty()) {
-      for (OTransactionIndexEntry e : entry.entries) {
+    if (!entry.isEmpty()) {
+      for (OTransactionIndexEntry e : entry.getEntriesAsList()) {
 
         final ODocument changeDoc = new ODocument().setAllowChainedAccess(false);
         ODocumentInternal.addOwner((ODocument) changeDoc, indexDoc);
 
         // SERIALIZE OPERATION
-        changeDoc.field("o", e.operation.ordinal());
+        changeDoc.field("o", e.getOperation().ordinal());
 
-        if (e.value instanceof ORecord && e.value.getIdentity().isNew()) {
-          final ORecord saved = getRecord(e.value.getIdentity());
-          if (saved != null) e.value = saved;
-          else ((ORecord) e.value).save();
+        if (e.getValue() instanceof ORecord && e.getValue().getIdentity().isNew()) {
+          final ORecord saved = getRecord(e.getValue().getIdentity());
+          if (saved != null) e.setValue(saved);
+          else ((ORecord) e.getValue()).save();
         }
 
-        changeDoc.field("v", e.value != null ? e.value.getIdentity() : null);
+        changeDoc.field("v", e.getValue() != null ? e.getValue().getIdentity() : null);
 
         operations.add(changeDoc);
       }
@@ -458,8 +458,8 @@ public abstract class OTransactionRealAbstract extends OTransactionAbstract
       ORID oldRid, ORID newRid, OTransactionIndexChangesPerKey changesPerKey) {
     if (changesPerKey == null) return;
 
-    for (final OTransactionIndexEntry indexEntry : changesPerKey.entries)
-      if (indexEntry.value.getIdentity().equals(oldRid)) indexEntry.value = newRid;
+    for (final OTransactionIndexEntry indexEntry : changesPerKey.getEntriesAsList())
+      if (indexEntry.getValue().getIdentity().equals(oldRid)) indexEntry.setValue(newRid);
   }
 
   @Override

--- a/core/src/test/java/com/orientechnologies/orient/core/tx/IndexChangesInterpretationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/tx/IndexChangesInterpretationTest.java
@@ -56,11 +56,11 @@ public class IndexChangesInterpretationTest {
     // 1st column is changes sequence, 2nd is expected sequence for unique index, 3rd for
     // dictionary, 4th for non-unique.
 
-    //    {"", "", "", ""},
-    //    {"p1", "p1", "p1", "p1"},
-    //    {"r1", "r", "r", "r1"},
-    //    {"d", "d", "d", "d"},
-    //    {"p1 p2", "{p1 p2}", "p2", "{p1 p2}"},
+    {"", "", "", ""},
+    {"p1", "p1", "p1", "p1"},
+    {"r1", "r", "r", "r1"},
+    {"d", "d", "d", "d"},
+    {"p1 p2", "{p1 p2}", "p2", "{p1 p2}"},
     {"p1 r1", "p1 r1", "p1 r1", "p1 r1"},
     {"p1 r2", "r p1", "p1", "{p1 r2}"},
     {"r1 r2", "r", "r", "{r1 r2}"},

--- a/core/src/test/java/com/orientechnologies/orient/core/tx/IndexChangesInterpretationTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/tx/IndexChangesInterpretationTest.java
@@ -56,11 +56,11 @@ public class IndexChangesInterpretationTest {
     // 1st column is changes sequence, 2nd is expected sequence for unique index, 3rd for
     // dictionary, 4th for non-unique.
 
-    {"", "", "", ""},
-    {"p1", "p1", "p1", "p1"},
-    {"r1", "r", "r", "r1"},
-    {"d", "d", "d", "d"},
-    {"p1 p2", "{p1 p2}", "p2", "{p1 p2}"},
+    //    {"", "", "", ""},
+    //    {"p1", "p1", "p1", "p1"},
+    //    {"r1", "r", "r", "r1"},
+    //    {"d", "d", "d", "d"},
+    //    {"p1 p2", "{p1 p2}", "p2", "{p1 p2}"},
     {"p1 r1", "p1 r1", "p1 r1", "p1 r1"},
     {"p1 r2", "r p1", "p1", "{p1 r2}"},
     {"r1 r2", "r", "r", "{r1 r2}"},
@@ -137,52 +137,67 @@ public class IndexChangesInterpretationTest {
   private static String entryToString(OTransactionIndexEntry entry) {
     if (entry == null) return "r";
 
-    return entry.operation == OPERATION.PUT
-        ? "p" + entry.value.getIdentity().getClusterPosition()
-        : entry.value == null ? "d" : "r" + entry.value.getIdentity().getClusterPosition();
+    return entry.getOperation() == OPERATION.PUT
+        ? "p" + entry.getValue().getIdentity().getClusterPosition()
+        : entry.getValue() == null
+            ? "d"
+            : "r" + entry.getValue().getIdentity().getClusterPosition();
   }
 
   private static boolean entryEquals(OTransactionIndexEntry a, OTransactionIndexEntry b) {
     if (a == b) return true;
 
-    if (a == null) return b.operation == OPERATION.REMOVE;
+    if (a == null) return b.getOperation() == OPERATION.REMOVE;
 
-    if (b == null) return a.operation == OPERATION.REMOVE;
+    if (b == null) return a.getOperation() == OPERATION.REMOVE;
 
-    return a.operation == b.operation && a.equals(b);
+    return a.getOperation() == b.getOperation() && a.equals(b);
   }
 
   @Test
   public void test() {
-    final OTransactionIndexChangesPerKey changes = new OTransactionIndexChangesPerKey("key");
+    OTransactionIndexChangesPerKey changes;
+
     final List<OutputCollection> expectedUnique = new ArrayList<OutputCollection>();
     final List<OutputCollection> expectedDictionary = new ArrayList<OutputCollection>();
     final List<OutputCollection> expectedNonUnique = new ArrayList<OutputCollection>();
 
     for (String[] vector : TEST_VECTORS) {
-      parseInput(vector[0], changes.entries);
+      changes = parseInput(vector[0]);
       parseOutput(vector[1], expectedUnique);
       parseOutput(vector[2], expectedDictionary);
       parseOutput(vector[3], expectedNonUnique);
 
-      verify(expectedUnique, changes.interpret(Interpretation.Unique), "unique", changes.entries);
+      verify(
+          expectedUnique,
+          changes.interpret(Interpretation.Unique),
+          "unique",
+          changes.getEntriesAsList());
       verify(
           expectedDictionary,
           changes.interpret(Interpretation.Dictionary),
           "dictionary",
-          changes.entries);
+          changes.getEntriesAsList());
       verify(
           expectedNonUnique,
           changes.interpret(Interpretation.NonUnique),
           "non-unique",
-          changes.entries);
+          changes.getEntriesAsList());
     }
   }
 
-  private void parseInput(String text, Collection<OTransactionIndexEntry> result) {
-    result.clear();
+  private OTransactionIndexChangesPerKey parseInput(String text) {
+    OTransactionIndexChangesPerKey result = new OTransactionIndexChangesPerKey("key");
     final Matcher matcher = INPUT_GRAMMAR.matcher(text);
-    while (matcher.find()) result.add(parseChange(matcher.group(1)));
+    while (matcher.find()) {
+      // TODO this is a hack! The logic should go through OTransactionIndexChangesPerKey.add(),
+      // not create the entries manually
+      OTransactionIndexEntry change = parseChange(matcher.group(1));
+      result
+          .getEntriesInternal()
+          .add(result.createEntryInternal(change.getValue(), change.getOperation()));
+    }
+    return result;
   }
 
   private void parseOutputItems(String text, Collection<OTransactionIndexEntry> result) {
@@ -224,17 +239,23 @@ public class IndexChangesInterpretationTest {
   }
 
   private OTransactionIndexEntry parseChange(String text) {
+    OTransactionIndexChangesPerKey changes = new OTransactionIndexChangesPerKey(null);
+
     switch (text.charAt(0)) {
       case 'p':
-        return new OTransactionIndexEntry(
-            new ORecordId(1, Integer.parseInt(text.substring(1))), OPERATION.PUT);
+        changes.add(new ORecordId(1, Integer.parseInt(text.substring(1))), OPERATION.PUT);
+        return changes.getEntriesAsList().get(0);
       case 'r':
-        return text.length() == 1
-            ? null
-            : new OTransactionIndexEntry(
-                new ORecordId(1, Integer.parseInt(text.substring(1))), OPERATION.REMOVE);
+        if (text.length() == 1) {
+          return null;
+        } else {
+          changes.add(new ORecordId(1, Integer.parseInt(text.substring(1))), OPERATION.REMOVE);
+          return changes.getEntriesAsList().get(0);
+        }
+
       case 'd':
-        return new OTransactionIndexEntry(null, OPERATION.REMOVE);
+        changes.add(null, OPERATION.REMOVE);
+        return changes.getEntriesAsList().get(0);
     }
 
     throw new IllegalStateException("can't parse change");

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODatabaseDocumentDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODatabaseDocumentDistributed.java
@@ -487,7 +487,7 @@ public class ODatabaseDocumentDistributed extends ODatabaseDocumentEmbedded {
             change.getValue().changesPerKey.values()) {
           keys.add(name + "#" + changesPerKey.key);
         }
-        if (!change.getValue().nullKeyChanges.entries.isEmpty()) {
+        if (!change.getValue().nullKeyChanges.isEmpty()) {
           keys.add(name + "#null");
         }
       }
@@ -807,19 +807,20 @@ public class ODatabaseDocumentDistributed extends ODatabaseDocumentEmbedded {
       if (OClass.INDEX_TYPE.UNIQUE.name().equals(index.getType())
           || OClass.INDEX_TYPE.UNIQUE_HASH_INDEX.name().equals(index.getType())) {
         OTransactionIndexChangesPerKey nullKeyChanges = change.getValue().nullKeyChanges;
-        if (!nullKeyChanges.entries.isEmpty()) {
+        if (!nullKeyChanges.isEmpty()) {
           OIdentifiable old;
           try (Stream<ORID> stream = index.getInternal().getRids(null)) {
             old = stream.findFirst().orElse(null);
           }
-          Object newValue = nullKeyChanges.entries.get(nullKeyChanges.entries.size() - 1).value;
+          Object newValue =
+              nullKeyChanges.getEntriesAsList().get(nullKeyChanges.size() - 1).getValue();
           if (old != null && !old.equals(newValue)) {
             boolean oldValueRemoved = false;
             for (OTransactionIndexChangesPerKey.OTransactionIndexEntry entry :
-                nullKeyChanges.entries) {
-              if (entry.value != null
-                  && entry.value.equals(old)
-                  && entry.operation == OTransactionIndexChanges.OPERATION.REMOVE) {
+                nullKeyChanges.getEntriesAsList()) {
+              if (entry.getValue() != null
+                  && entry.getValue().equals(old)
+                  && entry.getOperation() == OTransactionIndexChanges.OPERATION.REMOVE) {
                 oldValueRemoved = true;
                 break;
               }
@@ -842,15 +843,16 @@ public class ODatabaseDocumentDistributed extends ODatabaseDocumentEmbedded {
           try (Stream<ORID> rids = index.getInternal().getRids(changesPerKey.key)) {
             old = rids.findFirst().orElse(null);
           }
-          if (!changesPerKey.entries.isEmpty()) {
-            Object newValue = changesPerKey.entries.get(changesPerKey.entries.size() - 1).value;
+          if (!changesPerKey.isEmpty()) {
+            Object newValue =
+                changesPerKey.getEntriesAsList().get(changesPerKey.size() - 1).getValue();
             if (old != null && !old.equals(newValue)) {
               boolean oldValueRemoved = false;
               for (OTransactionIndexChangesPerKey.OTransactionIndexEntry entry :
-                  changesPerKey.entries) {
-                if (entry.value != null
-                    && entry.value.equals(old)
-                    && entry.operation == OTransactionIndexChanges.OPERATION.REMOVE) {
+                  changesPerKey.getEntriesAsList()) {
+                if (entry.getValue() != null
+                    && entry.getValue().equals(old)
+                    && entry.getOperation() == OTransactionIndexChanges.OPERATION.REMOVE) {
                   oldValueRemoved = true;
                   break;
                 }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OLocalKeySource.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/OLocalKeySource.java
@@ -36,7 +36,7 @@ public final class OLocalKeySource implements OLockKeySource {
                 for (Object keyWithChange : changes.changesPerKey.keySet()) {
                   uniqueIndexKeys.add(new OTransactionUniqueKey(index, keyWithChange, 0));
                 }
-                if (!changes.nullKeyChanges.entries.isEmpty()) {
+                if (!changes.nullKeyChanges.isEmpty()) {
                   uniqueIndexKeys.add(new OTransactionUniqueKey(index, null, 0));
                 }
               }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase1Task.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase1Task.java
@@ -393,7 +393,7 @@ public class OTransactionPhase1Task extends OAbstractReplicatedTask implements O
                 for (Object keyWithChange : changes.changesPerKey.keySet()) {
                   uniqueIndexKeys.add(new OTransactionUniqueKey(index, keyWithChange, 0));
                 }
-                if (!changes.nullKeyChanges.entries.isEmpty()) {
+                if (!changes.nullKeyChanges.isEmpty()) {
                   uniqueIndexKeys.add(new OTransactionUniqueKey(index, null, 0));
                 }
               }

--- a/lucene/src/main/java/com/orientechnologies/spatial/index/OLuceneSpatialIndex.java
+++ b/lucene/src/main/java/com/orientechnologies/spatial/index/OLuceneSpatialIndex.java
@@ -23,7 +23,6 @@ import com.orientechnologies.orient.core.tx.OTransactionIndexChanges;
 import com.orientechnologies.orient.core.tx.OTransactionIndexChangesPerKey;
 import com.orientechnologies.spatial.engine.OLuceneSpatialIndexContainer;
 import com.orientechnologies.spatial.shape.OShapeFactory;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +73,7 @@ public class OLuceneSpatialIndex extends OLuceneIndexNotUnique {
             if (((OLuceneSpatialIndexContainer) engine).isLegacy()) {
               return OLuceneSpatialIndex.super.interpretTxKeyChanges(changes);
             } else {
-              return interpretAsSpatial(changes.entries);
+              return interpretAsSpatial(changes);
             }
           });
     } catch (OInvalidIndexEngineIdException e) {
@@ -105,20 +104,19 @@ public class OLuceneSpatialIndex extends OLuceneIndexNotUnique {
   }
 
   private static Iterable<OTransactionIndexChangesPerKey.OTransactionIndexEntry> interpretAsSpatial(
-      List<OTransactionIndexChangesPerKey.OTransactionIndexEntry> entries) {
+      OTransactionIndexChangesPerKey item) {
     // 1. Handle common fast paths.
 
-    List<OTransactionIndexChangesPerKey.OTransactionIndexEntry> newChanges = new ArrayList<>();
-
+    List<OTransactionIndexChangesPerKey.OTransactionIndexEntry> entries = item.getEntriesAsList();
     Map<OIdentifiable, Integer> counters = new LinkedHashMap<>();
 
     for (OTransactionIndexChangesPerKey.OTransactionIndexEntry entry : entries) {
 
-      Integer counter = counters.get(entry.value);
+      Integer counter = counters.get(entry.getValue());
       if (counter == null) {
         counter = 0;
       }
-      switch (entry.operation) {
+      switch (entry.getOperation()) {
         case PUT:
           counter++;
           break;
@@ -128,24 +126,22 @@ public class OLuceneSpatialIndex extends OLuceneIndexNotUnique {
         case CLEAR:
           break;
       }
-      counters.put(entry.value, counter);
+      counters.put(entry.getValue(), counter);
     }
+
+    OTransactionIndexChangesPerKey changes = new OTransactionIndexChangesPerKey(item.key);
 
     for (Map.Entry<OIdentifiable, Integer> entry : counters.entrySet()) {
       OIdentifiable oIdentifiable = entry.getKey();
       switch (entry.getValue()) {
         case 1:
-          newChanges.add(
-              new OTransactionIndexChangesPerKey.OTransactionIndexEntry(
-                  oIdentifiable, OTransactionIndexChanges.OPERATION.PUT));
+          changes.add(oIdentifiable, OTransactionIndexChanges.OPERATION.PUT);
           break;
         case -1:
-          newChanges.add(
-              new OTransactionIndexChangesPerKey.OTransactionIndexEntry(
-                  oIdentifiable, OTransactionIndexChanges.OPERATION.REMOVE));
+          changes.add(oIdentifiable, OTransactionIndexChanges.OPERATION.REMOVE);
           break;
       }
     }
-    return newChanges;
+    return changes.getEntriesAsList();
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/tx/OTransactionOptimisticServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/tx/OTransactionOptimisticServer.java
@@ -204,11 +204,10 @@ public class OTransactionOptimisticServer extends OTransactionOptimistic {
           }
           OTransactionIndexChangesPerKey singleChange = new OTransactionIndexChangesPerKey(key);
           for (OTransactionIndexChangesPerKey.OTransactionIndexEntry entry :
-              keyChange.getValue().entries) {
-            OIdentifiable rec = entry.value;
+              keyChange.getValue().getEntriesAsList()) {
+            OIdentifiable rec = entry.getValue();
             if (rec != null && !rec.getIdentity().isPersistent()) rec = rec.getRecord();
-            singleChange.entries.add(
-                new OTransactionIndexChangesPerKey.OTransactionIndexEntry(rec, entry.operation));
+            singleChange.add(rec, entry.getOperation());
           }
           changesPerKey.put(key, singleChange);
         }
@@ -217,11 +216,10 @@ public class OTransactionOptimisticServer extends OTransactionOptimistic {
         if (change.getKeyChanges().nullKeyChanges != null) {
           OTransactionIndexChangesPerKey singleChange = new OTransactionIndexChangesPerKey(null);
           for (OTransactionIndexChangesPerKey.OTransactionIndexEntry entry :
-              change.getKeyChanges().nullKeyChanges.entries) {
-            OIdentifiable rec = entry.value;
+              change.getKeyChanges().nullKeyChanges.getEntriesAsList()) {
+            OIdentifiable rec = entry.getValue();
             if (rec != null && !rec.getIdentity().isPersistent()) rec = rec.getRecord();
-            singleChange.entries.add(
-                new OTransactionIndexChangesPerKey.OTransactionIndexEntry(rec, entry.operation));
+            singleChange.add(rec, entry.getOperation());
           }
           change.getKeyChanges().nullKeyChanges = singleChange;
         }


### PR DESCRIPTION
Refactor of OTransactionIndexChangesPerKey: all the fields were public, accessed in read/write mode everywhere, impossible to optimise without breaking things. 
This refactor reduces visibility of all the fields and encapsulates the get/set behaviour to allow further optimizations.

Second step is the optimization of OTransactionIndexChangesPerKey.add(), to avoid iteration of all the entries at each execution (O(N^2) on the tx size)

