### PR TITLE
3.1 fix using wrong variables

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerController.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerController.java
@@ -30,10 +30,10 @@ import java.io.IOException;
  */
 public class ORemoteServerController {
   private final ORemoteServerChannel[] requestChannels;
-  private volatile int requestChannelIndex = 0;
+  private int requestChannelIndex = 0;
 
   private final ORemoteServerChannel[] responseChannels;
-  private volatile int responseChannelIndex = 0;
+  private int responseChannelIndex = 0;
 
   private int protocolVersion = -1;
   public static final int CURRENT_PROTOCOL_VERSION = 2;
@@ -77,15 +77,23 @@ public class ORemoteServerController {
   }
 
   public void sendRequest(final ODistributedRequest req) {
-    int idx = requestChannelIndex++;
-    if (idx < 0) idx = 0;
-    requestChannels[idx % requestChannels.length].sendRequest(req);
+    int idx;
+    synchronized (requestChannels) {
+      requestChannelIndex++;
+      if (requestChannelIndex < 0) requestChannelIndex = 0;
+      idx = requestChannelIndex % requestChannels.length;
+    }
+    requestChannels[idx].sendRequest(req);
   }
 
   public void sendResponse(final ODistributedResponse response) {
-    int idx = responseChannelIndex++;
-    if (idx < 0) idx = 0;
-    responseChannels[idx % responseChannels.length].sendResponse(response);
+    int idx;
+    synchronized (responseChannels) {
+      responseChannelIndex++;
+      if (responseChannelIndex < 0) responseChannelIndex = 0;
+      idx = responseChannelIndex % responseChannels.length;
+    }
+    responseChannels[idx].sendResponse(response);
   }
 
   public void close() {
@@ -98,9 +106,13 @@ public class ORemoteServerController {
     return protocolVersion;
   }
 
-  public void sendBinaryRequest(OBinaryRequest request) {
-    int idx = requestChannelIndex++;
-    if (idx < 0) idx = 0;
-    requestChannels[idx % requestChannels.length].sendBinaryRequest(request);
+  public void sendBinaryRequest(OBinaryRequest<?> request) {
+    int idx;
+    synchronized (requestChannels) {
+      requestChannelIndex++;
+      if (requestChannelIndex < 0) requestChannelIndex = 0;
+      idx = requestChannelIndex % requestChannels.length;
+    }
+    requestChannels[idx].sendBinaryRequest(request);
   }
 }

--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerController.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerController.java
@@ -79,7 +79,7 @@ public class ORemoteServerController {
   public void sendRequest(final ODistributedRequest req) {
     int idx = requestChannelIndex++;
     if (idx < 0) idx = 0;
-    requestChannels[idx % responseChannels.length].sendRequest(req);
+    requestChannels[idx % requestChannels.length].sendRequest(req);
   }
 
   public void sendResponse(final ODistributedResponse response) {
@@ -101,6 +101,6 @@ public class ORemoteServerController {
   public void sendBinaryRequest(OBinaryRequest request) {
     int idx = requestChannelIndex++;
     if (idx < 0) idx = 0;
-    requestChannels[idx % responseChannels.length].sendBinaryRequest(request);
+    requestChannels[idx % requestChannels.length].sendBinaryRequest(request);
   }
 }


### PR DESCRIPTION
Fixes bad math and synchronisation of the request/response index variables and using the wrong array length in one case.

Previously a volatile was used on the variables, but an increment is not an anomic operation! Also, When the request/response index was < 0 then the array index would be set to 0, so after 2.3billion messages only the first channel would be used for the next 2.38billion!

Checklist

- [x] I have run the build using `mvn clean package` command
