### PR TITLE
Fix illegal memory access in Unsafe byte array comparator.

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/comparator/OUnsafeByteArrayComparator.java
+++ b/core/src/main/java/com/orientechnologies/common/comparator/OUnsafeByteArrayComparator.java
@@ -50,19 +50,15 @@ public class OUnsafeByteArrayComparator implements Comparator<byte[]> {
     unsafe =
         (Unsafe)
             AccessController.doPrivileged(
-                new PrivilegedAction<Object>() {
-                  public Object run() {
-                    try {
-                      Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                      f.setAccessible(true);
-                      return f.get(null);
-                    } catch (NoSuchFieldException e) {
-                      throw new Error(e);
-                    } catch (IllegalAccessException e) {
-                      throw new Error(e);
-                    }
-                  }
-                });
+                    (PrivilegedAction<Object>) () -> {
+                      try {
+                        Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                        f.setAccessible(true);
+                        return f.get(null);
+                      } catch (NoSuchFieldException | IllegalAccessException e) {
+                        throw new Error(e);
+                      }
+                    });
 
     BYTE_ARRAY_OFFSET = unsafe.arrayBaseOffset(byte[].class);
 
@@ -72,11 +68,8 @@ public class OUnsafeByteArrayComparator implements Comparator<byte[]> {
   }
 
   public int compare(byte[] arrayOne, byte[] arrayTwo) {
-    if (arrayOne.length > arrayTwo.length) return 1;
-
-    if (arrayOne.length < arrayTwo.length) return -1;
-
-    final int WORDS = arrayOne.length / LONG_SIZE;
+    final int commonLen = Math.min(arrayOne.length, arrayTwo.length);
+    final int WORDS = commonLen / LONG_SIZE;
 
     for (int i = 0; i < WORDS * LONG_SIZE; i += LONG_SIZE) {
       final long index = i + BYTE_ARRAY_OFFSET;
@@ -92,12 +85,12 @@ public class OUnsafeByteArrayComparator implements Comparator<byte[]> {
       return lessThanUnsigned(wOne, wTwo) ? -1 : 1;
     }
 
-    for (int i = WORDS * LONG_SIZE; i < arrayOne.length; i++) {
+    for (int i = WORDS * LONG_SIZE; i < commonLen; i++) {
       int diff = compareUnsignedByte(arrayOne[i], arrayTwo[i]);
       if (diff != 0) return diff;
     }
 
-    return 0;
+    return Integer.compare(arrayOne.length, arrayTwo.length);
   }
 
   private static boolean lessThanUnsigned(long longOne, long longTwo) {

--- a/core/src/test/java/com/orientechnologies/common/comparator/UnsafeComparatorTest.java
+++ b/core/src/test/java/com/orientechnologies/common/comparator/UnsafeComparatorTest.java
@@ -10,8 +10,7 @@ import org.junit.Test;
  * @since 11.07.12
  */
 public class UnsafeComparatorTest {
-  private OUnsafeByteArrayComparator comparator = OUnsafeByteArrayComparator.INSTANCE;
-  private OUnsafeByteArrayComparatorV2 comparatorV2 = OUnsafeByteArrayComparatorV2.INSTANCE;
+  private final OUnsafeByteArrayComparator comparator = OUnsafeByteArrayComparator.INSTANCE;
 
   @Test
   public void testOneByteArray() {
@@ -19,7 +18,6 @@ public class UnsafeComparatorTest {
     final byte[] keyTwo = new byte[] {2};
 
     assertCompareTwoKeys(comparator, keyOne, keyTwo);
-    assertCompareTwoKeys(comparatorV2, keyOne, keyTwo);
   }
 
   @Test
@@ -28,7 +26,6 @@ public class UnsafeComparatorTest {
     final byte[] keyTwo = new byte[] {1, 0, 0, 0, 0, 0, 0, 0};
 
     assertCompareTwoKeys(comparator, keyOne, keyTwo);
-    assertCompareTwoKeys(comparatorV2, keyOne, keyTwo);
   }
 
   @Test
@@ -37,13 +34,24 @@ public class UnsafeComparatorTest {
     final byte[] keyTwo = new byte[] {1, 1, 0, 0, 0, 0, 0, 0, 1};
 
     assertCompareTwoKeys(comparator, keyOne, keyTwo);
-    assertCompareTwoKeys(comparatorV2, keyOne, keyTwo);
+  }
+
+  @Test
+  public void testOneArraySmallerThanOther() {
+    final byte[] keyOne =
+        new byte[] {
+          1, 1, 0, 0, 1, 0,
+        };
+    final byte[] keyTwo = new byte[] {1, 1, 0, 0, 1, 0, 0, 0, 1};
+
+    assertCompareTwoKeys(comparator, keyOne, keyTwo);
   }
 
   private void assertCompareTwoKeys(
       final Comparator<byte[]> comparator, byte[] keyOne, byte[] keyTwo) {
     Assert.assertTrue(comparator.compare(keyOne, keyTwo) < 0);
     Assert.assertTrue(comparator.compare(keyTwo, keyOne) > 0);
-    Assert.assertTrue(comparator.compare(keyTwo, keyTwo) == 0);
+    //noinspection EqualsWithItself
+    Assert.assertEquals(0, comparator.compare(keyTwo, keyTwo));
   }
 }

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODatabaseDocumentDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODatabaseDocumentDistributed.java
@@ -444,7 +444,9 @@ public class ODatabaseDocumentDistributed extends ODatabaseDocumentEmbedded {
       if (quorum > availableNodes) {
         Set<String> online = dManager.getAvailableNodeNames(getName());
         throw new ODistributedException(
-            String.format("No enough nodes online to execute the operation, available nodes:%s quorun:%s", online, quorum));
+            String.format(
+                "No enough nodes online to execute the operation, available nodes:%s quorun:%s",
+                online, quorum));
       }
 
       txManager.commit(this, iTx);


### PR DESCRIPTION
What does this PR do?
Fix illegal memory access in Unsafe byte array comparator.

Motivation
Database stability.


Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
