### PR TITLE
3.1 channel exhaustion

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerChannel.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/distributed/ORemoteServerChannel.java
@@ -205,6 +205,7 @@ public class ORemoteServerChannel {
   }
 
   public void connect() throws IOException {
+    networkClose();
     channel =
         new OChannelBinarySynchClient(
             remoteHost,


### PR DESCRIPTION
When running a distributed cluster with 4 nodes, we noticed that the number of connections was growing by 6 connections on each server every 58 minutes. 58 minutes is the session time less the 2 minute hard limit for the token.
It was found that the remote server channels do not refresh their tokens and the channel is just recreated without closing the old channels. The old channels were left open and therefore retained in the performance and metrics monitoring code.
This meant that our servers could only remain running for approximately 6.5 days before they needed to be restarted. We have worked around this by increasing the session timeout to 1 month until this bug is fixed.

The PR closes the channel when creating a new one.

Checklist

- [x] I have run the build using `mvn clean package` command
