### PR TITLE
minor fix to avoid a storage to go to read only if the backup fail

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/disk/OLocalPaginatedStorage.java
@@ -307,11 +307,11 @@ public class OLocalPaginatedStorage extends OAbstractPaginatedStorage {
         release();
       }
     } catch (final RuntimeException e) {
-      throw logAndPrepareForRethrow(e);
+      throw logAndPrepareForRethrow(e, false);
     } catch (final Error e) {
-      throw logAndPrepareForRethrow(e);
+      throw logAndPrepareForRethrow(e, false);
     } catch (final Throwable t) {
-      throw logAndPrepareForRethrow(t);
+      throw logAndPrepareForRethrow(t, false);
     }
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -6477,7 +6477,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return logAndPrepareForRethrow(runtimeException, true);
   }
 
-  private RuntimeException logAndPrepareForRethrow(
+  protected RuntimeException logAndPrepareForRethrow(
       final RuntimeException runtimeException, final boolean putInReadOnlyMode) {
     if (!(runtimeException instanceof OHighLevelException
         || runtimeException instanceof ONeedRetryException)) {
@@ -6503,7 +6503,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return logAndPrepareForRethrow(error, true);
   }
 
-  private Error logAndPrepareForRethrow(final Error error, final boolean putInReadOnlyMode) {
+  protected Error logAndPrepareForRethrow(final Error error, final boolean putInReadOnlyMode) {
     if (!(error instanceof OHighLevelException)) {
       if (putInReadOnlyMode) {
         this.error = error;
@@ -6527,7 +6527,7 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
     return logAndPrepareForRethrow(throwable, true);
   }
 
-  private RuntimeException logAndPrepareForRethrow(
+  protected RuntimeException logAndPrepareForRethrow(
       final Throwable throwable, final boolean putInReadOnlyMode) {
     if (!(throwable instanceof OHighLevelException || throwable instanceof ONeedRetryException)) {
       if (putInReadOnlyMode) {


### PR DESCRIPTION
During the backup should not be there any operation that do changes that make the storage inconsistent, the only case where there should be the possibility of something going wrong in the storage side, is during the freeze logic, that already make the storage readOnly itself so no need to have an additional catch on top.

Regards