### PR TITLE
Support masking of Lucene query in log/exceptions

### DIFF
--- a/lucene/src/test/java/com/orientechnologies/lucene/builder/OLuceneQueryBuilderTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/builder/OLuceneQueryBuilderTest.java
@@ -1,0 +1,57 @@
+package com.orientechnologies.lucene.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.when;
+
+import com.orientechnologies.orient.core.index.OIndexDefinition;
+import com.orientechnologies.orient.core.record.impl.ODocument;
+import com.orientechnologies.orient.core.sql.parser.ParseException;
+import java.util.Collections;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class OLuceneQueryBuilderTest {
+  private OIndexDefinition indexDef;
+
+  @Before
+  public void setUp() throws Exception {
+    indexDef = Mockito.mock(OIndexDefinition.class);
+    when(indexDef.getFields()).thenReturn(Collections.<String>emptyList());
+    when(indexDef.isAutomatic()).thenReturn(true);
+    when(indexDef.getClassName()).thenReturn("Song");
+  }
+
+  @Test
+  public void testUnmaskedQueryReporting() {
+    final OLuceneQueryBuilder builder = new OLuceneQueryBuilder(OLuceneQueryBuilder.EMPTY_METADATA);
+
+    final String invalidQuery = "+(song:private{}private)";
+    try {
+      builder.buildQuery(
+          indexDef, invalidQuery, OLuceneQueryBuilder.EMPTY_METADATA, new EnglishAnalyzer());
+    } catch (ParseException e) {
+      assertThat(e.getMessage()).contains("Cannot parse", invalidQuery);
+      return;
+    }
+    fail("Expected ParseException");
+  }
+
+  @Test
+  public void testMaskedQueryReporting() {
+    final OLuceneQueryBuilder builder = new OLuceneQueryBuilder(OLuceneQueryBuilder.EMPTY_METADATA);
+
+    final String invalidQuery = "+(song:private{}private)";
+    final ODocument queryMetadata =
+        new ODocument().fromMap(Collections.singletonMap("reportQueryAs", "masked"));
+    try {
+      builder.buildQuery(indexDef, invalidQuery, queryMetadata, new EnglishAnalyzer());
+    } catch (ParseException e) {
+      assertThat(e.getMessage()).contains("Cannot parse", "masked").doesNotContain(invalidQuery);
+      return;
+    }
+    fail("Expected ParseException");
+  }
+}


### PR DESCRIPTION
What does this PR do?

Provide a 'reportQueryAs' metadata parameter that will be reported as the text of the Lucene query on any parse failure, allowing a client to prevent sensitive data included in Lucene SEARCH_CLASS, SEARCH_INDEX and SEARCH_FIELDS functions being logged or included in exception messages.

Motivation

We have Lucene full text indexes on the names of people, deployed in a privacy sensitive domain where logs containing the name data would be considered sensitive and not able to be shared with operations staff outside of a particular jurisdiction.
Parse errors on Lucene search queries provided in `SEARCH_CLASS` et al would be logged and reproduced in exception messages.
We fixed the escaping issues that caused the parse errors, but it's preferable to be able to assert that the database logs won't contain sensitive data.

Related issues

Additional Notes

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
