### PR TITLE
JVM crash during close of WAL has been fixed.

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
@@ -918,12 +918,7 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
             return null;
           }
 
-          final long freezeId = atomicOperationsManager.freezeComponentOperations();
-          try {
-            wal.appendSegment(segment + 1);
-          } finally {
-            atomicOperationsManager.releaseComponentOperations(freezeId);
-          }
+          wal.appendSegment(segment + 1);
 
           atomicOperationsTable.compactTable();
         } finally {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -6145,33 +6145,13 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
     writeCache.restoreModeOn();
     try {
-      final int nextOperationId;
-
-      if (OGlobalConfiguration.STORAGE_CHECK_LATEST_OPERATION_ID.getValueAsBoolean()) {
-        OLogManager.instance()
-            .infoNoDb(
-                this,
-                "Storage %s , scan all pages to "
-                    + "find the latest operation stored into the files,"
-                    + " if you wish to skip this step to speed up data restore but"
-                    + " decrease durability guarantees please set flag %s to the false",
-                name,
-                OGlobalConfiguration.STORAGE_CHECK_LATEST_OPERATION_ID.getKey());
-
-        nextOperationId = fetchNextOperationId();
-        assert nextOperationId >= 0;
-      } else {
-        nextOperationId = Integer.MIN_VALUE;
-      }
-
-      return restoreFrom(writeAheadLog, lsn, nextOperationId);
+      return restoreFrom(writeAheadLog, lsn);
     } finally {
       writeCache.restoreModeOff();
     }
   }
 
