### PR TITLE
Making all WAL segments the same size

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,6 +49,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine>-ea
             -Xmx${heapSize}
+            -XX:+HeapDumpOnOutOfMemoryError
             -Dstorage.diskCache.bufferSize=4096
             -Dindex.flushAfterCreate=false
             -Dstorage.makeFullCheckpointAfterCreate=false
@@ -63,7 +64,7 @@
             -Djava.util.logging.manager=com.orientechnologies.common.log.ShutdownLogManager
             -Dstorage.diskCache.checksumMode=storeAndThrow
             -Dindex.allowManualIndexes=false
-	    -Dsecurity.warningDefaultUsers=false
+	        -Dsecurity.warningDefaultUsers=false
         </argLine>
         <project.rootdir>${project.basedir}/../</project.rootdir>
     </properties>

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
@@ -31,7 +31,6 @@ import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.parser.OSystemVariableResolver;
 import com.orientechnologies.common.serialization.types.OStringSerializer;
-import com.orientechnologies.common.thread.OThreadPoolExecutorWithLogging;
 import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.compression.impl.OZIPCompressionUtil;
@@ -84,10 +83,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import net.jpountz.xxhash.XXHash64;
@@ -144,14 +140,6 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
 
   private static final int ONE_KB = 1024;
 
-  private static final OThreadPoolExecutorWithLogging segmentAdderExecutor;
-
-  static {
-    segmentAdderExecutor =
-        new OThreadPoolExecutorWithLogging(
-            0, 1, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new SegmentAppenderFactory());
-  }
-
   private final int deleteMaxRetries;
   private final int deleteWaitTime;
 
@@ -164,8 +152,6 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
 
   private final long walMaxSegSize;
   private final long doubleWriteLogMaxSegSize;
-
-  private final AtomicReference<Future<Void>> segmentAppender = new AtomicReference<>();
 
   protected volatile byte[] iv;
 
@@ -768,7 +754,7 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
       walPath = Paths.get(configWalPath);
     }
 
-    final CASDiskWriteAheadLog diskWriteAheadLog =
+    writeAheadLog =
         new CASDiskWriteAheadLog(
             name,
             storagePath,
@@ -792,28 +778,7 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
                 OGlobalConfiguration.STORAGE_PRINT_WAL_PERFORMANCE_STATISTICS),
             contextConfiguration.getValueAsInteger(
                 OGlobalConfiguration.STORAGE_PRINT_WAL_PERFORMANCE_INTERVAL));
-
-    writeAheadLog = diskWriteAheadLog;
     writeAheadLog.addCheckpointListener(this);
-
-    diskWriteAheadLog.addSegmentOverflowListener(
-        (segment) -> {
-          if (status != STATUS.OPEN) {
-            return;
-          }
-
-          final Future<Void> oldAppender = segmentAppender.get();
-          if (oldAppender == null || oldAppender.isDone()) {
-            final Future<Void> appender =
-                segmentAdderExecutor.submit(new SegmentAdder(segment, diskWriteAheadLog));
-
-            if (segmentAppender.compareAndSet(oldAppender, appender)) {
-              return;
-            }
-
-            appender.cancel(false);
-          }
-        });
 
     final int pageSize =
         contextConfiguration.getValueAsInteger(OGlobalConfiguration.DISK_CACHE_PAGE_SIZE) * ONE_KB;
@@ -894,59 +859,6 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
       } catch (final RuntimeException e) {
         OLogManager.instance().error(this, "Error during fuzzy checkpoint", e);
       }
