### PR TITLE
Cap string length in binary channels

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
+++ b/core/src/main/java/com/orientechnologies/orient/enterprise/channel/binary/OChannelBinary.java
@@ -143,6 +143,17 @@ public abstract class OChannelBinary extends OChannel
       OLogManager.instance()
           .info(this, "%s - Reading string (4+N bytes)...", socket.getRemoteSocketAddress());
       final int len = in.readInt();
+      if (len > maxChunkSize) {
+        throw new IOException(
+            "Impossible to read a string chunk of length:"
+                + len
+                + " max allowed chunk length:"
+                + maxChunkSize
+                + " see NETWORK_BINARY_MAX_CONTENT_LENGTH settings ");
+      }
+      if (debug)
+        OLogManager.instance()
+            .info(this, "%s - Read string chunk length: %d", socket.getRemoteSocketAddress(), len);
       if (len < 0) return null;
 
       // REUSE STATIC BUFFER?


### PR DESCRIPTION
Use same logic as readBytes to cap max chunk length at  at NETWORK_BINARY_MAX_CONTENT_LENGTH.
This prevents OOME when invalid protocol traffic is directed at binary port (e.g. by security scanners).

Motivation:
In our deployment our SRE's have a security scanner that probes all open ports and shoves random data as well as well-known attacks down them. We noticed that we were getting OOM exceptions and traced the root cause to this. We have subsequently disabled the security scanner from running against these ports, but thought it prudent to add a sanity check to orientdb.

Checklist
- [x] I have run the build using `mvn clean package` command
