### PR TITLE
Support parameterised metadata in Lucene queries

### DIFF
--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchFunctionTemplate.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchFunctionTemplate.java
@@ -4,11 +4,13 @@ import com.orientechnologies.lucene.collections.OLuceneResultSet;
 import com.orientechnologies.lucene.index.OLuceneFullTextIndex;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.functions.OIndexableSQLFunction;
 import com.orientechnologies.orient.core.sql.functions.OSQLFunctionAbstract;
 import com.orientechnologies.orient.core.sql.parser.OBinaryCompareOperator;
 import com.orientechnologies.orient.core.sql.parser.OExpression;
 import com.orientechnologies.orient.core.sql.parser.OFromClause;
+import java.util.Map;
 
 /** Created by frank on 25/05/2017. */
 public abstract class OLuceneSearchFunctionTemplate extends OSQLFunctionAbstract
@@ -67,6 +69,19 @@ public abstract class OLuceneSearchFunctionTemplate extends OSQLFunctionAbstract
     }
 
     return count;
+  }
+
+  protected ODocument getMetadata(OExpression metadata, OCommandContext ctx) {
+    final Object md = metadata.execute((OIdentifiable) null, ctx);
+    if (md instanceof ODocument) {
+      return (ODocument) md;
+    } else if (md instanceof Map) {
+      return new ODocument().fromMap((Map<String, ?>) md);
+    } else if (md instanceof String) {
+      return new ODocument().fromJSON((String) md);
+    } else {
+      return new ODocument().fromJSON(metadata.toString());
+    }
   }
 
   protected abstract OLuceneFullTextIndex searchForIndex(

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunction.java
@@ -119,7 +119,7 @@ public class OLuceneSearchOnClassFunction extends OLuceneSearchFunctionTemplate 
 
     if (index != null) {
 
-      ODocument metadata = getMetadata(args);
+      ODocument metadata = getMetadata(args, ctx);
 
       List<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =
@@ -136,9 +136,9 @@ public class OLuceneSearchOnClassFunction extends OLuceneSearchFunctionTemplate 
     return Collections.emptySet();
   }
 
-  private ODocument getMetadata(OExpression[] args) {
+  private ODocument getMetadata(OExpression[] args, OCommandContext ctx) {
     if (args.length == 2) {
-      return new ODocument().fromJSON(args[1].toString());
+      return getMetadata(args[1], ctx);
     }
     return OLuceneQueryBuilder.EMPTY_METADATA;
   }

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunction.java
@@ -116,7 +116,7 @@ public class OLuceneSearchOnFieldsFunction extends OLuceneSearchFunctionTemplate
     String query = (String) expression.execute((OIdentifiable) null, ctx);
     if (index != null) {
 
-      ODocument meta = getMetadata(args);
+      ODocument meta = getMetadata(args, ctx);
       Set<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =
           index
@@ -132,11 +132,11 @@ public class OLuceneSearchOnFieldsFunction extends OLuceneSearchFunctionTemplate
     throw new RuntimeException();
   }
 
-  private ODocument getMetadata(OExpression[] args) {
+  private ODocument getMetadata(OExpression[] args, OCommandContext ctx) {
     if (args.length == 3) {
-      return new ODocument().fromJSON(args[2].toString());
+      return getMetadata(args[2], ctx);
     }
-    return new ODocument();
+    return OLuceneQueryBuilder.EMPTY_METADATA;
   }
 
   @Override

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunction.java
@@ -122,7 +122,7 @@ public class OLuceneSearchOnIndexFunction extends OLuceneSearchFunctionTemplate 
     String query = (String) expression.execute((OIdentifiable) null, ctx);
     if (index != null && query != null) {
 
-      ODocument meta = getMetadata(index, query, args);
+      ODocument meta = getMetadata(args, ctx);
 
       List<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =
@@ -139,13 +139,11 @@ public class OLuceneSearchOnIndexFunction extends OLuceneSearchFunctionTemplate 
     return Collections.emptyList();
   }
 
-  private ODocument getMetadata(OLuceneFullTextIndex index, String query, OExpression[] args) {
+  private ODocument getMetadata(OExpression[] args, OCommandContext ctx) {
     if (args.length == 3) {
-      ODocument metadata = new ODocument().fromJSON(args[2].toString());
-
-      return metadata;
+      return getMetadata(args[2], ctx);
     }
-    return new ODocument();
+    return OLuceneQueryBuilder.EMPTY_METADATA;
   }
 
   @Override

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunctionTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.orientechnologies.lucene.tests.OLuceneBaseTest;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -119,5 +122,17 @@ public class OLuceneSearchOnClassFunctionTest extends OLuceneBaseTest {
                 assertThat(r.<String>getProperty("$description_hl"))
                     .containsIgnoringCase("<span>shouldHighlightWithNullValues</span>"));
     resultSet.close();
+  }
+
+  @Test
+  public void shouldSupportParameterizedMetadata() throws Exception {
+    final String query = "SELECT from Song where SEARCH_CLASS('*EVE*', ?) = true";
+
+    db.query(query, "{'allowLeadingWildcard': true}").close();
+    db.query(query, new ODocument("allowLeadingWildcard", Boolean.TRUE)).close();
+
+    Map<String, Object> mdMap = new HashMap();
+    mdMap.put("allowLeadingWildcard", true);
+    db.query(query, new Object[] {mdMap}).close();
   }
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
@@ -39,7 +39,7 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
     // TODO: metadata still not used
     final OResultSet resultSet =
         db.query(
-            "SELECT from Song where SEARCH_INDEX('Song.title', '*EVE*', {'allowLeadingWildcard': true}) = true");
+            "SELECT from Song where SEARCH_FIELDS(['title'], '*EVE*', {'allowLeadingWildcard': true}) = true");
     assertThat(resultSet).hasSize(14);
     resultSet.close();
   }

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.orientechnologies.lucene.test.BaseLuceneTest;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -145,5 +148,17 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
     assertThat((Object) item.getProperty("theList")).isInstanceOf(List.class);
     assertThat((List) item.getProperty("theList")).hasSize(3);
     result.close();
+  }
+
+  @Test
+  public void shouldSupportParameterizedMetadata() throws Exception {
+    final String query = "SELECT from Song where SEARCH_FIELDS(['title'], '*EVE*', ?) = true";
+
+    db.query(query, "{'allowLeadingWildcard': true}").close();
+    db.query(query, new ODocument("allowLeadingWildcard", Boolean.TRUE)).close();
+
+    Map<String, Object> mdMap = new HashMap();
+    mdMap.put("allowLeadingWildcard", true);
+    db.query(query, new Object[] {mdMap}).close();
   }
 }

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunctionTest.java
@@ -54,7 +54,7 @@ public class OLuceneSearchOnFieldsFunctionTest extends BaseLuceneTest {
   }
 
   @Test
