### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/maven_java_11.yml
+++ b/.github/workflows/maven_java_11.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ develop, 3.1.x, 3.0.x ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/maven_java_17.yml
+++ b/.github/workflows/maven_java_17.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/maven_java_8.yml
+++ b/.github/workflows/maven_java_8.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: 0 5 * * 1
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ name: Publish Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
