### PR TITLE
Activate pmd

### DIFF
--- a/code-analysis/pom.xml
+++ b/code-analysis/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<!-- ~ Copyright 2010-2013 Orient Technologies LTD ~ ~ Licensed under the
+    Apache License, Version 2.0 (the "License"); ~ you may not use this file
+    except in compliance with the License. ~ You may obtain a copy of the License
+    at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by
+    applicable law or agreed to in writing, software ~ distributed under the
+    License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied. ~ See the License for the specific
+    language governing permissions and ~ limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.orientechnologies</groupId>
+        <artifactId>orientdb-parent</artifactId>
+        <version>3.2.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>code-analysis</artifactId>
+    <version>0.1.0</version>
+    <name>code-analysis</name>
+</project>

--- a/code-analysis/src/main/resources/code-analysis/pmd-ruleset.xml
+++ b/code-analysis/src/main/resources/code-analysis/pmd-ruleset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <rule ref="category/java/codestyle.xml/UseDiamondOperator" />
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
     </mailingLists>
 
     <modules>
+        <module>code-analysis</module>
         <module>test-commons</module>
         <module>client</module>
         <module>core</module>
@@ -315,9 +316,29 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.10.0</version>
+                    <version>3.14.0</version>
+                    <executions>
+                        <execution>
+                            <id>pmd-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <rulesets>
+                            <ruleset>/code-analysis/pmd-ruleset.xml</ruleset>
+                        </rulesets>
+                        <printFailingErrors>true</printFailingErrors>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.orientechnologies</groupId>
+                            <artifactId>code-analysis</artifactId>
+                            <version>0.1.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
-
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/test-commons/pom.xml
+++ b/test-commons/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>objenesis</artifactId>
             <version>2.4</version>
         </dependency>
-
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/test-commons/src/main/java/com/orientechnologies/orient/test/CompositeException.java
+++ b/test-commons/src/main/java/com/orientechnologies/orient/test/CompositeException.java
@@ -24,7 +24,7 @@ import java.util.List;
 /** @author richter */
 public class CompositeException extends RuntimeException {
   private static final long serialVersionUID = 1L;
-  private final List<Throwable> causes = new ArrayList<Throwable>();
+  private final List<Throwable> causes = new ArrayList<>();
 
   public CompositeException(Collection<? extends Throwable> causes) {
     this.causes.addAll(causes);

--- a/test-commons/src/main/java/com/orientechnologies/orient/test/ConcurrentTestHelper.java
+++ b/test-commons/src/main/java/com/orientechnologies/orient/test/ConcurrentTestHelper.java
@@ -22,7 +22,7 @@ public class ConcurrentTestHelper<T> {
   private final List<Future<T>> futures;
 
   private ConcurrentTestHelper(int threadCount) {
-    this.futures = new ArrayList<Future<T>>(threadCount);
+    this.futures = new ArrayList<>(threadCount);
     this.executor = Executors.newFixedThreadPool(threadCount);
   }
 
@@ -32,7 +32,7 @@ public class ConcurrentTestHelper<T> {
   }
 
   protected static <T> Collection<T> go(List<Callable<T>> workers) {
-    final ConcurrentTestHelper<T> helper = new ConcurrentTestHelper<T>(workers.size());
+    final ConcurrentTestHelper<T> helper = new ConcurrentTestHelper<>(workers.size());
 
     helper.submit(workers);
 
@@ -40,7 +40,7 @@ public class ConcurrentTestHelper<T> {
   }
 
   protected static <T> List<Callable<T>> prepareWorkers(int threadCount, TestFactory<T> factory) {
-    final List<Callable<T>> callables = new ArrayList<Callable<T>>(threadCount);
+    final List<Callable<T>> callables = new ArrayList<>(threadCount);
     for (int i = 0; i < threadCount; i++) {
       callables.add(factory.createWorker());
     }
@@ -56,8 +56,8 @@ public class ConcurrentTestHelper<T> {
       executor.shutdown();
       assertTrue("Test threads hanged", executor.awaitTermination(30, TimeUnit.MINUTES));
 
-      List<T> results = new ArrayList<T>(futures.size());
-      List<Exception> exceptions = new ArrayList<Exception>();
+      List<T> results = new ArrayList<>(futures.size());
+      List<Exception> exceptions = new ArrayList<>();
       for (Future<T> future : futures) {
         try {
           results.add(future.get());

--- a/test-commons/src/main/java/com/orientechnologies/orient/test/TestBuilder.java
+++ b/test-commons/src/main/java/com/orientechnologies/orient/test/TestBuilder.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Callable;
  * @param <T> see {@link TestFactory}
  */
 public class TestBuilder<T> {
-  private final List<Callable<T>> workers = new ArrayList<Callable<T>>();
+  private final List<Callable<T>> workers = new ArrayList<>();
 
   public TestBuilder<T> add(int threadCount, TestFactory<T> factory) {
     workers.addAll(ConcurrentTestHelper.prepareWorkers(threadCount, factory));


### PR DESCRIPTION
What does this PR do?
I stumbled of PMD in the pluginManagement section of the parent pom.xml. In case you wanted to use it and never found the time to set it up: There you go. It's also a proposal to enhance code quality by automating the enforcement of rules. For starters I put in a very simple rule which is only active for one module.

Motivation
Rebasing a few older branches has been tedious due to numerous changes to the code style. Enforcing them makes live easier and poses no overhead if everyone configures their formatters correctly.

Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

Additional Notes
This now fails the build if someone pushes something that violates PMD rules and didn't check it locally. That should be discussed in the dev team. If you find this useful, I can continue the setup for all modules with the Diamond and/or other rule(s).

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