-  public void shouldSearhOnTwoFieldsInAND() throws Exception {
+  public void shouldSearchOnTwoFieldsInAND() throws Exception {
     final OResultSet resultSet =
         db.query(
             "SELECT from Song where SEARCH_FIELDS(['title'], 'tambourine') = true AND SEARCH_FIELDS(['author'], 'Bob') = true ");

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunctionTest.java
@@ -90,7 +90,7 @@ public class OLuceneSearchOnIndexFunctionTest extends BaseLuceneTest {
   }
 
   @Test
-  public void shouldSearhOnTwoIndexesInAND() throws Exception {
+  public void shouldSearchOnTwoIndexesInAND() throws Exception {
 
     OResultSet resultSet =
         db.query(
@@ -101,7 +101,7 @@ public class OLuceneSearchOnIndexFunctionTest extends BaseLuceneTest {
   }
 
   @Test
-  public void shouldSearhOnTwoIndexesWithLeadingWildcardInAND() throws Exception {
+  public void shouldSearchOnTwoIndexesWithLeadingWildcardInAND() throws Exception {
 
     OResultSet resultSet =
         db.query(

--- a/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunctionTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunctionTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.orientechnologies.lucene.test.BaseLuceneTest;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -112,5 +115,17 @@ public class OLuceneSearchOnIndexFunctionTest extends BaseLuceneTest {
   public void shouldFailWithWrongIndexName() throws Exception {
 
     db.query("SELECT from Song where SEARCH_INDEX('Song.wrongName', 'tambourine') = true ").close();
+  }
+
+  @Test
+  public void shouldSupportParameterizedMetadata() throws Exception {
+    final String query = "SELECT from Song where SEARCH_INDEX('Song.title', '*EVE*', ?) = true";
+
+    db.query(query, "{'allowLeadingWildcard': true}").close();
+    db.query(query, new ODocument("allowLeadingWildcard", Boolean.TRUE)).close();
+
+    Map<String, Object> mdMap = new HashMap();
+    mdMap.put("allowLeadingWildcard", true);
+    db.query(query, new Object[] {mdMap}).close();
   }
 }


### PR DESCRIPTION
What does this PR do?

Allow the metadata to SEARCH_CLASS, SEARCH_INDEX and SEARCH_FIELDS to be provided as an argument to the query, which makes handling dynamic metadata parameters (e.g. the reportQueryAs) a lot easier to work with.

Motivation
Implementing masking of Lucene full text expressions (that can leak personal information into logs) using literal metadata requires the entire query to be templated, not just the arguments, which makes programming it awkward.

Additional Notes
Also cleaned up some some minor issues in the Lucene function tests.

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
