### PR TITLE
Database thread local is cleared on remote tests.

### DIFF
--- a/server/src/test/java/com/orientechnologies/orient/core/db/OrientDBRemoteTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/core/db/OrientDBRemoteTest.java
@@ -36,6 +36,8 @@ public class OrientDBRemoteTest {
 
   @Before
   public void before() throws Exception {
+    ODatabaseRecordThreadLocal.instance().remove();
+
     OGlobalConfiguration.SERVER_BACKWARD_COMPATIBILITY.setValue(false);
     server = new OServer(false);
     server.setServerRootDirectory(SERVER_DIRECTORY);
@@ -256,5 +258,7 @@ public class OrientDBRemoteTest {
     Orient.instance().shutdown();
     OFileUtils.deleteRecursively(new File(SERVER_DIRECTORY));
     Orient.instance().startup();
+
+    ODatabaseRecordThreadLocal.instance().remove();
   }
 }


### PR DESCRIPTION
What does this PR do?
Because of a dangling thread-local instance of the database remote tests fails with invalid session error.
This fix clears the thread-local instances before and after the execution of each test.

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