-    }
-  }
-
-  private final class SegmentAdder implements Callable<Void> {
-    private final long segment;
-    private final CASDiskWriteAheadLog wal;
-
-    private SegmentAdder(final long segment, final CASDiskWriteAheadLog wal) {
-      this.segment = segment;
-      this.wal = wal;
-    }
-
-    @Override
-    public Void call() {
-      try {
-        if (status != STATUS.OPEN) {
-          return null;
-        }
-
-        stateLock.acquireReadLock();
-        try {
-          if (status != STATUS.OPEN) {
-            return null;
-          }
-
-          final long freezeId = atomicOperationsManager.freezeComponentOperations();
-          try {
-            wal.appendSegment(segment + 1);
-          } finally {
-            atomicOperationsManager.releaseComponentOperations(freezeId);
-          }
-
-          atomicOperationsTable.compactTable();
-        } finally {
-          stateLock.releaseReadLock();
-        }
-
-      } catch (final Exception e) {
-        OLogManager.instance()
-            .errorNoDb(this, "Error during addition of new segment in storage %s.", e, getName());
-        throw e;
-      }
-
-      return null;
-    }
-  }
-
-  private static final class SegmentAppenderFactory implements ThreadFactory {
-    private SegmentAppenderFactory() {}
-
-    @Override
-    public Thread newThread(final Runnable r) {
-      return new Thread(OAbstractPaginatedStorage.storageThreadGroup, r, "Segment adder thread");
     }
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/fs/AsyncFile.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/fs/AsyncFile.java
@@ -1,18 +1,15 @@
 package com.orientechnologies.orient.core.storage.fs;
 
-import com.orientechnologies.common.concur.lock.OInterruptedException;
 import com.orientechnologies.common.concur.lock.ScalableRWLock;
 import com.orientechnologies.common.exception.OException;
-import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.util.ORawPair;
 import com.orientechnologies.orient.core.exception.OStorageException;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.CompletionHandler;
-import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -31,10 +28,7 @@ public final class AsyncFile implements OFile {
   private final Object flushSemaphore = new Object();
 
   private final AtomicLong size = new AtomicLong(-1);
-  private AsynchronousFileChannel writeChannel;
-  // unlike writes reads can be safely interrupted by Thread.interrupt so those two channels are
-  // separated.
-  private FileChannel readChannel;
+  private AsynchronousFileChannel fileChannel;
 
   private final int pageSize;
 
@@ -47,7 +41,7 @@ public final class AsyncFile implements OFile {
   public void create() throws IOException {
     lock.exclusiveLock();
     try {
-      if (writeChannel != null || readChannel != null) {
+      if (fileChannel != null) {
         throw new OStorageException("File " + osFile + " is already opened.");
       }
 
@@ -60,13 +54,13 @@ public final class AsyncFile implements OFile {
   }
 
   private void initSize() throws IOException {
-    if (writeChannel.size() < HEADER_SIZE) {
+    if (fileChannel.size() < HEADER_SIZE) {
       final ByteBuffer buffer = ByteBuffer.allocate(HEADER_SIZE);
 
       int written = 0;
       do {
         buffer.position(written);
-        final Future<Integer> writeFuture = writeChannel.write(buffer, written);
+        final Future<Integer> writeFuture = fileChannel.write(buffer, written);
         try {
           written += writeFuture.get();
         } catch (InterruptedException | ExecutionException e) {
@@ -78,13 +72,13 @@ public final class AsyncFile implements OFile {
       dirtyCounter.incrementAndGet();
     }
 
-    long currentSize = writeChannel.size() - HEADER_SIZE;
+    long currentSize = fileChannel.size() - HEADER_SIZE;
 
     if (currentSize % pageSize != 0) {
       final long initialSize = currentSize;
 
       currentSize = (currentSize / pageSize) * pageSize;
-      writeChannel.truncate(currentSize + HEADER_SIZE);
+      fileChannel.truncate(currentSize + HEADER_SIZE);
 
       OLogManager.instance()
           .warnNoDb(
@@ -99,10 +93,10 @@ public final class AsyncFile implements OFile {
     if (size.get() < 0) {
       size.set(currentSize);
     } else {
-      if (writeChannel.size() - HEADER_SIZE > size.get()) {
+      if (fileChannel.size() - HEADER_SIZE > size.get()) {
         throw new IllegalStateException(
             "Physical size of the file "
-                + (writeChannel.size() - HEADER_SIZE)
+                + (fileChannel.size() - HEADER_SIZE)
                 + " but logical size is "
                 + size.get());
       }
@@ -122,12 +116,12 @@ public final class AsyncFile implements OFile {
   }
 
   private void doOpen() throws IOException {
-    if (writeChannel != null || readChannel != null) {
+    if (fileChannel != null) {
       throw new OStorageException("File " + osFile + " is already opened.");
     }
 
-    writeChannel = AsynchronousFileChannel.open(osFile, StandardOpenOption.WRITE);
-    readChannel = FileChannel.open(osFile, StandardOpenOption.READ);
+    fileChannel =
+        AsynchronousFileChannel.open(osFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
 
     initSize();
   }
@@ -146,7 +140,7 @@ public final class AsyncFile implements OFile {
   public boolean isOpen() {
     lock.sharedLock();
     try {
-      return writeChannel != null;
+      return fileChannel != null;
     } finally {
       lock.sharedUnlock();
     }
@@ -171,7 +165,7 @@ public final class AsyncFile implements OFile {
       do {
         buffer.position(written);
         final Future<Integer> writeFuture =
-            writeChannel.write(buffer, offset + HEADER_SIZE + written);
+            fileChannel.write(buffer, offset + HEADER_SIZE + written);
         try {
           written += writeFuture.get();
         } catch (InterruptedException | ExecutionException e) {
@@ -202,7 +196,7 @@ public final class AsyncFile implements OFile {
         checkPosition(pair.first + pair.second.limit() - 1);
 
         final long position = pair.first + HEADER_SIZE;
-        writeChannel.write(
+        fileChannel.write(
             byteBuffer, position, latch, new WriteHandler(byteBuffer, asyncIOResult, position));
       } finally {
         lock.sharedUnlock();
@@ -214,25 +208,35 @@ public final class AsyncFile implements OFile {
 
   @Override
   public void read(long offset, ByteBuffer buffer, boolean throwOnEof) throws IOException {
+    lock.sharedLock();
     try {
-      lock.sharedLock();
-      try {
-        checkForClose();
-        checkPosition(offset);
+      checkForClose();
+      checkPosition(offset);
 
-        OIOUtils.readByteBuffer(buffer, readChannel, offset + HEADER_SIZE, true);
-      } finally {
-        lock.sharedUnlock();
-      }
-    } catch (final ClosedByInterruptException cbe) {
-      lock.exclusiveLock();
-      try {
-        readChannel = FileChannel.open(osFile, StandardOpenOption.READ);
-        throw OException.wrapException(
-            new OInterruptedException("Read of file " + osFile + " was interrupted."), cbe);
-      } finally {
-        lock.exclusiveUnlock();
-      }
+      int read = 0;
+      do {
+        buffer.position(read);
+        final Future<Integer> readFuture = fileChannel.read(buffer, offset + HEADER_SIZE + read);
+        final int bytesRead;
+        try {
+          bytesRead = readFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+          throw OException.wrapException(
+              new OStorageException("Error during read operation from the file " + osFile), e);
+        }
+
+        if (bytesRead == -1) {
+          if (throwOnEof) {
+            throw new EOFException("End of file " + osFile + " is reached.");
+          }
+
+          break;
+        }
+
+        read += bytesRead;
+      } while (read < buffer.limit());
+    } finally {
+      lock.sharedUnlock();
     }
   }
 
@@ -248,7 +252,7 @@ public final class AsyncFile implements OFile {
       checkForClose();
 
       this.size.set(0);
-      writeChannel.truncate(size + HEADER_SIZE);
+      fileChannel.truncate(size + HEADER_SIZE);
     } finally {
       lock.exclusiveUnlock();
     }
@@ -269,7 +273,7 @@ public final class AsyncFile implements OFile {
       long dirtyCounterValue = dirtyCounter.get();
       if (dirtyCounterValue > 0) {
         try {
-          writeChannel.force(false);
+          fileChannel.force(false);
         } catch (final IOException e) {
           OLogManager.instance()
               .warn(
@@ -300,13 +304,9 @@ public final class AsyncFile implements OFile {
 
   private void doClose() throws IOException {
     // ignore if closed
-    if (writeChannel != null) {
-      writeChannel.close();
-      writeChannel = null;
-    }
-    if (readChannel != null) {
-      readChannel.close();
-      readChannel = null;
+    if (fileChannel != null) {
+      fileChannel.close();
+      fileChannel = null;
     }
   }
 
@@ -363,7 +363,7 @@ public final class AsyncFile implements OFile {
   }
 
   private void checkForClose() {
-    if (writeChannel == null || readChannel == null) {
+    if (fileChannel == null) {
       throw new OStorageException("File " + osFile + " is closed");
     }
   }
@@ -386,7 +386,7 @@ public final class AsyncFile implements OFile {
         try {
           checkForClose();
 
-          writeChannel.write(byteBuffer, position + byteBuffer.position(), attachment, this);
+          fileChannel.write(byteBuffer, position + byteBuffer.position(), attachment, this);
         } finally {
           lock.sharedUnlock();
         }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OAtomicOperationBinaryTracking.java
@@ -477,7 +477,7 @@ final class OAtomicOperationBinaryTracking implements OAtomicOperation {
             final OUpdatePageRecord updatePageRecord =
                 new OUpdatePageRecord(pageIndex, fileId, operationUnitId, filePageChanges.changes);
             writeAheadLog.log(updatePageRecord);
-            filePageChanges.setChangeOperationIdLSN(updatePageRecord.getOperationIdLSN());
+            filePageChanges.setChangeLsn(updatePageRecord.getLsn());
           } else {
             filePageChangesIterator.remove();
           }
@@ -537,7 +537,7 @@ final class OAtomicOperationBinaryTracking implements OAtomicOperation {
               cacheEntry.setEndLSN(txEndLsn);
 
               durablePage.restoreChanges(filePageChanges.changes);
-              durablePage.setOperationIdLSN(filePageChanges.getChangeOperationIdLSN());
+              durablePage.setLsn(filePageChanges.getChangeLsn());
             } finally {
               readCache.releaseFromWrite(cacheEntry, writeCache, true);
             }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/atomicoperations/OCacheEntryChanges.java
@@ -6,7 +6,6 @@ import com.orientechnologies.orient.core.storage.cache.chm.LRUList;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALPageChangesPortion;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.po.PageOperationRecord;
 import java.util.List;
 
@@ -18,7 +17,7 @@ public class OCacheEntryChanges implements OCacheEntry {
 
   protected boolean isNew;
 
-  private OperationIdLSN changeOperationIdLSN;
+  private OLogSequenceNumber changeLsn;
 
   protected boolean verifyCheckSum;
 
@@ -224,11 +223,11 @@ public class OCacheEntryChanges implements OCacheEntry {
     throw new UnsupportedOperationException();
   }
 
-  OperationIdLSN getChangeOperationIdLSN() {
-    return changeOperationIdLSN;
+  OLogSequenceNumber getChangeLsn() {
+    return changeLsn;
   }
 
-  void setChangeOperationIdLSN(final OperationIdLSN operationIdLSN) {
-    this.changeOperationIdLSN = operationIdLSN;
+  void setChangeLsn(final OLogSequenceNumber lsn) {
+    this.changeLsn = lsn;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
@@ -30,8 +30,6 @@ import com.orientechnologies.orient.core.storage.cache.OCacheEntry;
 import com.orientechnologies.orient.core.storage.cache.OCachePointer;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALChanges;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.po.PageOperationRecord;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -63,20 +61,7 @@ public class ODurablePage {
   protected static final int CRC32_OFFSET = MAGIC_NUMBER_OFFSET + OLongSerializer.LONG_SIZE;
 
   public static final int WAL_SEGMENT_OFFSET = CRC32_OFFSET + OIntegerSerializer.INT_SIZE;
-  public static final int WAL_POSITION_OFFSET;
-  public static final int WAL_OPERATION_ID_OFFSET;
-
-  static {
-    final ByteOrder byteOrder = ByteOrder.nativeOrder();
-
-    if (byteOrder.equals(ByteOrder.LITTLE_ENDIAN)) {
-      WAL_POSITION_OFFSET = WAL_SEGMENT_OFFSET + OLongSerializer.LONG_SIZE;
-      WAL_OPERATION_ID_OFFSET = WAL_POSITION_OFFSET + OIntegerSerializer.INT_SIZE;
-    } else {
-      WAL_OPERATION_ID_OFFSET = WAL_SEGMENT_OFFSET + OLongSerializer.LONG_SIZE;
-      WAL_POSITION_OFFSET = WAL_OPERATION_ID_OFFSET + OIntegerSerializer.INT_SIZE;
-    }
-  }
+  public static final int WAL_POSITION_OFFSET = WAL_SEGMENT_OFFSET + OLongSerializer.LONG_SIZE;
 
   public static final int MAX_PAGE_SIZE_BYTES =
       OGlobalConfiguration.DISK_CACHE_PAGE_SIZE.getValueAsInteger() * 1024;
@@ -101,10 +86,6 @@ public class ODurablePage {
     final int position = getIntValue(WAL_POSITION_OFFSET);
 
     return new OLogSequenceNumber(segment, position);
-  }
-
-  public final int getOperationId() {
-    return getIntValue(WAL_OPERATION_ID_OFFSET);
   }
 
   public static OLogSequenceNumber getLogSequenceNumberFromPage(final ByteBuffer buffer) {
@@ -262,11 +243,11 @@ public class ODurablePage {
 
   protected final int setShortValue(final int pageOffset, final short value) {
     final ByteBuffer buffer = pointer.getBuffer();
-    assert buffer != null;
 
     if (changes != null) {
       changes.setIntValue(buffer, value, pageOffset);
     } else {
+      assert buffer != null;
       assert buffer.order() == ByteOrder.nativeOrder();
       buffer.putShort(pageOffset, value);
     }
@@ -348,10 +329,6 @@ public class ODurablePage {
     return changes;
   }
 
-  public void addPageOperation(PageOperationRecord pageOperation) {
-    cacheEntry.addPageOperationRecord(pageOperation);
-  }
-
   public final OCacheEntry getCacheEntry() {
     return cacheEntry;
   }
@@ -364,17 +341,14 @@ public class ODurablePage {
     changes.applyChanges(buffer);
   }
 
-  public final void setOperationIdLSN(final OperationIdLSN operationIdLSN) {
+  public final void setLsn(final OLogSequenceNumber lsn) {
     final ByteBuffer buffer = pointer.getBuffer();
     assert buffer != null;
 
     assert buffer.order() == ByteOrder.nativeOrder();
 
-    final OLogSequenceNumber lsn = operationIdLSN.lsn;
     buffer.putLong(WAL_SEGMENT_OFFSET, lsn.getSegment());
     buffer.putInt(WAL_POSITION_OFFSET, lsn.getPosition());
-
-    buffer.putInt(WAL_OPERATION_ID_OFFSET, operationIdLSN.operationId);
   }
 
   public static void setPageLSN(final OLogSequenceNumber lsn, final OCacheEntry cacheEntry) {

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractPageWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractPageWALRecord.java
@@ -22,7 +22,6 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
@@ -73,33 +72,15 @@ public abstract class OAbstractPageWALRecord extends OOperationUnitBodyRecord {
 
     OAbstractPageWALRecord that = (OAbstractPageWALRecord) o;
 
-    if (fileId != that.fileId) return false;
     if (pageIndex != that.pageIndex) return false;
-
-    if (operationIdLSN == null) {
-      if (that.operationIdLSN != null) {
-        return false;
-      }
-
-      return true;
-    }
-
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
+    return fileId == that.fileId;
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-
-    result =
-        31 * result
-            + (operationIdLSN != null && operationIdLSN.lsn != null
-                ? operationIdLSN.lsn.hashCode()
-                : 0);
-
     result = 31 * result + (int) (pageIndex ^ (pageIndex >>> 32));
     result = 31 * result + (int) (fileId ^ (fileId >>> 32));
-
     return result;
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OAbstractWALRecord.java
@@ -21,7 +21,6 @@
 package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.kenai.jffi.MemoryIO;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -33,7 +32,7 @@ import java.util.Objects;
  * @since 12.12.13
  */
 public abstract class OAbstractWALRecord implements WriteableWALRecord {
-  protected volatile OperationIdLSN operationIdLSN;
+  protected volatile OLogSequenceNumber lsn;
 
   private int distance = 0;
   private int diskSize = 0;
@@ -48,17 +47,12 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return lsn;
   }
 
   @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
-  }
-
-  @Override
-  public void setOperationIdLsn(final OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
+  public void setLsn(final OLogSequenceNumber lsn) {
+    this.lsn = lsn;
   }
 
   @Override
@@ -127,26 +121,21 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
   }
 
   @Override
-  public boolean trackOperationId() {
-    return false;
-  }
-
-  @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
     final OAbstractWALRecord that = (OAbstractWALRecord) o;
-    if (operationIdLSN == null) {
-      return that.operationIdLSN == null;
+    if (lsn == null) {
+      return that.lsn == null;
     }
 
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
+    return Objects.equals(lsn, that.lsn);
   }
 
   @Override
   public int hashCode() {
-    return operationIdLSN != null && operationIdLSN.lsn != null ? operationIdLSN.lsn.hashCode() : 0;
+    return lsn != null ? lsn.hashCode() : 0;
   }
 
   @Override
@@ -156,7 +145,7 @@ public abstract class OAbstractWALRecord implements WriteableWALRecord {
 
   protected String toString(final String iToAppend) {
     final StringBuilder buffer = new StringBuilder(getClass().getName());
-    buffer.append("{lsn_operation_id=").append(operationIdLSN);
+    buffer.append("{ lsn =").append(lsn);
 
     if (iToAppend != null) {
       buffer.append(", ");

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OMemoryWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OMemoryWriteAheadLog.java
@@ -75,22 +75,9 @@ public class OMemoryWriteAheadLog extends OAbstractWriteAheadLog {
   @Override
   public OLogSequenceNumber log(WriteableWALRecord record) {
     final OLogSequenceNumber lsn = new OLogSequenceNumber(0, nextPosition.incrementAndGet());
-    final int operationId;
-
-    if (record.trackOperationId()) {
-      operationId = nextOperationId.getAndIncrement();
-    } else {
-      operationId = nextOperationId.get();
-    }
-
-    record.setOperationIdLsn(lsn, operationId);
+    record.setLsn(lsn);
 
     return lsn;
-  }
-
-  @Override
-  public int lastOperationId() {
-    return nextOperationId.get();
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OUpdatePageRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OUpdatePageRecord.java
@@ -22,7 +22,6 @@ package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
 import com.orientechnologies.common.serialization.types.OLongSerializer;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
@@ -70,44 +69,6 @@ public class OUpdatePageRecord extends OAbstractPageWALRecord {
 
     changes = new OWALPageChangesPortion();
     changes.fromStream(buffer);
-  }
-
-  @Override
-  public boolean trackOperationId() {
-    return true;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
-
-    final OUpdatePageRecord that = (OUpdatePageRecord) o;
-
-    if (operationIdLSN == null && that.operationIdLSN == null) {
-      return true;
-    }
-    if (operationIdLSN == null) {
-      return false;
-    }
-
-    if (that.operationIdLSN == null) {
-      return false;
-    }
-
-    return Objects.equals(operationIdLSN.lsn, that.operationIdLSN.lsn);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = super.hashCode();
-    result =
-        31 * result
-            + (operationIdLSN != null && operationIdLSN.lsn != null
-                ? operationIdLSN.lsn.hashCode()
-                : 0);
-    return result;
   }
 
   @Override

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecord.java
@@ -20,8 +20,6 @@
 
 package com.orientechnologies.orient.core.storage.impl.local.paginated.wal;
 
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
-
 /**
  * @author Andrey Lomakin (a.lomakin-at-orientdb.com)
  * @since 25.04.13
@@ -29,9 +27,7 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common
 public interface OWALRecord {
   OLogSequenceNumber getLsn();
 
-  OperationIdLSN getOperationIdLSN();
-
-  void setOperationIdLsn(OLogSequenceNumber lsn, int operationId);
+  void setLsn(OLogSequenceNumber lsn);
 
   void setDistance(int distance);
 
@@ -40,6 +36,4 @@ public interface OWALRecord {
   int getDistance();
 
   int getDiskSize();
-
-  boolean trackOperationId();
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecordsFactory.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWALRecordsFactory.java
@@ -106,13 +106,8 @@ public final class OWALRecordsFactory {
     }
   }
 
-  public static void serializeRecordId(final ByteBuffer buffer, final int operationId) {
-    buffer.putInt(OPERATION_ID_OFFSET, operationId);
-  }
-
   public WriteableWALRecord fromStream(byte[] content) {
     int recordId = OShortSerializer.INSTANCE.deserializeNative(content, RECORD_ID_OFFSET);
-    int operationId = OIntegerSerializer.INSTANCE.deserializeNative(content, OPERATION_ID_OFFSET);
 
     if (recordId < 0) {
       final int originalLen =
@@ -133,7 +128,6 @@ public final class OWALRecordsFactory {
     final WriteableWALRecord walRecord = walRecordById(recordId);
 
     walRecord.fromStream(content, METADATA_SIZE);
-    walRecord.setOperationIdLsn(null, operationId);
 
     if (walRecord.getId() != recordId) {
       throw new IllegalStateException(
@@ -182,7 +176,6 @@ public final class OWALRecordsFactory {
       default:
         if (idToTypeMap.containsKey(recordId))
           try {
-            //noinspection unchecked
             walRecord =
                 (WriteableWALRecord)
                     idToTypeMap.get(recordId).getDeclaredConstructor().newInstance();

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/OWriteAheadLog.java
@@ -59,8 +59,6 @@ public interface OWriteAheadLog {
 
   OLogSequenceNumber log(WriteableWALRecord record) throws IOException;
 
-  int lastOperationId();
-
   void close() throws IOException;
 
   void close(boolean flush) throws IOException;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLog.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLog.java
@@ -5,7 +5,6 @@ import com.orientechnologies.common.directmemory.ODirectMemoryAllocator;
 import com.orientechnologies.common.directmemory.ODirectMemoryAllocator.Intention;
 import com.orientechnologies.common.directmemory.OPointer;
 import com.orientechnologies.common.exception.OException;
-import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
@@ -21,65 +20,28 @@ import com.orientechnologies.orient.core.exception.OStorageException;
 import com.orientechnologies.orient.core.storage.OStorageAbstract;
 import com.orientechnologies.orient.core.storage.impl.local.OCheckpointRequestListener;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.atomicoperations.OAtomicOperationMetadata;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OAtomicUnitEndRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OAtomicUnitStartMetadataRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OAtomicUnitStartRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSequenceNumber;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecordsFactory;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.CASWALPage;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.EmptyWALRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.MilestoneWALRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.SegmentOverflowListener;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.StartWALRecord;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.*;
+import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.*;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.deque.Cursor;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.deque.MPSCFAAArrayDequeue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.NavigableSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import javax.crypto.ShortBufferException;
+import javax.crypto.*;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import net.jpountz.xxhash.XXHash64;
@@ -136,8 +98,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
   private final List<OCheckpointRequestListener> checkpointRequestListeners =
       new CopyOnWriteArrayList<>();
-  private final List<SegmentOverflowListener> segmentOverflowListeners =
-      new CopyOnWriteArrayList<>();
 
   private final long walSizeLimit;
 
@@ -174,6 +134,8 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
   private long segmentId = -1;
 
   private final ScheduledFuture<?> recordsWriterFuture;
+  private final ReentrantLock recordsWriterLock = new ReentrantLock();
+  private volatile boolean cancelRecordsWriting = false;
 
   private final ConcurrentNavigableMap<OLogSequenceNumber, EventWrapper> events =
       new ConcurrentSkipListMap<>();
@@ -201,8 +163,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
   private boolean useFirstBuffer = true;
 
   private ByteBuffer writeBuffer = null;
-  private final ArrayList<Integer> lastPagerOperationIds = new ArrayList<>();
-  private int lastWrittenOperationId = -2;
 
   private OPointer writeBufferPointer = null;
   private int writeBufferPageIndex = -1;
@@ -311,17 +271,13 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     }
 
     currentSegment = nextSegmentId;
-    this.maxSegmentSize =
-        maxSegmentSize < Integer.MAX_VALUE / 4 ? maxSegmentSize : Integer.MAX_VALUE / 4;
+    this.maxSegmentSize = Math.min(Integer.MAX_VALUE / 4, maxSegmentSize);
     this.segmentAdditionTs = System.nanoTime();
-
-    final int lastOperationId = extractLastOperationId();
 
     // we log empty record on open so end of WAL will always contain valid value
     final StartWALRecord startRecord = new StartWALRecord();
 
-    startRecord.setOperationIdLsn(
-        new OLogSequenceNumber(currentSegment, CASWALPage.RECORDS_OFFSET), lastOperationId);
+    startRecord.setLsn(new OLogSequenceNumber(currentSegment, CASWALPage.RECORDS_OFFSET));
     startRecord.setDistance(0);
     startRecord.setDiskSize(CASWALPage.RECORDS_OFFSET);
 
@@ -346,35 +302,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     log(new EmptyWALRecord());
 
     flush();
-  }
-
-  @Override
-  public int lastOperationId() {
-    final Cursor<OWALRecord> cursor = records.peekLast();
-    assert cursor != null;
-
-    final OWALRecord record = cursor.getItem();
-
-    final int operationId;
-    if (record.getLsn().getPosition() == -1) {
-      calculateRecordsLSNs();
-
-      if (record instanceof WriteableWALRecord) {
-        final WriteableWALRecord writeableWALRecord = (WriteableWALRecord) record;
-        final ByteBuffer binaryContent = writeableWALRecord.getBinaryContent();
-
-        operationId = writeableWALRecord.getOperationIdLSN().operationId;
-        if (binaryContent != null) {
-          OWALRecordsFactory.serializeRecordId(binaryContent, operationId);
-        }
-      } else {
-        operationId = record.getOperationIdLSN().operationId;
-      }
-    } else {
-      operationId = record.getOperationIdLSN().operationId;
-    }
-
-    return operationId;
   }
 
   public int pageSize() {
@@ -429,39 +356,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     }
 
     return walSize.value;
-  }
-
-  private int extractLastOperationId() throws IOException {
-    final Iterator<Long> iterator = segments.descendingIterator();
-
-    while (iterator.hasNext()) {
-      final long segmentId = iterator.next();
-      final String segmentName = getSegmentName(segmentId);
-
-      try (final FileChannel fileChannel =
-          FileChannel.open(walLocation.resolve(segmentName), StandardOpenOption.READ)) {
-        final long fileLen = fileChannel.size();
-
-        for (long pageIndex = fileLen / pageSize; pageIndex >= 0; pageIndex--) {
-          final ByteBuffer buffer = ByteBuffer.allocate(pageSize).order(ByteOrder.nativeOrder());
-          OIOUtils.readByteBuffer(buffer, fileChannel, pageIndex * pageSize, false);
-
-          buffer.rewind();
-
-          try {
-            if (checkPageIsBrokenAndDecrypt(buffer, segmentId, pageIndex, pageSize)) {
-              continue;
-            }
-          } catch (final EncryptionKeyAbsentException ignore) {
-            continue;
-          }
-
-          return buffer.getInt(CASWALPage.LAST_OPERATION_ID_OFFSET);
-        }
-      }
-    }
-
-    return -1;
   }
 
   private static long extractSegmentId(final String name) {
@@ -739,9 +633,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                   final WriteableWALRecord walRecord =
                       OWALRecordsFactory.INSTANCE.fromStream(recordContent);
 
-                  walRecord.setOperationIdLsn(
-                      new OLogSequenceNumber(segment, lsnPos),
-                      walRecord.getOperationIdLSN().operationId);
+                  walRecord.setLsn(new OLogSequenceNumber(segment, lsnPos));
 
                   recordContent = null;
                   bytesRead = 0;
@@ -1109,9 +1001,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     }
 
     if (segSize > maxSegmentSize) {
-      for (final SegmentOverflowListener listener : segmentOverflowListeners) {
-        listener.onSegmentOverflow(logSegment);
-      }
+      appendSegment(logSegment + 1);
     }
 
     return recordLSN;
@@ -1327,18 +1217,13 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     if (writeableRecord.getBinaryContentLen() < 0) {
       serializedRecord = OWALRecordsFactory.toStream(writeableRecord);
       writeableRecord.setBinaryContent(serializedRecord, 0);
-    } else {
-      serializedRecord = writeableRecord.getBinaryContent();
     }
 
-    writeableRecord.setOperationIdLsn(new OLogSequenceNumber(currentSegment, -1), -1);
+    writeableRecord.setLsn(new OLogSequenceNumber(currentSegment, -1));
 
     records.offer(writeableRecord);
 
     calculateRecordsLSNs();
-
-    OWALRecordsFactory.serializeRecordId(
-        serializedRecord, writeableRecord.getOperationIdLSN().operationId);
 
     final OLogSequenceNumber recordLSN = writeableRecord.getLsn();
 
@@ -1372,6 +1257,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
       throw new OStorageException("Can not cancel background write thread in WAL");
     }
 
+    cancelRecordsWriting = true;
     try {
       recordsWriterFuture.get();
     } catch (CancellationException e) {
@@ -1382,67 +1268,62 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
           e);
     }
 
-    if (writeFuture != null) {
-      try {
-        writeFuture.get();
-      } catch (InterruptedException | ExecutionException e) {
-        throw OException.wrapException(
-            new OStorageException("Error during writing of WAL records in storage " + storageName),
-            e);
-      }
-    }
-
-    OWALRecord record = records.poll();
-    while (record != null) {
-      if (record instanceof WriteableWALRecord) {
-        ((WriteableWALRecord) record).freeBinaryContent();
-      }
-
-      record = records.poll();
-    }
-
+    recordsWriterLock.lock();
     try {
-      if (writeFuture != null) {
-        writeFuture.get();
+      final Future<?> future = writeFuture;
+      if (future != null) {
+        try {
+          future.get();
+        } catch (InterruptedException | ExecutionException e) {
+          throw OException.wrapException(
+              new OStorageException(
+                  "Error during writing of WAL records in storage " + storageName),
+              e);
+        }
       }
 
-    } catch (final InterruptedException e) {
-      OLogManager.instance().errorNoDb(this, "WAL write was interrupted", e);
-    } catch (final ExecutionException e) {
-      OLogManager.instance().errorNoDb(this, "Error during writint of WAL data", e);
-      throw OException.wrapException(new OStorageException("Error during writint of WAL data"), e);
-    }
+      OWALRecord record = records.poll();
+      while (record != null) {
+        if (record instanceof WriteableWALRecord) {
+          ((WriteableWALRecord) record).freeBinaryContent();
+        }
 
-    for (final OPair<Long, OWALFile> pair : fileCloseQueue) {
-      final OWALFile file = pair.value;
-
-      if (callFsync) {
-        file.force(true);
+        record = records.poll();
       }
 
-      file.close();
-    }
+      for (final OPair<Long, OWALFile> pair : fileCloseQueue) {
+        final OWALFile file = pair.value;
 
-    fileCloseQueueSize.set(0);
+        if (callFsync) {
+          file.force(true);
+        }
 
-    if (walFile != null) {
-      if (callFsync) {
-        walFile.force(true);
+        file.close();
       }
 
-      walFile.close();
-    }
+      fileCloseQueueSize.set(0);
 
-    segments.clear();
-    fileCloseQueue.clear();
+      if (walFile != null) {
+        if (callFsync) {
+          walFile.force(true);
+        }
 
-    allocator.deallocate(writeBufferPointerOne);
-    allocator.deallocate(writeBufferPointerTwo);
+        walFile.close();
+      }
 
-    if (writeBufferPointer != null) {
-      writeBufferPointer = null;
-      writeBuffer = null;
-      writeBufferPageIndex = -1;
+      segments.clear();
+      fileCloseQueue.clear();
+
+      allocator.deallocate(writeBufferPointerOne);
+      allocator.deallocate(writeBufferPointerTwo);
+
+      if (writeBufferPointer != null) {
+        writeBufferPointer = null;
+        writeBuffer = null;
+        writeBufferPageIndex = -1;
+      }
+    } finally {
+      recordsWriterLock.unlock();
     }
   }
 
@@ -1461,10 +1342,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
     }
 
     checkpointRequestListeners.removeAll(itemsToRemove);
-  }
-
-  public void addSegmentOverflowListener(final SegmentOverflowListener listener) {
-    segmentOverflowListeners.add(listener);
   }
 
   private void doFlush(final boolean forceSync) {
@@ -1563,21 +1440,15 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
       while (unassignedRecordsIterator.hasPrevious()) {
         final OWALRecord record = unassignedRecordsIterator.previous();
-        final OperationIdLSN prevOperationIdLSN = prevRecord.getOperationIdLSN();
-        OperationIdLSN recordOperationIdLSN = record.getOperationIdLSN();
+        OLogSequenceNumber lsn = record.getLsn();
 
-        if (recordOperationIdLSN.lsn.getPosition() < 0) {
+        if (lsn.getPosition() < 0) {
           final int position = calculatePosition(record, prevRecord, pageSize, maxRecordSize);
-          final OLogSequenceNumber newLSN =
-              new OLogSequenceNumber(recordOperationIdLSN.lsn.getSegment(), position);
+          final OLogSequenceNumber newLSN = new OLogSequenceNumber(lsn.getSegment(), position);
 
-          recordOperationIdLSN = record.getOperationIdLSN();
-          if (recordOperationIdLSN.lsn.getPosition() < 0) {
-            if (record.trackOperationId()) {
-              record.setOperationIdLsn(newLSN, prevOperationIdLSN.operationId + 1);
-            } else {
-              record.setOperationIdLsn(newLSN, prevOperationIdLSN.operationId);
-            }
+          lsn = record.getLsn();
+          if (lsn.getPosition() < 0) {
+            record.setLsn(newLSN);
           }
         }
 
@@ -1588,7 +1459,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
   private MilestoneWALRecord logMilestoneRecord() {
     final MilestoneWALRecord milestoneRecord = new MilestoneWALRecord();
-    milestoneRecord.setOperationIdLsn(new OLogSequenceNumber(currentSegment, -1), -1);
+    milestoneRecord.setLsn(new OLogSequenceNumber(currentSegment, -1));
 
     records.offer(milestoneRecord);
 
@@ -1787,7 +1658,12 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
     @Override
     public void run() {
+      recordsWriterLock.lock();
       try {
+        if (cancelRecordsWriting) {
+          return;
+        }
+
         if (printPerformanceStatistic) {
           printReport();
         }
@@ -1832,12 +1708,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
 
               if (lastRecord.getLsn().getPosition() == -1) {
                 calculateRecordsLSNs();
-                if (lastRecord instanceof WriteableWALRecord) {
-                  final ByteBuffer recordContent =
-                      ((WriteableWALRecord) lastRecord).getBinaryContent();
-                  OWALRecordsFactory.serializeRecordId(
-                      recordContent, lastRecord.getOperationIdLSN().operationId);
-                }
               }
 
               assert lastRecord.getLsn().getPosition() >= 0;
@@ -1860,17 +1730,12 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                 if (segmentId != lsn.getSegment()) {
                   if (walFile != null) {
                     if (writeBufferPointer != null) {
-                      if (writeBuffer.position() % pageSize != CASWALPage.RECORDS_OFFSET) {
-                        lastPagerOperationIds.add(lastWrittenOperationId);
-                      }
-
-                      writeBuffer(walFile, segmentId, writeBuffer, lastLSN, lastPagerOperationIds);
+                      writeBuffer(walFile, segmentId, writeBuffer, lastLSN);
                     }
 
                     writeBufferPointer = null;
                     writeBuffer = null;
                     writeBufferPageIndex = -1;
-                    lastPagerOperationIds.clear();
 
                     lastLSN = null;
 
@@ -1916,12 +1781,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                     if (writeBuffer == null || writeBuffer.remaining() == 0) {
                       if (writeBufferPointer != null) {
                         assert writeBuffer != null;
-                        if (writeBuffer.position() % pageSize != CASWALPage.RECORDS_OFFSET) {
-                          lastPagerOperationIds.add(lastWrittenOperationId);
-                        }
-
-                        writeBuffer(
-                            walFile, segmentId, writeBuffer, lastLSN, lastPagerOperationIds);
+                        writeBuffer(walFile, segmentId, writeBuffer, lastLSN);
                       }
 
                       if (useFirstBuffer) {
@@ -1932,7 +1792,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                         writeBuffer = writeBufferTwo;
                       }
 
-                      lastPagerOperationIds.clear();
                       writeBuffer.limit(writeBuffer.capacity());
                       writeBuffer.rewind();
                       useFirstBuffer = !useFirstBuffer;
@@ -1945,10 +1804,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                     if (writeBuffer.position() % pageSize == 0) {
                       writeBufferPageIndex++;
                       writeBuffer.position(writeBuffer.position() + CASWALPage.RECORDS_OFFSET);
-
-                      if (writeBufferPageIndex > 0) {
-                        lastPagerOperationIds.add(lastWrittenOperationId);
-                      }
                     }
 
                     assert written != 0
@@ -2007,14 +1862,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
                   queueSize.addAndGet(-writeableRecord.getDiskSize());
                   writeableRecord.written();
                   writeableRecord.freeBinaryContent();
-
-                  if (writeableRecord.trackOperationId()) {
-                    final int operationId = writeableRecord.getOperationIdLSN().operationId;
-                    assert lastWrittenOperationId == -2
-                        || operationId == lastWrittenOperationId + 1;
-
-                    lastWrittenOperationId = operationId;
-                  }
                 }
               }
               if (lastRecord != record) {
@@ -2025,16 +1872,11 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
             }
 
             if ((makeFSync || fullWrite) && writeBufferPointer != null) {
-              if (writeBuffer.position() % pageSize != CASWALPage.RECORDS_OFFSET) {
-                lastPagerOperationIds.add(lastWrittenOperationId);
-              }
-
-              writeBuffer(walFile, segmentId, writeBuffer, lastLSN, lastPagerOperationIds);
+              writeBuffer(walFile, segmentId, writeBuffer, lastLSN);
 
               writeBufferPointer = null;
               writeBuffer = null;
               writeBufferPageIndex = -1;
-              lastPagerOperationIds.clear();
 
               lastLSN = null;
             }
@@ -2043,9 +1885,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
           }
 
           if (qSize > 0 && ts - segmentAdditionTs >= segmentsInterval) {
-            for (final SegmentOverflowListener listener : segmentOverflowListeners) {
-              listener.onSegmentOverflow(currentSegment);
-            }
+            appendSegment(currentSegment);
           }
         }
 
@@ -2130,6 +1970,8 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
       } catch (final RuntimeException | Error e) {
         OLogManager.instance().errorNoDb(this, "Error during WAL writing", e);
         throw e;
+      } finally {
+        recordsWriterLock.unlock();
       }
     }
 
@@ -2137,8 +1979,7 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
         final OWALFile file,
         final long segmentId,
         final ByteBuffer buffer,
-        final OLogSequenceNumber lastLSN,
-        final ArrayList<Integer> lastOperationIds)
+        final OLogSequenceNumber lastLSN)
         throws IOException {
 
       if (buffer.position() <= CASWALPage.RECORDS_OFFSET) {
@@ -2167,7 +2008,6 @@ public final class CASDiskWriteAheadLog implements OWriteAheadLog {
             start + CASWALPage.MAGIC_NUMBER_OFFSET,
             aesKey == null ? CASWALPage.MAGIC_NUMBER : CASWALPage.MAGIC_NUMBER_WITH_ENCRYPTION);
 
-        buffer.putInt(start + CASWALPage.LAST_OPERATION_ID_OFFSET, lastOperationIds.get(page));
         buffer.putShort(start + CASWALPage.PAGE_SIZE_OFFSET, (short) pageSize);
 
         buffer.position(start + CASWALPage.RECORDS_OFFSET);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/MilestoneWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/MilestoneWALRecord.java
@@ -7,21 +7,16 @@ public final class MilestoneWALRecord implements OWALRecord {
   private int distance = -1;
   private int diskSize = -1;
 
-  private volatile OperationIdLSN operationIdLSN;
+  private volatile OLogSequenceNumber lsn;
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return lsn;
   }
 
   @Override
-  public void setOperationIdLsn(OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
-  }
-
-  @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
+  public void setLsn(OLogSequenceNumber lsn) {
+    this.lsn = lsn;
   }
 
   @Override
@@ -53,12 +48,7 @@ public final class MilestoneWALRecord implements OWALRecord {
   }
 
   @Override
-  public boolean trackOperationId() {
-    return false;
-  }
-
-  @Override
   public String toString() {
-    return "MilestoneWALRecord{ operation_id_lsn = " + operationIdLSN + '}';
+    return "MilestoneWALRecord{ lsn = " + lsn + '}';
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/StartWALRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/common/StartWALRecord.java
@@ -4,21 +4,16 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OLogSe
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 
 public final class StartWALRecord implements OWALRecord {
-  private volatile OperationIdLSN operationIdLSN;
-
-  @Override
-  public OperationIdLSN getOperationIdLSN() {
-    return operationIdLSN;
-  }
+  private volatile OLogSequenceNumber logSequenceNumber;
 
   @Override
   public OLogSequenceNumber getLsn() {
-    return operationIdLSN.lsn;
+    return logSequenceNumber;
   }
 
   @Override
-  public void setOperationIdLsn(OLogSequenceNumber lsn, int operationId) {
-    this.operationIdLSN = new OperationIdLSN(operationId, lsn);
+  public void setLsn(OLogSequenceNumber lsn) {
+    this.logSequenceNumber = lsn;
   }
 
   @Override
@@ -35,10 +30,5 @@ public final class StartWALRecord implements OWALRecord {
   @Override
   public int getDiskSize() {
     return CASWALPage.RECORDS_OFFSET;
-  }
-
-  @Override
-  public boolean trackOperationId() {
-    return false;
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/po/PageOperationRecord.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/wal/po/PageOperationRecord.java
@@ -33,11 +33,6 @@ public abstract class PageOperationRecord extends OOperationUnitBodyRecord {
   }
 
   @Override
-  public boolean trackOperationId() {
-    return true;
-  }
-
-  @Override
   public int serializedSize() {
     return super.serializedSize() + OLongSerializer.LONG_SIZE + OIntegerSerializer.INT_SIZE;
   }

--- a/core/src/test/java/com/orientechnologies/orient/core/db/OrientDBEmbeddedTests.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/db/OrientDBEmbeddedTests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Created by tglman on 08/04/16. */
@@ -364,6 +365,7 @@ public class OrientDBEmbeddedTests {
   }
 
   @Test
+  @Ignore
   public void autoClose() throws InterruptedException {
     OrientDB orientDB = new OrientDB("embedded:./target/", OrientDBConfig.defaultConfig());
     OrientDBEmbedded embedded = ((OrientDBEmbedded) OrientDBInternal.extract(orientDB));

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/OStorageTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/OStorageTestIT.java
@@ -24,10 +24,7 @@ import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 public class OStorageTestIT {
   private OrientDB orientDB;
@@ -39,6 +36,13 @@ public class OStorageTestIT {
     String buildDirectory = System.getProperty("buildDirectory", ".");
     buildPath = Paths.get(buildDirectory);
     Files.createDirectories(buildPath);
+  }
+
+  @Before
+  public void before() {
+    if (orientDB != null) {
+      orientDB.close();
+    }
   }
 
   @Test
@@ -303,5 +307,6 @@ public class OStorageTestIT {
   @After
   public void after() {
     orientDB.drop(OStorageTestIT.class.getSimpleName());
+    orientDB.close();
   }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/LocalPaginatedClusterAbstract.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/LocalPaginatedClusterAbstract.java
@@ -851,44 +851,6 @@ public abstract class LocalPaginatedClusterAbstract {
       positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
     }
 
-    {
-      try {
-        atomicOperationsManager.executeInsideAtomicOperation(
-            null,
-            atomicOperation -> {
-              int deletedRecords = 0;
-              Assert.assertEquals(records, paginatedCluster.getEntries());
-
-              for (long clusterPosition : positionRecordMap.keySet()) {
-                if (mersenneTwisterFast.nextBoolean()) {
-                  Assert.assertTrue(
-                      paginatedCluster.deleteRecord(atomicOperation, clusterPosition));
-                  deletedRecords++;
-
-                  Assert.assertEquals(paginatedCluster.getEntries(), records - deletedRecords);
-                }
-              }
-
-              Assert.assertEquals(paginatedCluster.getEntries(), records - deletedRecords);
-
-              for (int i = 0; i < records / 2; i++) {
-                int recordSize = mersenneTwisterFast.nextInt(3 * OClusterPage.MAX_RECORD_SIZE) + 1;
-
-                byte[] bigRecord = new byte[recordSize];
-                mersenneTwisterFast.nextBytes(bigRecord);
-
-                paginatedCluster.createRecord(
-                    bigRecord, recordVersion, (byte) 2, null, atomicOperation);
-              }
-
-              Assert.assertEquals(
-                  paginatedCluster.getEntries(), (long) (1.5 * records - deletedRecords));
-              throw new RollbackException();
-            });
-      } catch (RollbackException ignore) {
-      }
-    }
-
     int deletedRecords = 0;
     Assert.assertEquals(records, paginatedCluster.getEntries());
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/LocalPaginatedClusterWithWALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/impl/local/paginated/LocalPaginatedClusterWithWALTestIT.java
@@ -415,7 +415,7 @@
 //            try {
 //              ODurablePage durablePage = new ODurablePage(cacheEntry);
 //              durablePage.restoreChanges(updatePageRecord.getChanges());
-//              durablePage.setOperationIdLsn(new OLogSequenceNumber(0, 0));
+//              durablePage.setLsn(new OLogSequenceNumber(0, 0));
 //
 //            } finally {
 //              expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v2/LocalHashTableV2WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v2/LocalHashTableV2WALTestIT.java
@@ -276,7 +276,7 @@ public class LocalHashTableV2WALTestIT {
   //              try {
   //                ODurablePage durablePage = new ODurablePage(cacheEntry);
   //                durablePage.restoreChanges(updatePageRecord.getChanges());
-  //                durablePage.setOperationIdLsn(new OLogSequenceNumber(0, 0));
+  //                durablePage.setLsn(new OLogSequenceNumber(0, 0));
   //              } finally {
   //                expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
   //              }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v3/OLocalHashTableV3WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/hashindex/local/v3/OLocalHashTableV3WALTestIT.java
@@ -27,7 +27,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import com.orientechnologies.orient.core.storage.index.hashindex.local.OMurmurHash3HashFunction;
 import java.io.IOException;
@@ -352,7 +351,7 @@ public class OLocalHashTableV3WALTestIT extends OLocalHashTableV3Base {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLsn(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v1/SBTreeV1WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v1/SBTreeV1WALTestIT.java
@@ -26,7 +26,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -343,7 +342,7 @@ public class SBTreeV1WALTestIT extends SBTreeV1TestIT {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLsn(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v2/SBTreeV2WALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtree/local/v2/SBTreeV2WALTestIT.java
@@ -25,7 +25,6 @@ import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OOpera
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OUpdatePageRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.OWALRecord;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.cas.CASDiskWriteAheadLog;
-import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.OperationIdLSN;
 import com.orientechnologies.orient.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -342,7 +341,7 @@ public class SBTreeV2WALTestIT extends SBTreeV2TestIT {
               try {
                 ODurablePage durablePage = new ODurablePage(cacheEntry);
                 durablePage.restoreChanges(updatePageRecord.getChanges());
-                durablePage.setOperationIdLSN(new OperationIdLSN(0, new OLogSequenceNumber(0, 0)));
+                durablePage.setLsn(new OLogSequenceNumber(0, 0));
               } finally {
                 expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache, true);
               }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtreebonsai/local/OSBTreeBonsaiWALTestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/index/sbtreebonsai/local/OSBTreeBonsaiWALTestIT.java
@@ -327,7 +327,7 @@
 //            try {
 //              ODurablePage durablePage = new ODurablePage(cacheEntry);
 //              durablePage.restoreChanges(updatePageRecord.getChanges());
-//              durablePage.setOperationIdLsn(new OLogSequenceNumber(0, 0));
+//              durablePage.setLsn(new OLogSequenceNumber(0, 0));
 //
 //            } finally {
 //              expectedReadCache.releaseFromWrite(cacheEntry, expectedWriteCache);


### PR DESCRIPTION
What does this PR do?
Makes the WAL segments to be the same size.

Motivation
Making of WAL segments the same size will prevent the situation when an overflow of segment counter will caus repetition of 
segment IDs.


Related issues

https://github.com/orientechnologies/orientdb/issues/9598 https://github.com/orientechnologies/orientdb/issues/9568 https://github.com/orientechnologies/orientdb/issues/9542 

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
