### PR TITLE
Fix rebuild lucene index

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/index/OIndexAbstract.java
@@ -678,7 +678,7 @@ public abstract class OIndexAbstract implements OIndexInternal {
     }
   }
 
-  private void doDelete() {
+  protected void doDelete() {
     while (true)
       try {
         //noinspection ObjectAllocationInLoop

--- a/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/index/OLuceneIndexNotUnique.java
@@ -190,25 +190,14 @@ public class OLuceneIndexNotUnique extends OIndexAbstract implements OLuceneInde
       }
   }
 
-  public OLuceneIndexNotUnique delete() {
-    acquireExclusiveLock();
-
-    try {
-      while (true)
-        try {
-          storage.deleteIndexEngine(indexId);
-          break;
-        } catch (OInvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
-        }
-
-      // REMOVE THE INDEX ALSO FROM CLASS MAP
-      if (getDatabase().getMetadata() != null)
-        getDatabase().getMetadata().getIndexManagerInternal().removeClassPropertyIndex(this);
-      return this;
-    } finally {
-      releaseExclusiveLock();
-    }
+  public void doDelete() {
+    while (true)
+      try {
+        storage.deleteIndexEngine(indexId);
+        break;
+      } catch (OInvalidIndexEngineIdException ignore) {
+        doReloadIndexEngine();
+      }
   }
 
   protected Object decodeKey(Object key) {


### PR DESCRIPTION
As commented in issue #9721 the fix for this is to make `OIndexAbstract.doDelete` protected and in `OLuceneIndexNonUnique` create a `doDelete` override that does the actual work of deleting the index from the existing `delete` override and remove that overridden `delete` function.

Checklist
- [x] I have run the build using `mvn clean package` command
