### PR TITLE
Adapting ODB export format for streaming

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -293,18 +293,6 @@
             <version>2.12.1</version>
         </dependency>-->
 
-        <!-- json parser -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.1</version>
-        </dependency>
-        <!--<dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.12.1</version>
-        </dependency>-->
-
         <!-- test -->
         <dependency>
             <groupId>com.orientechnologies</groupId>

--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
@@ -2556,7 +2556,6 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
         database.delete(leftOverRid);
       }
     }
-
     database.getMetadata().reload();
 
     final Set<ORID> brokenRids = new HashSet<>();

--- a/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/tool/ODatabaseImport.java
@@ -1486,7 +1486,7 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
       schemaImported = true;
       jsonReader.readNext(OJSONReader.END_OBJECT);
       jsonReader.readNext(OJSONReader.COMMA_SEPARATOR);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       OLogManager.instance().error(this, "Error on importing schema", e);
       listener.onMessage("ERROR (" + classImported + " entries): " + e);
     }
@@ -2175,16 +2175,29 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
     try {
 
       try {
-        record =
-            ORecordSerializerJSON.INSTANCE.fromString(
-                value,
-                record,
-                null,
-                null,
-                false,
-                maxRidbagStringSizeBeforeLazyImport,
-                skippedPartsIndexes);
-      } catch (OSerializationException e) {
+        if (exporterVersion < 13) {
+          record =
+              ORecordSerializerJSON.INSTANCE.fromString(
+                  value,
+                  record,
+                  null,
+                  null,
+                  false,
+                  maxRidbagStringSizeBeforeLazyImport,
+                  skippedPartsIndexes);
+        } else {
+          // FIXME: switch to `fromStream` + adapt e2e stream handling
+          record =
+              ORecordSerializerJSON.INSTANCE.fromString(
+                  value,
+                  record,
+                  null,
+                  null,
+                  false,
+                  maxRidbagStringSizeBeforeLazyImport,
+                  skippedPartsIndexes);
+        }
+      } catch (final OSerializationException e) {
         if (e.getCause() instanceof OSchemaException) {
           // EXTRACT CLASS NAME If ANY
           final int pos = value.indexOf("\"@class\":\"");
@@ -2512,7 +2525,9 @@ public class ODatabaseImport extends ODatabaseImpExpAbstract {
     long last = begin;
     Set<String> involvedClusters = new HashSet<>();
 
+    OLogManager.instance().debug(this, "Detected exporter version " + exporterVersion + ".");
     while (jsonReader.lastChar() != ']') {
+      // TODO: add special handling for `exporterVersion` / `ODatabaseExport.EXPORTER_VERSION` >= 13
       rid = importRecord(recordsBeforeImport);
 
       total++;

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchContext.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchContext.java
@@ -24,59 +24,56 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 /** @author Luca Molino (molino.luca--at--gmail.com) */
 public interface OFetchContext {
 
-  public void onBeforeFetch(final ODocument iRootRecord) throws OFetchException;
+  void onBeforeFetch(final ODocument iRootRecord) throws OFetchException;
 
-  public void onAfterFetch(final ODocument iRootRecord) throws OFetchException;
+  void onAfterFetch(final ODocument iRootRecord) throws OFetchException;
 
-  public void onBeforeArray(
+  void onBeforeArray(
       final ODocument iRootRecord,
       final String iFieldName,
       final Object iUserObject,
       final OIdentifiable[] iArray)
       throws OFetchException;
 
-  public void onAfterArray(
-      final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
+  void onAfterArray(final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
       throws OFetchException;
 
-  public void onBeforeCollection(
+  void onBeforeCollection(
       final ODocument iRootRecord,
       final String iFieldName,
       final Object iUserObject,
       final Iterable<?> iterable)
       throws OFetchException;
 
-  public void onAfterCollection(
+  void onAfterCollection(
       final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
       throws OFetchException;
 
-  public void onBeforeMap(
-      final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
+  void onBeforeMap(final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
       throws OFetchException;
 
-  public void onAfterMap(
-      final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
+  void onAfterMap(final ODocument iRootRecord, final String iFieldName, final Object iUserObject)
       throws OFetchException;
 
-  public void onBeforeDocument(
+  void onBeforeDocument(
       final ODocument iRecord,
       final ODocument iDocument,
       final String iFieldName,
       final Object iUserObject)
       throws OFetchException;
 
-  public void onAfterDocument(
+  void onAfterDocument(
       final ODocument iRootRecord,
       final ODocument iDocument,
       final String iFieldName,
       final Object iUserObject)
       throws OFetchException;
 
-  public void onBeforeStandardField(
+  void onBeforeStandardField(
       final Object iFieldValue, final String iFieldName, final Object iUserObject, OType fieldType);
 
-  public void onAfterStandardField(
+  void onAfterStandardField(
       final Object iFieldValue, final String iFieldName, final Object iUserObject, OType fieldType);
 
-  public boolean fetchEmbeddedDocuments();
+  boolean fetchEmbeddedDocuments();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
@@ -711,7 +711,6 @@ public class OFetchHelper {
           iListener,
           iContext,
           settings);
-
     } else if (fieldValue instanceof Map<?, ?>) {
       fetchMap(
           iRootRecord,

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
@@ -144,8 +144,7 @@ public class OFetchHelper {
       final int iFieldDepthLevel,
       final Map<ORID, Integer> parsedRecords,
       final String iFieldPathFromRoot,
-      final OFetchContext iContext)
-      throws IOException {
+      final OFetchContext iContext) {
     if (iFetchPlan == null) return;
 
     if (iFetchPlan == OFetchHelper.DEFAULT_FETCHPLAN) return;
@@ -766,7 +765,6 @@ public class OFetchHelper {
       final OFetchContext iContext,
       final ORecordSerializerJSON.FormatSettings settings)
       throws IOException {
-    // FIXME: fieldTypes handling required?
     final Map<String, ODocument> linked = (Map<String, ODocument>) fieldValue;
     iContext.onBeforeMap(iRootRecord, fieldName, iUserObject);
 
@@ -864,7 +862,6 @@ public class OFetchHelper {
       final OFetchListener iListener,
       final OFetchContext context,
       ORecordSerializerJSON.FormatSettings settings) {
-    // FIXME: fieldTypes handling required?
     if (fieldValue instanceof ODocument[]) {
       final ODocument[] linked = (ODocument[]) fieldValue;
       context.onBeforeArray(rootRecord, fieldName, iUserObject, linked);
@@ -1044,7 +1041,6 @@ public class OFetchHelper {
       final OFetchListener iListener,
       final OFetchContext iContext,
       final ORecordSerializerJSON.FormatSettings settings) {
-    // FIXME: fieldTypes handling required?
     if (fieldValue instanceof ORID && !((ORID) fieldValue).isValid()) {
       // RID NULL: TREAT AS "NULL" VALUE
       iContext.onBeforeStandardField(fieldValue, fieldName, iRootRecord, null);

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/OFetchHelper.java
@@ -65,40 +65,30 @@ public class OFetchHelper {
   }
 
   public static void fetch(
-      final ORecord iRootRecord,
-      final Object iUserObject,
-      final OFetchPlan iFetchPlan,
-      final OFetchListener iListener,
-      final OFetchContext iContext,
+      final ORecord rootRecord,
+      final Object userObject,
+      final OFetchPlan fetchPlan,
+      final OFetchListener listener,
+      final OFetchContext context,
       final String format) {
     try {
-      if (iRootRecord instanceof ODocument) {
+      if (rootRecord instanceof ODocument) {
         // SCHEMA AWARE
-        final ODocument record = (ODocument) iRootRecord;
+        final ODocument record = (ODocument) rootRecord;
         final Map<ORID, Integer> parsedRecords = new HashMap<>();
 
         final boolean isEmbedded = record.isEmbedded() || !record.getIdentity().isPersistent();
-        if (!isEmbedded) parsedRecords.put(iRootRecord.getIdentity(), 0);
+        if (!isEmbedded) parsedRecords.put(rootRecord.getIdentity(), 0);
 
         if (!format.contains("shallow")) {
-          processRecordRidMap(record, iFetchPlan, 0, 0, -1, parsedRecords, "", iContext);
+          processRecordRidMap(record, fetchPlan, 0, 0, -1, parsedRecords, "", context);
         }
         processRecord(
-            record,
-            iUserObject,
-            iFetchPlan,
-            0,
-            0,
-            -1,
-            parsedRecords,
-            "",
-            iListener,
-            iContext,
-            format);
+            record, userObject, fetchPlan, 0, 0, -1, parsedRecords, "", listener, context, format);
       }
-    } catch (Exception e) {
+    } catch (final Exception e) {
       OLogManager.instance()
-          .error(null, "Fetching error on record %s", e, iRootRecord.getIdentity());
+          .error(null, "Fetching error on record %s", e, rootRecord.getIdentity());
     }
   }
 
@@ -438,8 +428,7 @@ public class OFetchHelper {
       final String fieldPathFromRoot,
       final OFetchListener fetchListener,
       final OFetchContext fetchContext,
-      final String format)
-      throws IOException {
+      final String format) {
     if (record == null) {
       return;
     }
@@ -467,6 +456,7 @@ public class OFetchHelper {
       fetchContext.onAfterFetch(record);
     }
 
+    fetchContext.onBeforeFetch(record);
     final Set<String> toRemove = new HashSet<>();
     for (final String fieldName : record.getPropertyNames()) {
       process(
@@ -546,19 +536,19 @@ public class OFetchHelper {
   }
 
   private static void process(
-      ODocument record,
-      Object userObject,
-      OFetchPlan fetchPlan,
-      int currentLevel,
-      int levelFromRoot,
-      int fieldDepthLevel,
-      Map<ORID, Integer> parsedRecords,
-      String fieldPathFromRoot,
-      OFetchListener fetchListener,
-      OFetchContext fetchContext,
-      String format,
-      Set<String> toRemove,
-      String fieldName) {
+      final ODocument record,
+      final Object userObject,
+      final OFetchPlan fetchPlan,
+      final int currentLevel,
+      final int levelFromRoot,
+      final int fieldDepthLevel,
+      final Map<ORID, Integer> parsedRecords,
+      final String fieldPathFromRoot,
+      final OFetchListener fetchListener,
+      final OFetchContext fetchContext,
+      final String format,
+      final Set<String> toRemove,
+      final String fieldName) {
     final ORecordSerializerJSON.FormatSettings settings =
         new ORecordSerializerJSON.FormatSettings(format);
 
@@ -685,7 +675,7 @@ public class OFetchHelper {
       final String iFieldPathFromRoot,
       final OFetchListener iListener,
       final OFetchContext iContext,
-      ORecordSerializerJSON.FormatSettings settings)
+      final ORecordSerializerJSON.FormatSettings settings)
       throws IOException {
     int currentLevel = iCurrentLevel + 1;
     int fieldDepthLevel = iFieldDepthLevel;
@@ -928,7 +918,7 @@ public class OFetchHelper {
     final Iterable<?> linked;
     if (fieldValue instanceof Iterable<?> || fieldValue instanceof ORidBag) {
       linked = (Iterable<OIdentifiable>) fieldValue;
-      context.onBeforeCollection(iRootRecord, fieldName, iUserObject, (Iterable) linked);
+      context.onBeforeCollection(iRootRecord, fieldName, iUserObject, linked);
     } else if (fieldValue.getClass().isArray()) {
       linked = OMultiValue.getMultiValueIterable(fieldValue, false);
       context.onBeforeCollection(iRootRecord, fieldName, iUserObject, linked);

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/json/OJSONFetchContext.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/json/OJSONFetchContext.java
@@ -101,7 +101,7 @@ public class OJSONFetchContext implements OFetchContext {
       manageTypes(iFieldName, iterable, null);
       jsonWriter.beginCollection(++settings.indentLevel, true, iFieldName);
       collectionStack.add(iRootRecord);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw OException.wrapException(
           new OFetchException(
               "Error writing collection field "

--- a/core/src/main/java/com/orientechnologies/orient/core/fetch/json/OJSONFetchContext.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/fetch/json/OJSONFetchContext.java
@@ -93,21 +93,24 @@ public class OJSONFetchContext implements OFetchContext {
   }
 
   public void onBeforeCollection(
-      final ODocument iRootRecord,
-      final String iFieldName,
-      final Object iUserObject,
+      final ODocument rootRecord,
+      final String fieldName,
+      final Object userObject,
       final Iterable<?> iterable) {
     try {
-      manageTypes(iFieldName, iterable, null);
-      jsonWriter.beginCollection(++settings.indentLevel, true, iFieldName);
-      collectionStack.add(iRootRecord);
+      manageTypes(fieldName, iterable, null);
+      if (settings.earlyTypes) {
+        onAfterFetch(rootRecord);
+      }
+      jsonWriter.beginCollection(++settings.indentLevel, true, fieldName);
+      collectionStack.add(rootRecord);
     } catch (final IOException e) {
       throw OException.wrapException(
           new OFetchException(
               "Error writing collection field "
-                  + iFieldName
+                  + fieldName
                   + " of record "
-                  + iRootRecord.getIdentity()),
+                  + rootRecord.getIdentity()),
           e);
     }
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
@@ -45,10 +45,10 @@ import java.util.WeakHashMap;
 
 @SuppressWarnings({"unchecked", "serial"})
 public abstract class ORecordAbstract implements ORecord {
-  public static final String DEFAULT_FORMAT =
-      "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded,earlyTypes,fetchPlan:*:0";
-  public static final String OLD_FORMAT_WITH_LATE_TYPES =
-      "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded,fetchPlan:*:0";
+  public static final String BASE_FORMAT =
+      "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded";
+  public static final String DEFAULT_FORMAT = BASE_FORMAT + "," + "earlyTypes,fetchPlan:*:0";
+  public static final String OLD_FORMAT_WITH_LATE_TYPES = BASE_FORMAT + "," + "fetchPlan:*:0";
   // TODO: take new format
   // public static final String DEFAULT_FORMAT = OLD_FORMAT_WITH_LATE_TYPES;
   protected ORecordId recordId;

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
@@ -45,13 +45,12 @@ import java.util.WeakHashMap;
 
 @SuppressWarnings({"unchecked", "serial"})
 public abstract class ORecordAbstract implements ORecord {
-  // public static final String DEFAULT_FORMAT =
-  //
-  // "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded,earlyTypes,fetchPlan:*:0";
+  public static final String DEFAULT_FORMAT =
+      "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded,earlyTypes,fetchPlan:*:0";
   public static final String OLD_FORMAT_WITH_LATE_TYPES =
       "rid,version,class,type,attribSameRow,keepTypes,alwaysFetchEmbedded,fetchPlan:*:0";
   // TODO: take new format
-  public static final String DEFAULT_FORMAT = OLD_FORMAT_WITH_LATE_TYPES;
+  // public static final String DEFAULT_FORMAT = OLD_FORMAT_WITH_LATE_TYPES;
   protected ORecordId recordId;
   protected int recordVersion = 0;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
@@ -46,7 +46,8 @@ import java.util.Map.Entry;
 @SuppressWarnings("unchecked")
 public class OJSONWriter {
   private static final String DEF_FORMAT =
-      "rid,type,version,class,attribSameRow,indent:2,dateAsLong";
+      "rid,type,version,class,attribSameRow,earlyTypes,indent:2,dateAsLong"; // TODO: added
+                                                                             // earlyTypes
   private final String format;
   private Writer out;
   private boolean prettyPrint = false;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
@@ -520,7 +520,6 @@ public class OJSONWriter {
         }
       }
     }
-
     return this;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONWriter.java
@@ -47,7 +47,7 @@ import java.util.Map.Entry;
 public class OJSONWriter {
   private static final String DEF_FORMAT =
       "rid,type,version,class,attribSameRow,earlyTypes,indent:2,dateAsLong"; // TODO: added
-                                                                             // earlyTypes
+  // earlyTypes
   private final String format;
   private Writer out;
   private boolean prettyPrint = false;

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/record/string/ORecordSerializerJSON.java
@@ -745,7 +745,7 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
 
   @Override
   public StringBuilder toString(
-      final ORecord iRecord,
+      final ORecord record,
       final StringBuilder output,
       final String format,
       boolean autoDetectCollectionType) {
@@ -757,28 +757,28 @@ public class ORecordSerializerJSON extends ORecordSerializerStringAbstract {
       json.beginObject();
 
       final OJSONFetchContext context = new OJSONFetchContext(json, settings);
-      context.writeSignature(json, iRecord);
+      context.writeSignature(json, record);
 
-      if (iRecord instanceof ODocument) {
+      if (record instanceof ODocument) {
         final OFetchPlan fp = OFetchHelper.buildFetchPlan(settings.fetchPlan);
 
-        OFetchHelper.fetch(iRecord, null, fp, new OJSONFetchListener(), context, format);
-      } else if (iRecord instanceof ORecordStringable) {
+        OFetchHelper.fetch(record, null, fp, new OJSONFetchListener(), context, format);
+      } else if (record instanceof ORecordStringable) {
         // STRINGABLE
-        final ORecordStringable record = (ORecordStringable) iRecord;
-        json.writeAttribute(settings.indentLevel, true, "value", record.value());
-      } else if (iRecord instanceof OBlob) {
+        final ORecordStringable recordStringable = (ORecordStringable) record;
+        json.writeAttribute(settings.indentLevel, true, "value", recordStringable.value());
+      } else if (record instanceof OBlob) {
         // BYTES
-        final OBlob record = (OBlob) iRecord;
+        final OBlob recordBlob = (OBlob) record;
         json.writeAttribute(
             settings.indentLevel,
             true,
             "value",
-            Base64.getEncoder().encodeToString(record.toStream()));
+            Base64.getEncoder().encodeToString(recordBlob.toStream()));
       } else {
         throw new OSerializationException(
             "Error on marshalling record of type '"
-                + iRecord.getClass()
+                + record.getClass()
                 + "' to JSON. The record type cannot be exported to JSON");
       }
       json.endObject(settings.indentLevel, true);

--- a/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/DirtyTrackingTreeRidBagRemoteTest.java
+++ b/graphdb/src/test/java/com/tinkerpop/blueprints/impls/orient/DirtyTrackingTreeRidBagRemoteTest.java
@@ -25,7 +25,6 @@ import org.junit.*;
 
 /** Created by tglman on 04/05/16. */
 public class DirtyTrackingTreeRidBagRemoteTest {
-
   private OServer server;
   private String serverHome;
   private String oldOrientDBHome;
@@ -37,7 +36,6 @@ public class DirtyTrackingTreeRidBagRemoteTest {
           NoSuchMethodException, InstantiationException, IOException, IllegalAccessException {
     final String buildDirectory = System.getProperty("buildDirectory", ".");
     serverHome = buildDirectory + "/" + DirtyTrackingTreeRidBagRemoteTest.class.getSimpleName();
-
     deleteDirectory(new File(serverHome));
 
     final File file = new File(serverHome);
@@ -74,7 +72,7 @@ public class DirtyTrackingTreeRidBagRemoteTest {
         OGlobalConfiguration.RID_BAG_EMBEDDED_TO_SBTREEBONSAI_THRESHOLD.getDefValue());
     final int max =
         OGlobalConfiguration.RID_BAG_EMBEDDED_TO_SBTREEBONSAI_THRESHOLD.getValueAsInteger() * 2;
-    OrientGraph graph =
+    final OrientGraph graph =
         new OrientGraph(
             "remote:localhost:3064/" + DirtyTrackingTreeRidBagRemoteTest.class.getSimpleName(),
             "root",
@@ -84,9 +82,9 @@ public class DirtyTrackingTreeRidBagRemoteTest {
       graph.getRawGraph().declareIntent(new OIntentMassiveInsert());
       graph.createEdgeType("Edge");
       OIdentifiable oneVertex = null;
-      Map<Object, Vertex> vertices = new HashMap<Object, Vertex>();
+      final Map<Object, Vertex> vertices = new HashMap<Object, Vertex>();
       for (int i = 0; i < max; i++) {
-        Vertex v = graph.addVertex("class:V");
+        final Vertex v = graph.addVertex("class:V");
         v.setProperty("key", "foo" + i);
         graph.commit();
         vertices.put(v.getProperty("key"), v);
@@ -95,16 +93,16 @@ public class DirtyTrackingTreeRidBagRemoteTest {
       graph.commit();
       // Add the edges
       for (int i = 0; i < max; i++) {
-        String codeUCD1 = "foo" + i;
+        final String codeUCD1 = "foo" + i;
         // Take the first vertex
-        Vertex med1 = (Vertex) vertices.get(codeUCD1);
+        final Vertex med1 = vertices.get(codeUCD1);
         // For the 2nd term
         for (int j = 0; j < max; j++) {
-          String key = "foo" + j;
+          final String key = "foo" + j;
           // Take the second vertex
-          Vertex med2 = (Vertex) vertices.get(key);
+          final Vertex med2 = vertices.get(key);
           // ((OrientVertex)med2).getRecord().reload();
-          OrientEdge eInteraction = graph.addEdge(null, med1, med2, "Edge");
+          graph.addEdge(null, med1, med2, "Edge");
           assertNotNull(
               graph
                   .getRawGraph()
@@ -116,21 +114,20 @@ public class DirtyTrackingTreeRidBagRemoteTest {
       }
       graph.getRawGraph().getLocalCache().clear();
 
-      OrientVertex vertex = graph.getVertex(oneVertex);
+      final OrientVertex vertex = graph.getVertex(oneVertex);
       assertEquals(new GremlinPipeline<Vertex, Long>().start(vertex).in("Edge").count(), max);
     } finally {
       graph.shutdown();
     }
   }
 
-  private static void deleteDirectory(File f) throws IOException {
+  private static void deleteDirectory(final File f) throws IOException {
     if (f.isDirectory()) {
       final File[] files = f.listFiles();
       if (files != null) {
-        for (File c : files) deleteDirectory(c);
+        for (final File c : files) deleteDirectory(c);
       }
     }
-
     if (f.exists() && !f.delete()) throw new FileNotFoundException("Failed to delete file: " + f);
   }
 }

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/BaseHttpTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/BaseHttpTest.java
@@ -61,12 +61,12 @@ public abstract class BaseHttpTest {
     JSON
   }
 
-  public BaseHttpTest payload(final String s, final CONTENT iContent) {
+  public BaseHttpTest payload(final String content, final CONTENT contentType) {
     payload =
         new StringEntity(
-            s,
+            content,
             ContentType.create(
-                iContent == CONTENT.JSON ? "application/json" : "plain/text", Consts.UTF_8));
+                contentType == CONTENT.JSON ? "application/json" : "plain/text", Consts.UTF_8));
     return this;
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGraphTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGraphTest.java
@@ -51,9 +51,9 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
             .getResponse();
 
     // TODO: check error later
-    /*Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
 
-    InputStream content = response.getEntity().getContent();
+    /*InputStream content = response.getEntity().getContent();
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     OIOUtils.copyStream(content, out, -1);
 
@@ -87,7 +87,7 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
     Assert.assertEquals(coll.size(), 1);
   }
 
-  // TODO: failing due to stream parser refactoring
+  // TODO: could be failing due to stream parser refactoring
   @Test
   public void getGraphResult() throws IOException {
     Assert.assertEquals(

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONExportBenchmark.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONExportBenchmark.java
@@ -17,25 +17,13 @@ package com.orientechnologies.orient.test.database.auto;
 
 import com.orientechnologies.orient.core.record.ORecordAbstract;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.storage.index.nkbtree.normalizers.benchmark.Plotter;
-import org.knowm.xchart.XYChart;
-import org.knowm.xchart.style.Styler;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.results.Result;
-import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONExportBenchmark.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONExportBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.orientechnologies.orient.test.database.auto;
+
+import com.orientechnologies.orient.core.record.ORecordAbstract;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.storage.index.nkbtree.normalizers.benchmark.Plotter;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.style.Styler;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 5, batchSize = 1)
+@Warmup(iterations = 5, batchSize = 1)
+@Fork(3)
+public class JSONExportBenchmark extends DocumentDBBaseTest {
+  public static void main(String[] args) throws RunnerException {
+    final Options opt =
+        new OptionsBuilder()
+            .include("JSONExportBenchmark.*")
+            .jvmArgs("-server", "-XX:+UseConcMarkSweepGC", "-Xmx4G", "-Xms1G")
+            .build();
+    new Runner(opt).run();
+    return;
+  }
+
+  ODocument doc = null;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    doc = new ODocument();
+    doc.field("nan", Double.NaN);
+    doc.field("p_infinity", Double.POSITIVE_INFINITY);
+    doc.field("n_infinity", Double.NEGATIVE_INFINITY);
+    doc.field("long", 100000000000l);
+    doc.field("date", new Date());
+    doc.field("byte", (byte) 12);
+  }
+
+  @Benchmark
+  public void testExportFormatOld() {
+    doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+  }
+
+  @Benchmark
+  public void testExportFormatNew() {
+    doc.toJSON();
+  }
+}

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONStreamTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONStreamTest.java
@@ -21,7 +21,6 @@ import com.orientechnologies.orient.core.db.record.OTrackedList;
 import com.orientechnologies.orient.core.exception.OSerializationException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.metadata.schema.OType;
-import com.orientechnologies.orient.core.record.ORecordAbstract;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.serialization.serializer.OJSONWriter;
 import com.orientechnologies.orient.core.serialization.serializer.record.string.ORecordSerializerJSON;
@@ -149,8 +148,7 @@ public class JSONStreamTest extends DocumentDBBaseTest {
     list.add(new ODocument().field("name", "Luca"));
     list.add(new ODocument().field("name", "Marcus"));
 
-    // FIXME: export with DEFAULT_FORMAT does not work for collections yet
-    final String json = doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    final String json = doc.toJSON();
     final ODocument loadedDoc =
         new ODocument().fromJSON(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
     Assert.assertTrue(doc.hasSameContentOf(loadedDoc));
@@ -1222,8 +1220,7 @@ public class JSONStreamTest extends DocumentDBBaseTest {
             "{\"name\":\"Luca\", \"ref\":\"#-1:-1\"}".getBytes(StandardCharsets.UTF_8)));
     // Assert.assertNull(nullRefDoc.rawField("ref"));
 
-    // FIXME: export with DEFAULT_FORMAT does not work for collections yet
-    final String json = nullRefDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    final String json = nullRefDoc.toJSON();
     int pos = json.indexOf("\"ref\":");
 
     Assert.assertTrue(pos > -1);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -178,13 +178,11 @@ public class JSONTest extends DocumentDBBaseTest {
     Assert.assertEquals(json, input);
   }
 
-  // TODO: adapt to new input format
   @Test
   public void testNanEarlyTypes() {
     ODocument doc = new ODocument();
     String input =
-        "{\"@type\":\"d\",\"@version\":0,\"nan\":null,\"p_infinity\":null,\"n_infinity\":null,\"@fieldTypes\":\"nan=d,p_infinity=d,n_infinity=d\"}";
-    // "{\"@type\":\"d\",\"@version\":0,\"@fieldTypes\":\"nan=d,p_infinity=d,n_infinity=d\",\"nan\":null,\"p_infinity\":null,\"n_infinity\":null}";
+        "{\"@type\":\"d\",\"@version\":0,\"@fieldTypes\":\"nan=d,p_infinity=d,n_infinity=d\",\"nan\":null,\"p_infinity\":null,\"n_infinity\":null}";
     doc.field("nan", Double.NaN);
     doc.field("p_infinity", Double.POSITIVE_INFINITY);
     doc.field("n_infinity", Double.NEGATIVE_INFINITY);
@@ -193,8 +191,7 @@ public class JSONTest extends DocumentDBBaseTest {
 
     doc = new ODocument();
     input =
-        "{\"@type\":\"d\",\"@version\":0,\"nan\":null,\"p_infinity\":null,\"n_infinity\":null,\"@fieldTypes\":\"nan=f,p_infinity=f,n_infinity=f\"}";
-    // "{\"@type\":\"d\",\"@version\":0,\"@fieldTypes\":\"nan=f,p_infinity=f,n_infinity=f\",\"nan\":null,\"p_infinity\":null,\"n_infinity\":null}";
+        "{\"@type\":\"d\",\"@version\":0,\"@fieldTypes\":\"nan=f,p_infinity=f,n_infinity=f\",\"nan\":null,\"p_infinity\":null,\"n_infinity\":null}";
     doc.field("nan", Float.NaN);
     doc.field("p_infinity", Float.POSITIVE_INFINITY);
     doc.field("n_infinity", Float.NEGATIVE_INFINITY);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -1167,10 +1167,8 @@ public class JSONTest extends DocumentDBBaseTest {
           new OSQLSynchQuery<ODocument>("traverse * from " + o.getIdentity().toString())) {
         Assert.assertTrue(traverse.remove(id.getIdentity()));
       }
-
       Assert.assertTrue(traverse.isEmpty());
     }
-
     Assert.assertTrue(traverseMap.isEmpty());
   }
 

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -138,7 +138,7 @@ public class JSONTest extends DocumentDBBaseTest {
   }
 
   @Test
-  public void testNan() {
+  public void testNanOldFormat() {
     ODocument doc = new ODocument();
     String input =
         "{\"@type\":\"d\",\"@version\":0,\"nan\":null,\"p_infinity\":null,\"n_infinity\":null,\"@fieldTypes\":\"nan=d,p_infinity=d,n_infinity=d\"}";
@@ -207,7 +207,7 @@ public class JSONTest extends DocumentDBBaseTest {
     list.add(new ODocument().field("name", "Luca"));
     list.add(new ODocument().field("name", "Marcus"));
 
-    final String json = doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    final String json = doc.toJSON();
     final ODocument loadedDoc = new ODocument().fromJSON(json);
     Assert.assertTrue(doc.hasSameContentOf(loadedDoc));
     Assert.assertTrue(loadedDoc.containsField("embeddedList"));
@@ -313,7 +313,7 @@ public class JSONTest extends DocumentDBBaseTest {
       firstLevelDoc.field("doc", secondLevelDoc);
       secondLevelDoc.field("doc", thirdLevelDoc);
 
-      final String json = newDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+      final String json = newDoc.toJSON();
       ODocument loadedDoc = new ODocument().fromJSON(json);
 
       Assert.assertTrue(newDoc.hasSameContentOf(loadedDoc));
@@ -621,9 +621,9 @@ public class JSONTest extends DocumentDBBaseTest {
       list.add(doc1);
     }
     doc.field("out", list);
-    String json = doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    String json = doc.toJSON();
     ODocument newDoc = new ODocument().fromJSON(json);
-    Assert.assertEquals(json, newDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES));
+    Assert.assertEquals(json, newDoc.toJSON());
     Assert.assertTrue(newDoc.hasSameContentOf(doc));
 
     doc = new ODocument();
@@ -646,9 +646,9 @@ public class JSONTest extends DocumentDBBaseTest {
       docMap.put(String.valueOf(i), doc1);
     }
     doc.field("out", docMap);
-    json = doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    json = doc.toJSON();
     newDoc = new ODocument().fromJSON(json);
-    Assert.assertEquals(newDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES), json);
+    Assert.assertEquals(newDoc.toJSON(), json);
     Assert.assertTrue(newDoc.hasSameContentOf(doc));
   }
 
@@ -669,9 +669,9 @@ public class JSONTest extends DocumentDBBaseTest {
       list.add(doc1);
     }
     doc.field("theList", list);
-    String json = doc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    String json = doc.toJSON();
     ODocument newDoc = new ODocument().fromJSON(json);
-    Assert.assertEquals(newDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES), json);
+    Assert.assertEquals(newDoc.toJSON(), json);
     Assert.assertTrue(newDoc.hasSameContentOf(doc));
   }
 
@@ -1365,7 +1365,7 @@ public class JSONTest extends DocumentDBBaseTest {
     nullRefDoc.fromJSON("{\"name\":\"Luca\", \"ref\":\"#-1:-1\"}");
     // Assert.assertNull(nullRefDoc.rawField("ref"));
 
-    String json = nullRefDoc.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
+    String json = nullRefDoc.toJSON();
     int pos = json.indexOf("\"ref\":");
 
     Assert.assertTrue(pos > -1);

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -712,8 +712,7 @@ public class JSONTest extends DocumentDBBaseTest {
 
     result =
         database.query(
-            new OSQLSynchQuery<>(
-                "select from device where domainset[domain = 'abc'] is not null"));
+            new OSQLSynchQuery<>("select from device where domainset[domain = 'abc'] is not null"));
     Assert.assertTrue(result.size() > 0);
 
     result =

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/JSONTest.java
@@ -707,18 +707,18 @@ public class JSONTest extends DocumentDBBaseTest {
 
     List<ODocument> result =
         database.query(
-            new OSQLSynchQuery<Object>("select from device where domainset.domain contains 'abc'"));
+            new OSQLSynchQuery<>("select from device where domainset.domain contains 'abc'"));
     Assert.assertTrue(result.size() > 0);
 
     result =
         database.query(
-            new OSQLSynchQuery<Object>(
+            new OSQLSynchQuery<>(
                 "select from device where domainset[domain = 'abc'] is not null"));
     Assert.assertTrue(result.size() > 0);
 
     result =
         database.query(
-            new OSQLSynchQuery<Object>("select from device where domainset.domain contains 'pqr'"));
+            new OSQLSynchQuery<>("select from device where domainset.domain contains 'pqr'"));
     Assert.assertTrue(result.size() > 0);
   }
 
@@ -750,7 +750,7 @@ public class JSONTest extends DocumentDBBaseTest {
 
     List<ODocument> result =
         database.query(
-            new OSQLSynchQuery<Object>(
+            new OSQLSynchQuery<>(
                 "select from device where domainset.domain.lvlone.value = 'five'"));
     Assert.assertTrue(result.size() > 0);
   }

--- a/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ORidBagTest.java
+++ b/tests/src/test/java/com/orientechnologies/orient/test/database/auto/ORidBagTest.java
@@ -1629,6 +1629,7 @@ public abstract class ORidBagTest extends DocumentDBBaseTest {
     testDocument.save(database.getClusterNameById(database.getDefaultClusterId()));
     testDocument.reload();
 
+    // FIXME: switch to DEFAULT format
     final String json = testDocument.toJSON(ORecordAbstract.OLD_FORMAT_WITH_LATE_TYPES);
 
     final ODocument doc = new ODocument();


### PR DESCRIPTION
Adapting ODB export format for streaming, i.e. moving `@FieldTypes` after the signature and in front of the data. A stream parser will then be able to read the type definition, before it gets to parse the data itself.

- [x] Re-using the ODB's `format` settings to introduce `earlyTypes`, which will place `@fieldTypes` in front of its scope, instead of putting it behind it. This is necessary for stream parsing, which requires to have the type information to apply it during the first pass through the scope.
- [x] Adding new format and fixing existing tests
- [x] Adapt `ODatabaseExport` by introducing a new schema version (`12` -> `13`)
- [x] Check impact of new export mechanism (expected that `new` slightly slower than `old`). Simple benchmark with different types (could be further extended):
```
Benchmark                                Mode  Cnt   Score    Error  Units
JSONExportBenchmark.testExportFormatNew  avgt   15  52,459 ±  9,281  us/op
JSONExportBenchmark.testExportFormatOld  avgt   15  50,185 ± 13,272  us/op
```
- [x] Checked tests regarding different `fetch` types

**Disclaimer**
Does not contain performance improvements or stream-based export.