### PR TITLE
Remove cache from .travis.yml in order to be able to spot missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: java
-cache:
-  directories:
-  - $HOME/.m2
 install: true
 script:
   - mvn clean test -Dmaven.test.redirectTestOutputToFile=true -P travis


### PR DESCRIPTION
What does this PR do?
Building for the first fime (with `./mvnw install`) currently fails due to failing download of https://download.java.net/maven/2/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar. It's probably not noticed because all CI systems use caches.

Motivation
Being able to build orientdb.

Related issues
./.

Additional Notes
Don't know if you're actively using Travis CI. It seems like a good double check for this.

Checklist
[] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
