### PR TITLE
3.1 Set keep alive on server accepted sockets

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/OServerNetworkListener.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/OServerNetworkListener.java
@@ -239,6 +239,7 @@ public class OServerNetworkListener extends Thread {
           }
 
           socket.setPerformancePreferences(0, 2, 1);
+          socket.setKeepAlive(true);
           if (socketBufferSize > 0) {
             socket.setSendBufferSize(socketBufferSize);
             socket.setReceiveBufferSize(socketBufferSize);


### PR DESCRIPTION
Client create sockets turn on keep-alive, so this PR also turns them on on socket connections accepted on the server side.

Because the distributed server sockets are not written to the server is not notified of a closed connection if a firewall in the middle just drops the connection after a connection lifetime period expires. By enabling keep-alive on the server side, the server is notified of a failed/dropped connection after the keep-alive timeout.

Checklist
- [x] I have run the build using `mvn clean package` command
