### PR TITLE
3.1 check distributed lock success

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
@@ -4,7 +4,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.orientechnologies.common.types.OModifiableInteger;
 import com.orientechnologies.orient.server.distributed.ODistributedLockManager;
 import com.orientechnologies.orient.server.distributed.task.ODistributedLockException;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -37,14 +36,16 @@ public class OHazelcastLockManager implements ODistributedLockManager {
       try {
         if (!hazelcast.getLock(resource).tryLock(timeout, TimeUnit.MILLISECONDS)) {
           throw new ODistributedLockException(
-                  String.format("Timed out after %d ms attempting to obtain lock for resource '%s' on node '%s'",
-                          timeout, resource, nodeSource));
+              String.format(
+                  "Timed out after %d ms attempting to obtain lock for resource '%s' on node '%s'",
+                  timeout, resource, nodeSource));
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new ODistributedLockException(
-                String.format("Interrupted while attempting to obtain lock for resource '%s' on node '%s'",
-                        timeout, resource, nodeSource));
+            String.format(
+                "Interrupted while attempting to obtain lock for resource '%s' on node '%s'",
+                timeout, resource, nodeSource));
       }
     } else {
       hazelcast.getLock(resource).lock();

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastLockManager.java
@@ -3,6 +3,8 @@ package com.orientechnologies.orient.server.hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.orientechnologies.common.types.OModifiableInteger;
 import com.orientechnologies.orient.server.distributed.ODistributedLockManager;
+import com.orientechnologies.orient.server.distributed.task.ODistributedLockException;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,9 +35,16 @@ public class OHazelcastLockManager implements ODistributedLockManager {
 
     if (timeout != 0) {
       try {
-        hazelcast.getLock(resource).tryLock(timeout, TimeUnit.MILLISECONDS);
+        if (!hazelcast.getLock(resource).tryLock(timeout, TimeUnit.MILLISECONDS)) {
+          throw new ODistributedLockException(
+                  String.format("Timed out after %d ms attempting to obtain lock for resource '%s' on node '%s'",
+                          timeout, resource, nodeSource));
+        }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new ODistributedLockException(
+                String.format("Interrupted while attempting to obtain lock for resource '%s' on node '%s'",
+                        timeout, resource, nodeSource));
       }
     } else {
       hazelcast.getLock(resource).lock();


### PR DESCRIPTION
When gaining a distributed lock if a timeout occurs the LockManager would return false, but nothing checks the return value and would bindly assume it has the lock.

This PR throws ODistributedLockException if the timeout occurs when trying to gain the lock.

Checklist
- [x] I have run the build using `mvn clean package` command
