### PR TITLE
Use release version of maven shade plugin

### DIFF
--- a/etl/pom.xml
+++ b/etl/pom.xml
@@ -35,13 +35,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>maven-snapshots</id>
-            <url>https://repository.apache.org/content/repositories/snapshots/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -59,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <dependencyReducedPomLocation>${basedir}/target/dependency-reduced-pom.xml
                     </dependencyReducedPomLocation>


### PR DESCRIPTION
The maven-shade-plugin version 3.3.0 was released in May, the SNAPSHOT has been removed from the snapshots repository and broke the build.
The PR fixes this by using the 3.3.0 release version of maven-shade-plugin

Checklist
- [x] I have run the build using `mvn clean package` command
