### PR TITLE
fix(9695): Repairs for the LET expression evaluates $current differen…

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/ProjectionCalculationStep.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/ProjectionCalculationStep.java
@@ -34,15 +34,14 @@ public class ProjectionCalculationStep extends AbstractExecutionStep {
       @Override
       public OResult next() {
         OResult item = parentRs.next();
-        Object oldCurrent = ctx.getVariable("$current");
-        ctx.setVariable("$current", item);
         OResult result = calculateProjections(ctx, item);
-        ctx.setVariable("$current", oldCurrent);
+        ctx.setVariable("$current", result);
         return result;
       }
 
       @Override
       public void close() {
+        ctx.setVariable("$current", null);
         parentRs.close();
       }
 

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -2031,7 +2031,7 @@ public class OSelectStatementExecutionTest {
 
   @Test
   public void testLetVariableSubqueryProjectionFetchFromClassTarget_9695() {
-    String className = "testSelectFromSubqueryWithLetQuery_9695";
+    String className = "testLetVariableSubqueryProjectionFetchFromClassTarget_9695";
     db.getMetadata().getSchema().createClass(className);
 
     for (int i = 0; i < 10; i++) {

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -2030,6 +2030,42 @@ public class OSelectStatementExecutionTest {
   }
 
   @Test
+  public void testLetVariableSubqueryProjectionFetchFromClassTarget_9695() {
+    String className = "testSelectFromSubqueryWithLetQuery_9695";
+    db.getMetadata().getSchema().createClass(className);
+
+    for (int i = 0; i < 10; i++) {
+      ODocument doc = db.newInstance(className);
+      doc.setProperty("i", i);
+      doc.setProperty("iSeq", new int[] {i, 2 * i, 4 * i});
+      doc.save();
+    }
+    OResultSet result =
+        db.query(
+            "select $current.*, $b.*, $b.@class from (select 1 as sqa, @class as sqc from "
+                + className
+                + " LIMIT 2)\n"
+                + "let $b = $current");
+    printExecutionPlan(result);
+    Assert.assertTrue(result.hasNext());
+    OResult item = result.next();
+    Assert.assertNotNull(item);
+    Object currentProperty = item.getProperty("$current.*");
+    Assert.assertTrue(currentProperty instanceof OResult);
+    final OResult currentResult = (OResult) currentProperty;
+    Assert.assertTrue(currentResult.isProjection());
+    Assert.assertEquals(Integer.valueOf(1), currentResult.<Integer>getProperty("sqa"));
+    Assert.assertEquals(className, currentResult.getProperty("sqc"));
+    Object bProperty = item.getProperty("$b.*");
+    Assert.assertTrue(bProperty instanceof OResult);
+    final OResult bResult = (OResult) bProperty;
+    Assert.assertTrue(bResult.isProjection());
+    Assert.assertEquals(Integer.valueOf(1), bResult.<Integer>getProperty("sqa"));
+    Assert.assertEquals(className, bResult.getProperty("sqc"));
+    result.close();
+  }
+
+  @Test
   public void testUnwind1() {
     String className = "testUnwind1";
     db.getMetadata().getSchema().createClass(className);


### PR DESCRIPTION
…tly from SELECT $current when subquery is fetching from the class target #9695

What does this PR do?
Repairs the evaluation of the projections from the subqueries fetch from the class targets

Motivation
Regression

Related issues
#9695

Additional Notes
Anything else we should know when reviewing?

Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
