### PR TITLE
bumped jnr-posix version for m1 support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -268,7 +268,7 @@
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
-            <version>3.0.50</version>
+            <version>3.1.15</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.concurrentlinkedhashmap</groupId>


### PR DESCRIPTION
What does this PR do?
Bumps *jnr-posix* version to the latest one ( 3.1.15 )

Motivation
*jnr-posix* version 3.0.50 does not support newest M1 architecture. Bumping to the newest one fixes the problem.

Related issues
None

Additional Notes
ETL build fails, but it also does on develop, so I think the problem is not connected to this PR.

Checklist
[x] I have run the build using `mvn clean package` command
[?] My unit tests cover both failure and success scenarios
