### PR TITLE
fix(9700) : Fix inifite loop on tracking/untracking element

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordInternal.java
@@ -149,18 +149,22 @@ public class ORecordInternal {
 
   public static void track(final ORecordElement pointer, final OIdentifiable pointed) {
     ORecordElement firstRecord = pointer;
-    while (!(firstRecord instanceof ORecord)) {
-      firstRecord = pointer.getOwner();
+    while (firstRecord != null && !(firstRecord instanceof ORecord)) {
+      firstRecord = firstRecord.getOwner();
     }
-    ((ORecordAbstract) firstRecord).track(pointed);
+    if (firstRecord instanceof ORecordAbstract) {
+      ((ORecordAbstract) firstRecord).track(pointed);
+    }
   }
 
   public static void unTrack(final ORecordElement pointer, final OIdentifiable pointed) {
     ORecordElement firstRecord = pointer;
-    while (!(firstRecord instanceof ORecord)) {
-      firstRecord = pointer.getOwner();
+    while (firstRecord != null && !(firstRecord instanceof ORecord)) {
+      firstRecord = firstRecord.getOwner();
     }
-    ((ORecordAbstract) firstRecord).unTrack(pointed);
+    if (firstRecord instanceof ORecordAbstract) {
+      ((ORecordAbstract) firstRecord).unTrack(pointed);
+    }
   }
 
   public static ORecordSerializer getRecordSerializer(ORecord iRecord) {


### PR DESCRIPTION
What does this PR do?
It fixes a blocking issue when importing a database exported from 3.2.07 to 3.2.0.
The import runs infinitely until timeout.
The cause is an infinite loop at the modified class: methods track and untrack

Motivation
Regression.

Related issues
https://github.com/orientechnologies/orientdb/issues/9700



Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
