### PR TITLE
Use ShutdownLogManager in distributed server

### DIFF
--- a/distributed/script/dserver.bat
+++ b/distributed/script/dserver.bat
@@ -80,6 +80,6 @@ set MAXHEAP=-Xmx4G
 rem ORIENTDB MAXIMUM DISKCACHE IN MB, EXAMPLE: "-Dstorage.diskCache.bufferSize=8192" FOR 8GB of DISKCACHE
 set MAXDISKCACHE=
 
-call %JAVA% -server %JAVA_OPTS% %MAXHEAP% %JAVA_OPTS_SCRIPT% %ORIENTDB_SETTINGS% %MAXDISKCACHE% -Ddistributed=true -Djava.util.logging.config.file="%LOG_FILE%" -Dorientdb.config.file="%CONFIG_FILE%" -Dorientdb.www.path="%WWW_PATH%" -Dorientdb.build.number="@BUILD@" -cp "%ORIENTDB_HOME%\lib\*;%ORIENTDB_HOME%\plugins\*" %CMD_LINE_ARGS% com.orientechnologies.orient.server.OServerMain
+call %JAVA% -server %JAVA_OPTS% %MAXHEAP% %JAVA_OPTS_SCRIPT% %ORIENTDB_SETTINGS% %MAXDISKCACHE% -Ddistributed=true -Djava.util.logging.manager=com.orientechnologies.common.log.ShutdownLogManager -Djava.util.logging.config.file="%LOG_FILE%" -Dorientdb.config.file="%CONFIG_FILE%" -Dorientdb.www.path="%WWW_PATH%" -Dorientdb.build.number="@BUILD@" -cp "%ORIENTDB_HOME%\lib\*;%ORIENTDB_HOME%\plugins\*" %CMD_LINE_ARGS% com.orientechnologies.orient.server.OServerMain
 
 :end

--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -119,6 +119,7 @@ exec "$JAVA" $JAVA_OPTS \
     $ORIENTDB_SETTINGS \
     $DEBUG_OPTS \
     -Ddistributed=true \
+    -Djava.util.logging.manager=com.orientechnologies.common.log.ShutdownLogManager \
     -Djava.util.logging.config.file="$ORIENTDB_LOG_CONF" \
     -Dorientdb.config.file="$CONFIG_FILE" \
     -Dorientdb.www.path="$ORIENTDB_WWW_PATH" \

--- a/distributed/script/dserver.sh
+++ b/distributed/script/dserver.sh
@@ -77,7 +77,7 @@ if [ -z "$ORIENTDB_WWW_PATH" ] ; then
 fi
 
 if [ -z "$ORIENTDB_PID" ] ; then
-ORIENTDB_PID=$ORIENTDB_HOME/bin/orient.pid
+    ORIENTDB_PID=$ORIENTDB_HOME/bin/orient.pid
 fi
 
 if [ -f "$ORIENTDB_PID" ]; then

--- a/server/script/server.bat
+++ b/server/script/server.bat
@@ -3,12 +3,12 @@ rem
 rem Copyright (c) OrientDB LTD (http://www.orientdb.com)
 rem
 
-echo            .                                          
-echo           .`        `                                 
-echo           ,      `:.                                  
-echo          `,`    ,:`                                   
-echo          .,.   :,,                                    
-echo          .,,  ,,,                                     
+echo            .
+echo           .`        `
+echo           ,      `:.
+echo          `,`    ,:`
+echo          .,.   :,,
+echo          .,,  ,,,
 echo     .    .,.:::::  ````                                 :::::::::     :::::::::
 echo     ,`   .::,,,,::.,,,,,,`;;                      .:    ::::::::::    :::    :::
 echo     `,.  ::,,,,,,,:.,,.`  `                       .:    :::      :::  :::     :::
@@ -21,12 +21,12 @@ echo   `,...,,:,,,,,,,,,: .:,. ,, ,,         :     :   .:    :::      :::  :::  
 echo     .,,,,::,,,,,,,:  `: , ,,  :     `   :     :   .:    :::      :::  :::     :::
 echo       ...,::,,,,::.. `:  .,,  :,    :   :     :   .:    :::::::::::   :::     :::
 echo            ,::::,,,. `:   ,,   :::::    :     :   .:    :::::::::     ::::::::::
-echo            ,,:` `,,.                                  
-echo           ,,,    .,`                                  
+echo            ,,:` `,,.
+echo           ,,,    .,`
 echo          ,,.     `,                                              VELOCE
-echo        ``        `.                                         
+echo        ``        `.
 echo                  ``                                         www.orientdb.com
-echo                  `                                    
+echo                  `
 
 rem Guess ORIENTDB_HOME if not defined
 set CURRENT_DIR=%cd%
@@ -63,7 +63,6 @@ shift
 goto setArgs
 
 :doneSetArgs
-
 
 if NOT exist "%CONFIG_FILE%" set CONFIG_FILE=%ORIENTDB_HOME%/config/orientdb-server-config.xml
 

--- a/server/script/server.sh
+++ b/server/script/server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) OrientDB LTD (http://http://orientdb.com/)
+# Copyright (c) OrientDB LTD (http://orientdb.com/)
 #
 
 echo "           .                                          "
@@ -61,7 +61,7 @@ fi
 export JAVA_OPTS
 
 # Set JavaHome if it exists
-if [ -f "${JAVA_HOME}/bin/java" ]; then 
+if [ -f "${JAVA_HOME}/bin/java" ]; then
    JAVA=${JAVA_HOME}/bin/java
 else
    JAVA=java


### PR DESCRIPTION
What does this PR do?

Modify dserver.sh to use the custom OrientDB JUL LogManager so shutdown messages are logged properly.

Motivation
Shutdown messages are lost when server is run via dserver.sh

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