-  protected OLogSequenceNumber restoreFrom(
-      OWriteAheadLog writeAheadLog, OLogSequenceNumber lsn, int nextOperationId)
+  protected OLogSequenceNumber restoreFrom(OWriteAheadLog writeAheadLog, OLogSequenceNumber lsn)
       throws IOException {
     OLogSequenceNumber logSequenceNumber = null;
     final OModifiableBoolean atLeastOnePageUpdate = new OModifiableBoolean();
@@ -6185,33 +6165,8 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
     long lastReportTime = 0;
 
-    final String errorMessage =
-        "In storage %s WAL does not contain enough data to correctly restore database after crash. "
-            + "Required operation id %d operation id contained into the WAL %d."
-            + " Please create issue in bug tracker";
-
     try {
       List<WriteableWALRecord> records = writeAheadLog.read(lsn, 1_000);
-
-      if (nextOperationId >= 0) {
-        if (records.isEmpty()) {
-          final int lastOperationId = writeAheadLog.lastOperationId();
-          if (nextOperationId - 1 != lastOperationId) {
-            OLogManager.instance()
-                .errorNoDb(this, errorMessage, null, name, nextOperationId - 1, lastOperationId);
-          }
-
-          return null;
-        } else {
-          final WriteableWALRecord writeableWALRecord = records.get(0);
-          final int firstOperationId = writeableWALRecord.getOperationIdLSN().operationId;
-
-          if (firstOperationId > nextOperationId) {
-            OLogManager.instance()
-                .errorNoDb(this, errorMessage, null, name, nextOperationId, firstOperationId);
-          }
-        }
-      }
 
       while (!records.isEmpty()) {
         for (final WriteableWALRecord walRecord : records) {
@@ -6381,7 +6336,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
           final ODurablePage durablePage = new ODurablePage(cacheEntry);
           if (durablePage.getLSN().compareTo(walRecord.getLsn()) < 0) {
             durablePage.restoreChanges(updatePageRecord.getChanges());
-            durablePage.setOperationIdLSN(updatePageRecord.getOperationIdLSN());
+            durablePage.setLSN(updatePageRecord.getLsn());
           }
         } finally {
           readCache.releaseFromWrite(cacheEntry, writeCache, true);
@@ -6408,60 +6363,6 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
         assert false : "Invalid WAL record type was passed " + walRecord.getClass().getName();
       }
     }
-  }
-
-  private int fetchNextOperationId() throws IOException {
-    int lastOperationId = 0;
-
-    final Map<String, Long> files = writeCache.files();
-    int scannedFiles = 0;
-    for (final Map.Entry<String, Long> fileEntry : files.entrySet()) {
-      OLogManager.instance()
-          .infoNoDb(
-              this,
-              "Scanning of file %s in storage %s (%d out of %d files are scanned)",
-              fileEntry.getKey(),
-              name,
-              scannedFiles,
-              files.size());
-
-      final long fileId = fileEntry.getValue();
-      final long filledUpTo = writeCache.getFilledUpTo(fileId);
-
-      int prevScannedPercent = 0;
-      for (int pageIndex = 0; pageIndex < filledUpTo; pageIndex++) {
-        final OCacheEntry cacheEntry =
-            readCache.loadForRead(fileId, pageIndex, false, writeCache, true);
-        try {
-          final ODurablePage durablePage = new ODurablePage(cacheEntry);
-
-          final int operationId = durablePage.getOperationId();
-          if (operationId > lastOperationId) {
-            lastOperationId = operationId;
-          } else if (lastOperationId == operationId) {
-            throw new IllegalStateException("Id of WAL operation can not be duplicated");
-          }
-
-          final int scannedPercent = (int) ((100 * (pageIndex + 1)) / filledUpTo);
-          if (scannedPercent >= prevScannedPercent + 10) {
-            prevScannedPercent = scannedPercent;
-            OLogManager.instance()
-                .infoNoDb(
-                    this,
-                    "%d %% of file %s in storage %s  is scanned.",
-                    scannedPercent,
-                    fileEntry.getKey(),
-                    name);
-          }
-        } finally {
-          readCache.releaseFromRead(cacheEntry, writeCache);
-        }
-      }
-
-      scannedFiles++;
-    }
-
-    return lastOperationId;
   }
 
   @SuppressWarnings("unused")

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationBinaryTracking.java
@@ -478,7 +478,7 @@ final class OAtomicOperationBinaryTracking implements OAtomicOperation {
             final OUpdatePageRecord updatePageRecord =
                 new OUpdatePageRecord(pageIndex, fileId, operationUnitId, filePageChanges.changes);
             writeAheadLog.log(updatePageRecord);
-            filePageChanges.setChangeOperationIdLSN(updatePageRecord.getOperationIdLSN());
+            filePageChanges.setChangeLSN(updatePageRecord.getLsn());
           } else {
             filePageChangesIterator.remove();
           }
@@ -538,7 +538,7 @@ final class OAtomicOperationBinaryTracking implements OAtomicOperation {
               cacheEntry.setEndLSN(txEndLsn);
 
               durablePage.restoreChanges(filePageChanges.changes);
-              durablePage.setOperationIdLSN(filePageChanges.getChangeOperationIdLSN());
+              durablePage.setLSN(filePageChanges.getChangeSN());
             } finally {
               readCache.releaseFromWrite(cacheEntry, writeCache, true);
             }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationsManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationsManager.java
@@ -63,7 +63,6 @@ public class OAtomicOperationsManager {
   private final int operationsCacheLimit;
 
   private final OperationsFreezer atomicOperationsFreezer = new OperationsFreezer();
-  private final OperationsFreezer componentOperationsFreezer = new OperationsFreezer();
   private final AtomicOperationsTable atomicOperationsTable;
 
   public OAtomicOperationsManager(
@@ -243,22 +242,10 @@ public class OAtomicOperationsManager {
       final OAtomicOperation atomicOperation, final String lockName) {
     acquireExclusiveLockTillOperationComplete(atomicOperation, lockName);
     atomicOperation.incrementComponentOperations();
-
-    componentOperationsFreezer.startOperation();
   }
 
   private void endComponentOperation(final OAtomicOperation atomicOperation) {
     atomicOperation.decrementComponentOperations();
-
-    componentOperationsFreezer.endOperation();
-  }
-
-  public long freezeComponentOperations() {
-    return componentOperationsFreezer.freezeOperations(null, null);
-  }
-
-  public void releaseComponentOperations(final long freezeId) {
-    componentOperationsFreezer.releaseOperations(freezeId);
   }
 
   private boolean tryStartComponentOperation(
@@ -285,7 +272,6 @@ public class OAtomicOperationsManager {
     }
     operation.addLockedObject(lockName);
 
-    componentOperationsFreezer.startOperation();
     return true;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
@@ -6,7 +6,6 @@ import com.orientechnologies.orient.core.storage.cache.chm.LRUList;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALPageChangesPortion;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.po.PageOperationRecord;
 import java.util.List;
 
@@ -18,7 +17,7 @@ public class OCacheEntryChanges implements OCacheEntry {
 
   protected boolean isNew;
 
-  private OperationIdLSN changeOperationIdLSN;
+  private OLogSequenceNumber changeLsn;
 
   protected boolean verifyCheckSum;
 
@@ -224,11 +223,11 @@ public class OCacheEntryChanges implements OCacheEntry {
     throw new UnsupportedOperationException();
   }
 
-  OperationIdLSN getChangeOperationIdLSN() {
-    return changeOperationIdLSN;
+  OLogSequenceNumber getChangeSN() {
+    return changeLsn;
   }
 
-  void setChangeOperationIdLSN(final OperationIdLSN operationIdLSN) {
-    this.changeOperationIdLSN = operationIdLSN;
+  void setChangeLSN(final OLogSequenceNumber lsn) {
+    this.changeLsn = lsn;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractPageWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractPageWALRecord.java
@@ -22,7 +22,6 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
@@ -73,33 +72,15 @@ public abstract class OAbstractPageWALRecord extends OOperationUnitBodyRecord {
 
     OAbstractPageWALRecord that = (OAbstractPageWALRecord) o;
 
-    if (fileId != that.fileId) return false;
     if (pageIndex != that.pageIndex) return false;
-
-    if (operationIdLSN == null) {
-      if (that.operationIdLSN != null) {
-        return false;
-      }
-
-      return true;
-    }
-
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
+    return fileId == that.fileId;
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-
-    result =
-        31 * result
-            + (operationIdLSN != null && operationIdLSN.lsn != null
-                ? operationIdLSN.lsn.hashCode()
-                : 0);
-
     result = 31 * result + (int) (pageIndex ^ (pageIndex >>> 32));
     result = 31 * result + (int) (fileId ^ (fileId >>> 32));
-
     return result;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractWALRecord.java
@@ -21,7 +21,6 @@
 package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.kenai.jffi.MemoryIO;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -33,7 +32,7 @@ import java.util.Objects;
  * @since 12.12.13
  */
 public abstract class OAbstractWALRecord implements WriteableWALRecord {
-  protected volatile OperationIdLSN operationIdLSN;
+  protected volatile OLogSequenceNumber logSequenceNumber;
 
   private int distance = 0;
   private int diskSize = 0;
@@ -48,17 +47,12 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return logSequenceNumber;
   }
 
   @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
-  }
-
-  @Override
-  public void setOperationIdLsn(final OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
+  public void setLsn(final OLogSequenceNumber lsn) {
+    this.logSequenceNumber = lsn;
   }
 
   @Override
@@ -132,21 +126,18 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    final OAbstractWALRecord that = (OAbstractWALRecord) o;
-    if (operationIdLSN == null) {
-      return that.operationIdLSN == null;
-    }
+    OAbstractWALRecord that = (OAbstractWALRecord) o;
 
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
+    return Objects.equals(logSequenceNumber, that.logSequenceNumber);
   }
 
   @Override
   public int hashCode() {
-    return operationIdLSN != null && operationIdLSN.lsn != null ? operationIdLSN.lsn.hashCode() : 0;
+    return logSequenceNumber != null ? logSequenceNumber.hashCode() : 0;
   }
 
   @Override
@@ -156,7 +147,7 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
 
   protected String toString(final String iToAppend) {
     final StringBuilder buffer = new StringBuilder(getClass().getName());
-    buffer.append("{lsn_operation_id=").append(operationIdLSN);
+    buffer.append("{lsn_operation_id=").append(logSequenceNumber);
 
     if (iToAppend != null) {
       buffer.append(", ");

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OLogSequenceNumber.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OLogSequenceNumber.java
@@ -27,16 +27,16 @@ import java.io.IOException;
  */
 public class OLogSequenceNumber implements Comparable<OLogSequenceNumber> {
   private final long segment;
-  private final int position;
+  private final long position;
 
-  public OLogSequenceNumber(final long segment, final int position) {
+  public OLogSequenceNumber(final long segment, final long position) {
     this.segment = segment;
     this.position = position;
   }
 
   public OLogSequenceNumber(final DataInput in) throws IOException {
     this.segment = in.readLong();
-    this.position = in.readInt();
+    this.position = in.readLong();
   }
 
   public long getSegment() {
@@ -45,29 +45,23 @@ public class OLogSequenceNumber implements Comparable<OLogSequenceNumber> {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
 
     OLogSequenceNumber that = (OLogSequenceNumber) o;
 
-    if (segment != that.segment) {
-      return false;
-    }
+    if (segment != that.segment) return false;
     return position == that.position;
   }
 
   @Override
   public int hashCode() {
     int result = (int) (segment ^ (segment >>> 32));
-    result = 31 * result + position;
+    result = 31 * result + (int) (position ^ (position >>> 32));
     return result;
   }
 
-  public int getPosition() {
+  public long getPosition() {
     return position;
   }
 
@@ -84,7 +78,7 @@ public class OLogSequenceNumber implements Comparable<OLogSequenceNumber> {
 
   public void toStream(final DataOutput out) throws IOException {
     out.writeLong(segment);
-    out.writeInt(position);
+    out.writeLong(position);
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OMemoryWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OMemoryWriteAheadLog.java
@@ -75,22 +75,8 @@ public class OMemoryWriteAheadLog extends OAbstractWriteAheadLog {
   @Override
   public OLogSequenceNumber log(WriteableWALRecord record) {
     final OLogSequenceNumber lsn = new OLogSequenceNumber(0, nextPosition.incrementAndGet());
-    final int operationId;
-
-    if (record.trackOperationId()) {
-      operationId = nextOperationId.getAndIncrement();
-    } else {
-      operationId = nextOperationId.get();
-    }
-
-    record.setOperationIdLsn(lsn, operationId);
-
+    record.setLsn(lsn);
     return lsn;
-  }
-
-  @Override
-  public int lastOperationId() {
-    return nextOperationId.get();
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OUpdatePageRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OUpdatePageRecord.java
@@ -22,7 +22,6 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
@@ -75,39 +74,6 @@ public class OUpdatePageRecord extends OAbstractPageWALRecord {
   @Override
   public boolean trackOperationId() {
     return true;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
-    final OUpdatePageRecord that = (OUpdatePageRecord) o;
-
-    if (operationIdLSN == null && that.operationIdLSN == null) {
-      return true;
-    }
-    if (operationIdLSN == null) {
-      return false;
-    }
-
-    if (that.operationIdLSN == null) {
-      return false;
-    }
-
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result =
-        31 * result
-            + (operationIdLSN != null && operationIdLSN.lsn != null
-                ? operationIdLSN.lsn.hashCode()
-                : 0);
-    return result;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecord.java
@@ -20,8 +20,6 @@
 
 package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
-
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
  * @since 25.04.13
@@ -29,9 +27,7 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common
 public interface OWALRecord {
   OLogSequenceNumber getLsn();
 
-  OperationIdLSN getOperationIdLSN();
-
-  void setOperationIdLsn(OLogSequenceNumber lsn, int operationId);
+  void setLsn(OLogSequenceNumber lsn);
 
   void setDistance(int distance);
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecordsFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecordsFactory.java
@@ -170,15 +170,11 @@ public final class OWALRecordsFactory {
   private static final int RECORD_ID_OFFSET = 0;
   private static final int RECORD_ID_SIZE = 2;
 
-  private static final int OPERATION_ID_OFFSET = RECORD_ID_OFFSET + RECORD_ID_SIZE;
-  private static final int OPERATION_ID_SIZE = 4;
-
-  private static final int ORIGINAL_CONTENT_SIZE_OFFSET = OPERATION_ID_OFFSET + OPERATION_ID_SIZE;
+  private static final int ORIGINAL_CONTENT_SIZE_OFFSET = RECORD_ID_OFFSET + RECORD_ID_SIZE;
   private static final int ORIGINAL_CONTENT_SIZE = 4;
 
-  private static final int METADATA_SIZE = RECORD_ID_SIZE + OPERATION_ID_SIZE;
-  private static final int COMPRESSED_METADATA_SIZE =
-      RECORD_ID_SIZE + OPERATION_ID_SIZE + ORIGINAL_CONTENT_SIZE;
+  private static final int METADATA_SIZE = RECORD_ID_SIZE;
+  private static final int COMPRESSED_METADATA_SIZE = RECORD_ID_SIZE + ORIGINAL_CONTENT_SIZE;
 
   private final Map<Integer, Class<?>> idToTypeMap = new HashMap<>();
 
@@ -210,7 +206,7 @@ public final class OWALRecordsFactory {
         ByteBuffer.allocate(maxCompressedLength + COMPRESSED_METADATA_SIZE)
             .order(ByteOrder.nativeOrder());
 
-    content.position(OPERATION_ID_OFFSET + OPERATION_ID_SIZE);
+    content.position(METADATA_SIZE);
     compressedContent.position(COMPRESSED_METADATA_SIZE);
     final int compressedLength =
         compressor.compress(
@@ -232,13 +228,8 @@ public final class OWALRecordsFactory {
     }
   }
 
-  public static void serializeRecordId(final ByteBuffer buffer, final int operationId) {
-    buffer.putInt(OPERATION_ID_OFFSET, operationId);
-  }
-
   public WriteableWALRecord fromStream(byte[] content) {
     int recordId = OShortSerializer.INSTANCE.deserializeNative(content, RECORD_ID_OFFSET);
-    int operationId = OIntegerSerializer.INSTANCE.deserializeNative(content, OPERATION_ID_OFFSET);
 
     if (recordId < 0) {
       final int originalLen =
@@ -259,7 +250,7 @@ public final class OWALRecordsFactory {
     final WriteableWALRecord walRecord = walRecordById(recordId);
 
     walRecord.fromStream(content, METADATA_SIZE);
-    walRecord.setOperationIdLsn(null, operationId);
+    walRecord.setLsn(null);
 
     if (walRecord.getId() != recordId) {
       throw new IllegalStateException(
@@ -719,7 +710,6 @@ public final class OWALRecordsFactory {
       default:
         if (idToTypeMap.containsKey(recordId))
           try {
-            //noinspection unchecked
             walRecord =
                 (WriteableWALRecord)
                     idToTypeMap.get(recordId).getDeclaredConstructor().newInstance();

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWriteAheadLog.java
@@ -59,8 +59,6 @@ public interface OWriteAheadLog {
 
   OLogSequenceNumber log(WriteableWALRecord record) throws IOException;
 
-  int lastOperationId();
-
   void close() throws IOException;
 
   void close(boolean flush) throws IOException;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLog.java
@@ -67,6 +67,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -170,6 +171,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
   private long segmentId = -1;
 
   private final ScheduledFuture<?> recordsWriterFuture;
+  private final ReentrantLock recordsWriterLock = new ReentrantLock();
 
   private final ConcurrentNavigableMap<OLogSequenceNumber, EventWrapper> events =
       new ConcurrentSkipListMap<>();
@@ -1312,57 +1314,63 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
       }
     }
 
-    OWALRecord record = records.poll();
-    while (record != null) {
-      if (record instanceof WriteableWALRecord) {
-        ((WriteableWALRecord) record).freeBinaryContent();
-      }
-
-      record = records.poll();
-    }
-
+    recordsWriterLock.lock();
     try {
-      if (writeFuture != null) {
-        writeFuture.get();
+      OWALRecord record = records.poll();
+      while (record != null) {
+        if (record instanceof WriteableWALRecord) {
+          ((WriteableWALRecord) record).freeBinaryContent();
+        }
+
+        record = records.poll();
       }
 
-    } catch (final InterruptedException e) {
-      OLogManager.instance().errorNoDb(this, "WAL write was interrupted", e);
-    } catch (final ExecutionException e) {
-      OLogManager.instance().errorNoDb(this, "Error during writint of WAL data", e);
-      throw OException.wrapException(new OStorageException("Error during writint of WAL data"), e);
-    }
+      try {
+        if (writeFuture != null) {
+          writeFuture.get();
+        }
 
-    for (final OPair<Long, OWALFile> pair : fileCloseQueue) {
-      final OWALFile file = pair.value;
-
-      if (callFsync) {
-        file.force(true);
+      } catch (final InterruptedException e) {
+        OLogManager.instance().errorNoDb(this, "WAL write was interrupted", e);
+      } catch (final ExecutionException e) {
+        OLogManager.instance().errorNoDb(this, "Error during writint of WAL data", e);
+        throw OException.wrapException(
+            new OStorageException("Error during writint of WAL data"), e);
       }
 
-      file.close();
-    }
+      for (final OPair<Long, OWALFile> pair : fileCloseQueue) {
+        final OWALFile file = pair.value;
 
-    fileCloseQueueSize.set(0);
+        if (callFsync) {
+          file.force(true);
+        }
 
-    if (walFile != null) {
-      if (callFsync) {
-        walFile.force(true);
+        file.close();
       }
 
-      walFile.close();
-    }
+      fileCloseQueueSize.set(0);
 
-    segments.clear();
-    fileCloseQueue.clear();
+      if (walFile != null) {
+        if (callFsync) {
+          walFile.force(true);
+        }
 
-    allocator.deallocate(writeBufferPointerOne);
-    allocator.deallocate(writeBufferPointerTwo);
+        walFile.close();
+      }
 
-    if (writeBufferPointer != null) {
-      writeBufferPointer = null;
-      writeBuffer = null;
-      writeBufferPageIndex = -1;
+      segments.clear();
+      fileCloseQueue.clear();
+
+      allocator.deallocate(writeBufferPointerOne);
+      allocator.deallocate(writeBufferPointerTwo);
+
+      if (writeBufferPointer != null) {
+        writeBufferPointer = null;
+        writeBuffer = null;
+        writeBufferPageIndex = -1;
+      }
+    } finally {
+      recordsWriterLock.unlock();
     }
   }
 
@@ -1701,6 +1709,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
     @Override
     public void run() {
+      recordsWriterLock.lock();
       try {
         if (printPerformanceStatistic) {
           printReport();
@@ -2010,6 +2019,8 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
       } catch (final RuntimeException | Error e) {
         OLogManager.instance().errorNoDb(this, "Error during WAL writing", e);
         throw e;
+      } finally {
+        recordsWriterLock.unlock();
       }
     }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/CASWALPage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/CASWALPage.java
@@ -17,10 +17,7 @@ public final class CASWALPage {
   /** Offset of position which stores XX_HASH value of content stored on this page. */
   public static final int XX_OFFSET = MAGIC_NUMBER_OFFSET + OLongSerializer.LONG_SIZE;
 
-  /** Offset of position which stores operation id of the last record in the page */
-  public static final int LAST_OPERATION_ID_OFFSET = XX_OFFSET + OLongSerializer.LONG_SIZE;
-
-  public static final int PAGE_SIZE_OFFSET = LAST_OPERATION_ID_OFFSET + OIntegerSerializer.INT_SIZE;
+  public static final int PAGE_SIZE_OFFSET = XX_OFFSET + OLongSerializer.LONG_SIZE;
 
   public static final int DEFAULT_PAGE_SIZE = 4 * 1024;
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/MilestoneWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/MilestoneWALRecord.java
@@ -7,21 +7,16 @@ public final class MilestoneWALRecord implements OWALRecord {
   private int distance = -1;
   private int diskSize = -1;
 
-  private volatile OperationIdLSN operationIdLSN;
+  private volatile OLogSequenceNumber logSequenceNumber;
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return logSequenceNumber;
   }
 
   @Override
-  public void setOperationIdLsn(OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
-  }
-
-  @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
+  public void setLsn(OLogSequenceNumber lsn) {
+    this.logSequenceNumber = lsn;
   }
 
   @Override
@@ -55,10 +50,5 @@ public final class MilestoneWALRecord implements OWALRecord {
   @Override
   public boolean trackOperationId() {
     return false;
-  }
-
-  @Override
-  public String toString() {
-    return "MilestoneWALRecord{ operation_id_lsn = " + operationIdLSN + '}';
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/StartWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/StartWALRecord.java
@@ -4,21 +4,16 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSe
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 
 public final class StartWALRecord implements OWALRecord {
-  private volatile OperationIdLSN operationIdLSN;
-
-  @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
-  }
+  private volatile OLogSequenceNumber logSequenceNumber;
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return logSequenceNumber;
   }
 
   @Override
-  public void setOperationIdLsn(OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
+  public void setLsn(OLogSequenceNumber lsn) {
+    this.logSequenceNumber = lsn;
   }
 
   @Override

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogIT.java
@@ -68,6 +68,7 @@ public class CASDiskWriteAheadLogIT {
       OFileUtils.deleteRecursively(testDirectory.toFile());
 
       final long seed = System.nanoTime();
+      System.out.println("testAddSingleOnePageRecord seed : " + seed);
       try {
         final Random random = new Random(seed);
 
@@ -97,7 +98,6 @@ public class CASDiskWriteAheadLogIT {
 
         TestRecord walRecord = new TestRecord(random, wal.pageSize(), 1);
         final OLogSequenceNumber lsn = wal.log(walRecord);
-        Assert.assertEquals(0, walRecord.getOperationIdLSN().operationId);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
         Assert.assertEquals(wal.end(), lsn);
@@ -105,7 +105,6 @@ public class CASDiskWriteAheadLogIT {
         List<WriteableWALRecord> records = wal.read(lsn, 10);
         Assert.assertEquals(1, records.size());
         TestRecord readRecord = (TestRecord) records.get(0);
-        Assert.assertEquals(0, readRecord.getOperationIdLSN().operationId);
 
         Assert.assertArrayEquals(walRecord.data, readRecord.data);
         Assert.assertEquals(lsn, readRecord.getLsn());
@@ -148,9 +147,6 @@ public class CASDiskWriteAheadLogIT {
         Assert.assertEquals(lsn, readRecord.getLsn());
 
         Assert.assertTrue(records.get(1) instanceof EmptyWALRecord);
-
-        Assert.assertEquals(0, records.get(0).getOperationIdLSN().operationId);
-        Assert.assertEquals(0, records.get(1).getOperationIdLSN().operationId);
 
         wal.close();
 
@@ -200,7 +196,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -208,8 +204,6 @@ public class CASDiskWriteAheadLogIT {
 
         TestRecord walRecord = new TestRecord(random, wal.pageSize(), 1);
         final OLogSequenceNumber lsn = wal.log(walRecord);
-
-        Assert.assertEquals(0, walRecord.getOperationIdLSN().operationId);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
         Assert.assertEquals(wal.end(), lsn);
@@ -220,7 +214,6 @@ public class CASDiskWriteAheadLogIT {
 
         Assert.assertArrayEquals(walRecord.data, readRecord.data);
         Assert.assertEquals(lsn, readRecord.getLsn());
-        Assert.assertEquals(0, readRecord.getOperationIdLSN().operationId);
 
         wal.close();
 
@@ -261,9 +254,6 @@ public class CASDiskWriteAheadLogIT {
         Assert.assertEquals(lsn, readRecord.getLsn());
 
         Assert.assertTrue(records.get(1) instanceof EmptyWALRecord);
-
-        Assert.assertEquals(0, records.get(0).getOperationIdLSN().operationId);
-        Assert.assertEquals(0, records.get(1).getOperationIdLSN().operationId);
 
         wal.close();
 
@@ -313,7 +303,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -417,7 +407,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -458,7 +448,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -515,7 +505,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -524,16 +514,12 @@ public class CASDiskWriteAheadLogIT {
         TestRecord walRecord = new TestRecord(random, 2 * wal.pageSize(), wal.pageSize());
         final OLogSequenceNumber lsn = wal.log(walRecord);
 
-        Assert.assertEquals(0, walRecord.getOperationIdLSN().operationId);
-
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
         Assert.assertEquals(wal.end(), lsn);
 
         List<WriteableWALRecord> records = wal.read(lsn, 10);
         Assert.assertEquals(1, records.size());
         TestRecord readRecord = (TestRecord) records.get(0);
-
-        Assert.assertEquals(0, readRecord.getOperationIdLSN().operationId);
 
         Assert.assertArrayEquals(walRecord.data, readRecord.data);
         Assert.assertEquals(lsn, readRecord.getLsn());
@@ -557,7 +543,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -578,8 +564,6 @@ public class CASDiskWriteAheadLogIT {
 
         Assert.assertTrue(records.get(1) instanceof EmptyWALRecord);
 
-        Assert.assertEquals(0, records.get(0).getOperationIdLSN().operationId);
-        Assert.assertEquals(0, records.get(1).getOperationIdLSN().operationId);
         wal.close();
 
         Thread.sleep(1);
@@ -627,7 +611,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -636,15 +620,12 @@ public class CASDiskWriteAheadLogIT {
         TestRecord walRecord = new TestRecord(random, 2 * wal.pageSize(), wal.pageSize());
         final OLogSequenceNumber lsn = wal.log(walRecord);
 
-        Assert.assertEquals(0, walRecord.getOperationIdLSN().operationId);
-
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
         Assert.assertEquals(wal.end(), lsn);
 
         List<WriteableWALRecord> records = wal.read(lsn, 10);
         Assert.assertEquals(1, records.size());
         TestRecord readRecord = (TestRecord) records.get(0);
-        Assert.assertEquals(0, readRecord.getOperationIdLSN().operationId);
 
         Assert.assertArrayEquals(walRecord.data, readRecord.data);
         Assert.assertEquals(lsn, walRecord.getLsn());
@@ -668,7 +649,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -688,9 +669,6 @@ public class CASDiskWriteAheadLogIT {
         Assert.assertEquals(lsn, readRecord.getLsn());
 
         Assert.assertTrue(records.get(1) instanceof EmptyWALRecord);
-
-        Assert.assertEquals(0, records.get(0).getOperationIdLSN().operationId);
-        Assert.assertEquals(0, records.get(1).getOperationIdLSN().operationId);
 
         wal.close();
 
@@ -735,7 +713,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -749,8 +727,6 @@ public class CASDiskWriteAheadLogIT {
 
           OLogSequenceNumber lsn = wal.log(walRecord);
           Assert.assertEquals(walRecord.getLsn(), lsn);
-
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
@@ -769,10 +745,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -796,7 +768,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -820,10 +792,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -874,7 +842,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -887,7 +855,6 @@ public class CASDiskWriteAheadLogIT {
           records.add(walRecord);
 
           OLogSequenceNumber lsn = wal.log(walRecord);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
           Assert.assertEquals(walRecord.getLsn(), lsn);
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -907,9 +874,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -933,7 +897,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -957,9 +921,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1007,7 +968,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1024,7 +985,6 @@ public class CASDiskWriteAheadLogIT {
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
           Assert.assertEquals(walRecord.getLsn(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 4; i++) {
@@ -1040,9 +1000,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1068,7 +1025,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1092,9 +1049,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1152,7 +1106,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1169,7 +1123,6 @@ public class CASDiskWriteAheadLogIT {
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
           Assert.assertEquals(walRecord.getLsn(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 4; i++) {
@@ -1185,9 +1138,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1213,7 +1163,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1237,9 +1187,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1293,7 +1240,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1310,7 +1257,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 5; i++) {
@@ -1326,9 +1272,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1352,7 +1295,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1375,9 +1318,6 @@ public class CASDiskWriteAheadLogIT {
             final TestRecord testResultRecord = (TestRecord) resultRecord;
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1429,7 +1369,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1446,7 +1386,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 5; i++) {
@@ -1462,9 +1401,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1488,7 +1424,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1511,9 +1447,6 @@ public class CASDiskWriteAheadLogIT {
             final TestRecord testResultRecord = (TestRecord) resultRecord;
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1561,7 +1494,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1578,7 +1511,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 4; i++) {
@@ -1594,9 +1526,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1621,7 +1550,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1645,10 +1574,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1706,7 +1631,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1723,7 +1648,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < 4; i++) {
@@ -1739,9 +1663,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1766,7 +1687,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1790,9 +1711,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1846,7 +1764,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1865,7 +1783,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -1886,9 +1803,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1912,7 +1826,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -1936,9 +1850,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -1987,7 +1898,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2006,7 +1917,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -2027,9 +1937,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2053,7 +1960,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2077,9 +1984,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, testResultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2124,7 +2028,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2143,7 +2047,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -2160,9 +2063,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2188,7 +2088,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2208,9 +2108,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2265,7 +2162,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2284,7 +2181,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(i, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -2301,9 +2197,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2329,7 +2222,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2349,9 +2242,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2403,7 +2293,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2427,7 +2317,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
             Assert.assertEquals(wal.end(), lastLsn);
-            Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2461,9 +2350,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2500,7 +2386,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2530,9 +2416,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2545,7 +2428,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), walRecord.getLsn());
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < records.size(); i++) {
@@ -2568,9 +2450,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2631,7 +2510,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2655,7 +2534,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
             Assert.assertEquals(wal.end(), lastLsn);
-            Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2682,9 +2560,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2721,7 +2596,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2751,9 +2626,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2766,7 +2638,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), walRecord.getLsn());
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < records.size(); i++) {
@@ -2789,9 +2660,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -2848,7 +2716,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2867,7 +2735,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -2911,7 +2778,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -2984,7 +2851,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3003,7 +2870,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -3048,7 +2914,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3116,7 +2982,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3135,7 +3001,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -3157,9 +3022,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3185,7 +3047,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3263,7 +3125,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3282,7 +3144,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -3304,9 +3165,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3332,7 +3190,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3357,9 +3215,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3384,7 +3239,7 @@ public class CASDiskWriteAheadLogIT {
   public void testAddRecordsMix() throws Exception {
     final int iterations = 1;
     for (int n = 0; n < iterations; n++) {
-      final long seed = 26866978951787L; // System.nanoTime();
+      final long seed = System.nanoTime();
 
       OFileUtils.deleteRecursively(testDirectory.toFile());
 
@@ -3409,7 +3264,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3428,7 +3283,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -3449,9 +3303,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3475,7 +3326,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3499,9 +3350,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3548,7 +3396,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3567,7 +3415,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount; i++) {
@@ -3588,9 +3435,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3614,7 +3458,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3638,9 +3482,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3683,7 +3524,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
         Assert.assertEquals(wal.end(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3701,7 +3542,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -3723,9 +3563,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3751,7 +3588,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3776,9 +3613,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3832,7 +3666,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3851,7 +3685,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
         }
 
         for (int i = 0; i < recordsCount - 1; i++) {
@@ -3873,9 +3706,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3901,7 +3731,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -3926,9 +3756,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -3979,7 +3806,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
         for (int i = 0; i < recordsCount; i++) {
 
@@ -4039,7 +3866,7 @@ public class CASDiskWriteAheadLogIT {
               1000,
               false,
               false,
-              true,
+              false,
               10);
 
       long seed = System.nanoTime();
@@ -4084,7 +3911,7 @@ public class CASDiskWriteAheadLogIT {
               1000,
               false,
               false,
-              true,
+              false,
               10);
 
       Assert.assertNotNull(loadedWAL.getFlushedLsn());
@@ -4126,7 +3953,7 @@ public class CASDiskWriteAheadLogIT {
               1000,
               false,
               false,
-              true,
+              false,
               10);
 
       ExecutorService executorService = Executors.newCachedThreadPool();
@@ -4231,7 +4058,7 @@ public class CASDiskWriteAheadLogIT {
               1000,
               false,
               false,
-              true,
+              false,
               10);
 
       long minSegment = begin.getSegment();
@@ -4300,7 +4127,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
 
     AtomicReference<Future<Void>> segmentAppender = new AtomicReference<>();
@@ -4430,7 +4257,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         List<TestRecord> records = new ArrayList<>();
@@ -4446,7 +4273,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
 
           if (random.nextDouble() < 0.05) {
             final int segments = random.nextInt(5) + 1;
@@ -4476,9 +4302,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -4503,7 +4326,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -4531,9 +4354,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -4555,6 +4375,7 @@ public class CASDiskWriteAheadLogIT {
       OFileUtils.deleteRecursively(testDirectory.toFile());
 
       final long seed = System.nanoTime();
+      System.out.println("testAppendSegmentNext seed : " + seed);
       final Random random = new Random(seed);
 
       try {
@@ -4576,7 +4397,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         List<TestRecord> records = new ArrayList<>();
@@ -4592,8 +4413,6 @@ public class CASDiskWriteAheadLogIT {
 
           Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
           Assert.assertEquals(wal.end(), lsn);
-
-          Assert.assertEquals(records.size() - 1, walRecord.getOperationIdLSN().operationId);
 
           if (random.nextDouble() < 0.05) {
             final int segments = random.nextInt(5) + 1;
@@ -4624,9 +4443,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -4653,7 +4469,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Assert.assertEquals(wal.begin(), new OLogSequenceNumber(1, CASWALPage.RECORDS_OFFSET));
@@ -4681,9 +4497,6 @@ public class CASDiskWriteAheadLogIT {
 
             Assert.assertArrayEquals(record.data, resultRecord.data);
             Assert.assertEquals(record.getLsn(), resultRecord.getLsn());
-            Assert.assertEquals(
-                record.getOperationIdLSN().operationId,
-                resultRecord.getOperationIdLSN().operationId);
           }
         }
 
@@ -4724,7 +4537,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
 
     final long seed = System.nanoTime();
@@ -4765,6 +4578,7 @@ public class CASDiskWriteAheadLogIT {
       OFileUtils.deleteRecursively(testDirectory.toFile());
 
       final long seed = System.nanoTime();
+      System.out.println(" testWALCrash : " + seed);
       final Random random = new Random(seed);
 
       try {
@@ -4786,7 +4600,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         ExecutorService executorService = Executors.newCachedThreadPool();
@@ -4865,7 +4679,7 @@ public class CASDiskWriteAheadLogIT {
                 1000,
                 false,
                 false,
-                true,
+                false,
                 10);
 
         Iterator<TestRecord> recordIterator = records.iterator();
@@ -4937,7 +4751,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
     wal.close();
     Assert.assertEquals(
@@ -4966,7 +4780,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
     wal.close();
     Assert.assertTrue(
@@ -4993,7 +4807,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
     wal.close();
     Assert.assertEquals(
@@ -5024,7 +4838,7 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
 
     final Lock lock = new ReentrantLock();
@@ -5053,21 +4867,12 @@ public class CASDiskWriteAheadLogIT {
     }
 
     final OLogSequenceNumber lsn = wal.begin();
-    int operationId = 0;
 
     List<WriteableWALRecord> records = wal.read(lsn, 100);
     while (!records.isEmpty()) {
-      for (WriteableWALRecord record : records) {
-        if (record.trackOperationId()) {
-          Assert.assertEquals(operationId, record.getOperationIdLSN().operationId);
-          operationId++;
-        }
-      }
-
       records = wal.next(records.get(records.size() - 1).getLsn(), 100);
     }
 
-    Assert.assertEquals(800_000, operationId);
     wal.close();
 
     CASDiskWriteAheadLog reopenedWal =
@@ -5088,23 +4893,13 @@ public class CASDiskWriteAheadLogIT {
             1000,
             false,
             false,
-            true,
+            false,
             10);
-
-    operationId = 0;
 
     records = reopenedWal.read(lsn, 100);
     while (!records.isEmpty()) {
-      for (WriteableWALRecord record : records) {
-        if (record.trackOperationId()) {
-          Assert.assertEquals(operationId, record.getOperationIdLSN().operationId);
-          operationId++;
-        }
-      }
-
       records = reopenedWal.next(records.get(records.size() - 1).getLsn(), 100);
     }
-    Assert.assertEquals(800_000, operationId);
     reopenedWal.close();
   }
 
@@ -5168,7 +4963,7 @@ public class CASDiskWriteAheadLogIT {
 
     final OLogSequenceNumber lastLSN =
         records.floorKey(new OLogSequenceNumber(segment, Integer.MAX_VALUE));
-    final int position = random.nextInt(lastLSN.getPosition());
+    final int position = random.nextInt((int) lastLSN.getPosition());
 
     OLogSequenceNumber lsn = records.ceilingKey(new OLogSequenceNumber(segment, position));
     Assert.assertNotNull(lsn);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/cache/WOWCacheTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/cache/WOWCacheTestIT.java
@@ -916,8 +916,8 @@ public class WOWCacheTestIT {
 
     long segment =
         OLongSerializer.INSTANCE.deserializeNative(content, ODurablePage.WAL_SEGMENT_OFFSET);
-    int position =
-        OIntegerSerializer.INSTANCE.deserializeNative(content, ODurablePage.WAL_POSITION_OFFSET);
+    long position =
+        OLongSerializer.INSTANCE.deserializeNative(content, ODurablePage.WAL_POSITION_OFFSET);
 
     OLogSequenceNumber readLsn = new OLogSequenceNumber(segment, position);
 
@@ -939,7 +939,7 @@ public class WOWCacheTestIT {
     fileClassic.open();
     byte[] content = new byte[8 + ODurablePage.NEXT_FREE_POSITION];
     fileClassic.read(
-        pageIndex * (8 + ODurablePage.NEXT_FREE_POSITION),
+            (long) pageIndex * (8 + ODurablePage.NEXT_FREE_POSITION),
         ByteBuffer.wrap(content).order(ByteOrder.nativeOrder()),
         true);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/cache/WOWCacheTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/cache/WOWCacheTestIT.java
@@ -939,7 +939,7 @@ public class WOWCacheTestIT {
     fileClassic.open();
     byte[] content = new byte[8 + ODurablePage.NEXT_FREE_POSITION];
     fileClassic.read(
-            (long) pageIndex * (8 + ODurablePage.NEXT_FREE_POSITION),
+        (long) pageIndex * (8 + ODurablePage.NEXT_FREE_POSITION),
         ByteBuffer.wrap(content).order(ByteOrder.nativeOrder()),
         true);
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v3/OLocalHashTableV3WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v3/OLocalHashTableV3WALTestIT.java
@@ -27,7 +27,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import com.orientechnologies.orient.core.storage.index.hashindex.local.OMurmurHash3HashFunction;
 import java.io.IOException;
@@ -361,7 +360,7 @@ public class OLocalHashTableV3WALTestIT extends OLocalHashTableV3Base {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLSN(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v1/SBTreeV1WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v1/SBTreeV1WALTestIT.java
@@ -25,7 +25,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -348,7 +347,7 @@ public class SBTreeV1WALTestIT extends SBTreeV1TestIT {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLSN(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v2/SBTreeV2WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v2/SBTreeV2WALTestIT.java
@@ -24,7 +24,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -347,7 +346,7 @@ public class SBTreeV2WALTestIT extends SBTreeV2TestIT {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLSN(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }


### PR DESCRIPTION
What does this PR do?
Allows keeping WAL segments bigger than 2GB into the WAL.

Motivation
Because high load segments may be not created in timely manner to keep the size lower than 2 GB.

Related issues
https://github.com/orientechnologies/orientdb/issues/9568 https://github.com/orientechnologies/orientdb/issues/9598 https://github.com/orientechnologies/orientdb/issues/9542

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
