### PR TITLE
Fix thread pool executors to operate as intended

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=8.0.322-zulu
-

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.322-zulu
+

--- a/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/client/remote/OStorageRemote.java
@@ -27,7 +27,7 @@ import com.orientechnologies.common.concur.lock.OModificationOperationProhibited
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OIOException;
 import com.orientechnologies.common.log.OLogManager;
-import com.orientechnologies.common.thread.OScheduledThreadPoolExecutorWithLogging;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.common.util.OCallable;
 import com.orientechnologies.common.util.OCommonConst;
 import com.orientechnologies.orient.client.ONotSendRequestException;
@@ -291,7 +291,7 @@ public class OStorageRemote extends OStorageAbstract implements OStorageProxy, O
         clientConfiguration.getValueAsInteger(OGlobalConfiguration.NETWORK_SOCKET_RETRY_DELAY);
     parseServerURLs();
 
-    asynchExecutor = new OScheduledThreadPoolExecutorWithLogging(1);
+    asynchExecutor = OThreadPoolExecutors.newSingleThreadScheduledPool("OStorageRemote Async");
 
     this.connectionManager = connectionManager;
     this.context = context;

--- a/core/src/main/java/com/orientechnologies/common/thread/BaseThreadFactory.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/BaseThreadFactory.java
@@ -1,0 +1,22 @@
+package com.orientechnologies.common.thread;
+
+import java.util.concurrent.ThreadFactory;
+
+abstract class BaseThreadFactory implements ThreadFactory {
+
+  private final ThreadGroup parentThreadGroup;
+
+  protected BaseThreadFactory(ThreadGroup parentThreadGroup) {
+    this.parentThreadGroup = parentThreadGroup;
+  }
+
+  @Override
+  public final Thread newThread(final Runnable r) {
+    final Thread thread = new Thread(parentThreadGroup, r);
+    thread.setDaemon(true);
+    thread.setName(nextThreadName());
+    return thread;
+  }
+
+  protected abstract String nextThreadName();
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/NamedThreadFactory.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/NamedThreadFactory.java
@@ -1,0 +1,20 @@
+package com.orientechnologies.common.thread;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class NamedThreadFactory extends BaseThreadFactory {
+
+  private final String baseName;
+
+  private final AtomicInteger threadId = new AtomicInteger(1);
+
+  NamedThreadFactory(final String baseName, ThreadGroup parentThreadGroup) {
+    super(parentThreadGroup);
+    this.baseName = baseName;
+  }
+
+  @Override
+  protected String nextThreadName() {
+    return String.format("%s-%d", baseName, threadId.getAndIncrement());
+  }
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/OScheduledThreadPoolExecutorWithLogging.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OScheduledThreadPoolExecutorWithLogging.java
@@ -37,7 +37,7 @@ public class OScheduledThreadPoolExecutorWithLogging extends ScheduledThreadPool
   protected void afterExecute(Runnable r, Throwable t) {
     super.afterExecute(r, t);
 
-    if (r instanceof Future<?>) {
+    if ((t == null) && r instanceof Future<?>) {
       final Future<?> future = (Future<?>) r;
       // scheduled futures can block execution forever if they are not done
       if (future.isDone()) {

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutorWithLogging.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutorWithLogging.java
@@ -61,7 +61,7 @@ public class OThreadPoolExecutorWithLogging extends ThreadPoolExecutor {
   protected void afterExecute(Runnable r, Throwable t) {
     super.afterExecute(r, t);
 
-    if (r instanceof Future<?>) {
+    if ((t == null) && (r instanceof Future<?>)) {
       final Future<?> future = (Future<?>) r;
       try {
         future.get();

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -1,92 +1,10 @@
 package com.orientechnologies.common.thread;
 
-import java.util.Random;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class OThreadPoolExecutors {
 
   private OThreadPoolExecutors() {}
-
-  /**
-   * A {@link ThreadPoolExecutor} with an unbounded work queue, that still scales the pool beyond
-   * the core pool size.
-   */
-  protected static class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
-
-    /**
-     * An unbounded work queue for a {@link ThreadPoolExecutor} that causes the pool to scale beyond
-     * the {@link ThreadPoolExecutor#getCorePoolSize()} core pool size}. <br>
-     * This is achieved by defining a target queue capacity, and wiring the {@link
-     * RejectedExecutionHandler} for the thread pool to re-queue using {@link #safeOffer(Runnable)}.
-     * <br>
-     * The work queue will probabilistically reject {@link #offer(Runnable) offers} to the work
-     * queue (with that probability growing to 100% as the indicated capacity is reached). The
-     * rejection of the offer will trigger pool growth in the thread pool, and once the max pool
-     * size has been reached will cause {@link RejectedExecutionHandler#rejectedExecution(Runnable,
-     * ThreadPoolExecutor) rejection}. <br>
-     * The implementation of {@link RejectedExecutionHandler} for this queue will then add it
-     * directly to the work queue, bypassing the rejection logic.
-     */
-    private static class ScalingQueue extends LinkedBlockingQueue<Runnable> {
-      private final int capacity;
-
-      private final Random rand = new Random();
-
-      private volatile boolean maxPoolReached = false;
-
-      public ScalingQueue(int capacity) {
-        super(); // Don't limit actual queue - capacity is used to signal ThreadPoolExecutor to grow
-        this.capacity = capacity;
-      }
-
-      @Override
-      public boolean offer(Runnable r) {
-        if (isEmpty()) {
-          maxPoolReached = false;
-        }
-        if (!maxPoolReached) {
-          final int size = size();
-          final int trigger = capacity <= 1 ? (capacity - 1) : rand.nextInt(capacity);
-          if (size > trigger) {
-            return false;
-          }
-        }
-        return super.offer(r);
-      }
-
-      protected void safeOffer(Runnable r) {
-        super.offer(r); // Queue is unbounded, so offer will succceed
-      }
-
-      protected void setMaxPoolReached(boolean maxPoolReached) {
-        this.maxPoolReached = maxPoolReached;
-      }
-    }
-
-    public ScalingThreadPoolExecutor(
-        int corePoolSize,
-        int maxPoolSize,
-        long timeout,
-        TimeUnit timeoutUnit,
-        int queueCapacity,
-        NamedThreadFactory namedThreadFactory) {
-      super(
-          corePoolSize,
-          maxPoolSize,
-          timeout,
-          timeoutUnit,
-          new ScalingQueue(queueCapacity),
-          namedThreadFactory,
-          (r, executor) -> ((ScalingQueue) executor.getQueue()).safeOffer(r));
-    }
-
-    @Override
-    protected void afterExecute(Runnable r, Throwable t) {
-      super.afterExecute(r, t);
-      ((ScalingQueue) getQueue()).setMaxPoolReached(getPoolSize() == getMaximumPoolSize());
-    }
-  }
 
   public static ExecutorService newScalingThreadPool(
       String threadName,
@@ -119,6 +37,25 @@ public class OThreadPoolExecutors {
         timeout,
         timeoutUnit,
         queueCapacity,
+        new NamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  public static ExecutorService newBlockingScalingThreadPool(
+      String threadName,
+      ThreadGroup parentThreadGroup,
+      int corePoolSize,
+      int maxPoolSize,
+      int targetQueueCapacity,
+      int maxQueueCapacity,
+      long timeout,
+      TimeUnit timeoutUnit) {
+    return new ScalingThreadPoolExecutor(
+        corePoolSize,
+        maxPoolSize,
+        timeout,
+        timeoutUnit,
+        targetQueueCapacity,
+        maxQueueCapacity,
         new NamedThreadFactory(threadName, parentThreadGroup));
   }
 
@@ -194,54 +131,4 @@ public class OThreadPoolExecutors {
         1, new SingletonNamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  private abstract static class BaseThreadFactory implements ThreadFactory {
-
-    private final ThreadGroup parentThreadGroup;
-
-    protected BaseThreadFactory(ThreadGroup parentThreadGroup) {
-      this.parentThreadGroup = parentThreadGroup;
-    }
-
-    @Override
-    public final Thread newThread(final Runnable r) {
-      final Thread thread = new Thread(parentThreadGroup, r);
-      thread.setDaemon(true);
-      thread.setName(nextThreadName());
-      return thread;
-    }
-
-    protected abstract String nextThreadName();
-  }
-
-  private static final class SingletonNamedThreadFactory extends BaseThreadFactory {
-
-    private final String name;
-
-    private SingletonNamedThreadFactory(final String name, ThreadGroup parentThreadGroup) {
-      super(parentThreadGroup);
-      this.name = name;
-    }
-
-    @Override
-    protected String nextThreadName() {
-      return name;
-    }
-  }
-
-  private static final class NamedThreadFactory extends BaseThreadFactory {
-
-    private final String baseName;
-
-    private final AtomicInteger threadId = new AtomicInteger(1);
-
-    private NamedThreadFactory(final String baseName, ThreadGroup parentThreadGroup) {
-      super(parentThreadGroup);
-      this.baseName = baseName;
-    }
-
-    @Override
-    protected String nextThreadName() {
-      return String.format("%s-%d", baseName, threadId.getAndIncrement());
-    }
-  }
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -1,0 +1,247 @@
+package com.orientechnologies.common.thread;
+
+import java.util.Random;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OThreadPoolExecutors {
+
+  private OThreadPoolExecutors() {}
+
+  /**
+   * A {@link ThreadPoolExecutor} with an unbounded work queue, that still scales the pool beyond
+   * the core pool size.
+   */
+  protected static class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
+
+    /**
+     * An unbounded work queue for a {@link ThreadPoolExecutor} that causes the pool to scale beyond
+     * the {@link ThreadPoolExecutor#getCorePoolSize()} core pool size}. <br>
+     * This is achieved by defining a target queue capacity, and wiring the {@link
+     * RejectedExecutionHandler} for the thread pool to re-queue using {@link #safeOffer(Runnable)}.
+     * <br>
+     * The work queue will probabilistically reject {@link #offer(Runnable) offers} to the work
+     * queue (with that probability growing to 100% as the indicated capacity is reached). The
+     * rejection of the offer will trigger pool growth in the thread pool, and once the max pool
+     * size has been reached will cause {@link RejectedExecutionHandler#rejectedExecution(Runnable,
+     * ThreadPoolExecutor) rejection}. <br>
+     * The implementation of {@link RejectedExecutionHandler} for this queue will then add it
+     * directly to the work queue, bypassing the rejection logic.
+     */
+    private static class ScalingQueue extends LinkedBlockingQueue<Runnable> {
+      private final int capacity;
+
+      private final Random rand = new Random();
+
+      private volatile boolean maxPoolReached = false;
+
+      public ScalingQueue(int capacity) {
+        super(); // Don't limit actual queue - capacity is used to signal ThreadPoolExecutor to grow
+        this.capacity = capacity;
+      }
+
+      @Override
+      public boolean offer(Runnable r) {
+        if (isEmpty()) {
+          maxPoolReached = false;
+        }
+        if (!maxPoolReached) {
+          final int size = size();
+          final int trigger = capacity <= 1 ? (capacity - 1) : rand.nextInt(capacity);
+          if (size > trigger) {
+            return false;
+          }
+        }
+        return super.offer(r);
+      }
+
+      protected void safeOffer(Runnable r) {
+        super.offer(r); // Queue is unbounded, so offer will succceed
+      }
+
+      protected void setMaxPoolReached(boolean maxPoolReached) {
+        this.maxPoolReached = maxPoolReached;
+      }
+    }
+
+    public ScalingThreadPoolExecutor(
+        int corePoolSize,
+        int maxPoolSize,
+        long timeout,
+        TimeUnit timeoutUnit,
+        int queueCapacity,
+        NamedThreadFactory namedThreadFactory) {
+      super(
+          corePoolSize,
+          maxPoolSize,
+          timeout,
+          timeoutUnit,
+          new ScalingQueue(queueCapacity),
+          namedThreadFactory,
+          (r, executor) -> ((ScalingQueue) executor.getQueue()).safeOffer(r));
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+      super.afterExecute(r, t);
+      ((ScalingQueue) getQueue()).setMaxPoolReached(getPoolSize() == getMaximumPoolSize());
+    }
+  }
+
+  public static ExecutorService newScalingThreadPool(
+      String threadName,
+      int corePoolSize,
+      int maxPoolSize,
+      int queueCapacity,
+      long timeout,
+      TimeUnit timeoutUnit) {
+    return newScalingThreadPool(
+        threadName,
+        Thread.currentThread().getThreadGroup(),
+        corePoolSize,
+        maxPoolSize,
+        queueCapacity,
+        timeout,
+        timeoutUnit);
+  }
+
+  public static ExecutorService newScalingThreadPool(
+      String threadName,
+      ThreadGroup parentThreadGroup,
+      int corePoolSize,
+      int maxPoolSize,
+      int queueCapacity,
+      long timeout,
+      TimeUnit timeoutUnit) {
+    return new ScalingThreadPoolExecutor(
+        corePoolSize,
+        maxPoolSize,
+        timeout,
+        timeoutUnit,
+        queueCapacity,
+        new NamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  public static ExecutorService newFixedThreadPool(String threadName, int poolSize) {
+    return newFixedThreadPool(threadName, Thread.currentThread().getThreadGroup(), poolSize);
+  }
+
+  public static ExecutorService newFixedThreadPool(
+      String threadName, ThreadGroup parentThreadGroup, int poolSize) {
+    return new OThreadPoolExecutorWithLogging(
+        poolSize,
+        poolSize,
+        0,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        new NamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  public static ExecutorService newCachedThreadPool(String threadName) {
+    return newCachedThreadPool(threadName, Thread.currentThread().getThreadGroup());
+  }
+
+  public static ExecutorService newCachedThreadPool(
+      String threadName, ThreadGroup parentThreadGroup) {
+    return newCachedThreadPool(threadName, parentThreadGroup, Integer.MAX_VALUE, 0);
+  }
+
+  public static ExecutorService newCachedThreadPool(
+      String threadName, ThreadGroup parentThreadGroup, int maxThreads, int maxQueue) {
+    return new OThreadPoolExecutorWithLogging(
+        0,
+        maxThreads,
+        60L,
+        TimeUnit.SECONDS,
+        maxQueue <= 0 ? new SynchronousQueue<>() : new LinkedBlockingQueue<>(maxQueue),
+        new NamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  public static ExecutorService newSingleThreadPool(String threadName) {
+    return newSingleThreadPool(threadName, Thread.currentThread().getThreadGroup());
+  }
+
+  public static ExecutorService newSingleThreadPool(
+      String threadName, ThreadGroup parentThreadGroup) {
+    return new OThreadPoolExecutorWithLogging(
+        1,
+        1,
+        0,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        new SingletonNamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  public static ExecutorService newSingleThreadPool(
+      String threadName, int maxQueue, RejectedExecutionHandler rejectHandler) {
+    return new OThreadPoolExecutorWithLogging(
+        1,
+        1,
+        0,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(maxQueue),
+        new SingletonNamedThreadFactory(threadName, Thread.currentThread().getThreadGroup()),
+        rejectHandler);
+  }
+
+  public static ScheduledExecutorService newSingleThreadScheduledPool(String threadName) {
+    return newSingleThreadScheduledPool(threadName, Thread.currentThread().getThreadGroup());
+  }
+
+  public static ScheduledExecutorService newSingleThreadScheduledPool(
+      String threadName, ThreadGroup parentThreadGroup) {
+    return new OScheduledThreadPoolExecutorWithLogging(
+        1, new SingletonNamedThreadFactory(threadName, parentThreadGroup));
+  }
+
+  private abstract static class BaseThreadFactory implements ThreadFactory {
+
+    private final ThreadGroup parentThreadGroup;
+
+    protected BaseThreadFactory(ThreadGroup parentThreadGroup) {
+      this.parentThreadGroup = parentThreadGroup;
+    }
+
+    @Override
+    public final Thread newThread(final Runnable r) {
+      final Thread thread = new Thread(parentThreadGroup, r);
+      thread.setDaemon(true);
+      thread.setName(nextThreadName());
+      return thread;
+    }
+
+    protected abstract String nextThreadName();
+  }
+
+  private static final class SingletonNamedThreadFactory extends BaseThreadFactory {
+
+    private final String name;
+
+    private SingletonNamedThreadFactory(final String name, ThreadGroup parentThreadGroup) {
+      super(parentThreadGroup);
+      this.name = name;
+    }
+
+    @Override
+    protected String nextThreadName() {
+      return name;
+    }
+  }
+
+  private static final class NamedThreadFactory extends BaseThreadFactory {
+
+    private final String baseName;
+
+    private final AtomicInteger threadId = new AtomicInteger(1);
+
+    private NamedThreadFactory(final String baseName, ThreadGroup parentThreadGroup) {
+      super(parentThreadGroup);
+      this.baseName = baseName;
+    }
+
+    @Override
+    protected String nextThreadName() {
+      return String.format("%s-%d", baseName, threadId.getAndIncrement());
+    }
+  }
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -130,5 +130,4 @@ public class OThreadPoolExecutors {
     return new OScheduledThreadPoolExecutorWithLogging(
         1, new SingletonNamedThreadFactory(threadName, parentThreadGroup));
   }
-
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/ScalingThreadPoolExecutor.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/ScalingThreadPoolExecutor.java
@@ -8,21 +8,21 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A {@link ThreadPoolExecutor} that scales the pool beyond the core pool size, even if an
- * unbounded work queue is used.
+ * A {@link ThreadPoolExecutor} that scales the pool beyond the core pool size, even if an unbounded
+ * work queue is used.
  */
 class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
 
   /**
-   * An optionally bounded work queue for a {@link ThreadPoolExecutor} that causes the pool to
-   * scale beyond the {@link ThreadPoolExecutor#getCorePoolSize() core pool size}. <br>
+   * An optionally bounded work queue for a {@link ThreadPoolExecutor} that causes the pool to scale
+   * beyond the {@link ThreadPoolExecutor#getCorePoolSize() core pool size}. <br>
    * This is achieved by defining a target queue capacity, and wiring the {@link
    * RejectedExecutionHandler} for the thread pool to re-queue using {@link #safeOffer(Runnable)}.
    * <br>
-   * The work queue will probabilistically reject {@link #offer(Runnable) offers} to the work
-   * queue (with that probability growing to 100% as the indicated capacity is reached). The
-   * rejection of the offer will trigger pool growth in the thread pool, and once the max pool
-   * size has been reached will cause {@link RejectedExecutionHandler#rejectedExecution(Runnable,
+   * The work queue will probabilistically reject {@link #offer(Runnable) offers} to the work queue
+   * (with that probability growing to 100% as the indicated capacity is reached). The rejection of
+   * the offer will trigger pool growth in the thread pool, and once the max pool size has been
+   * reached will cause {@link RejectedExecutionHandler#rejectedExecution(Runnable,
    * ThreadPoolExecutor) rejection}. <br>
    * The implementation of {@link RejectedExecutionHandler} for the executor will then add it
    * directly to the work queue, bypassing the rejection logic.
@@ -54,7 +54,8 @@ class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
       }
       if (!maxPoolReached) {
         final int size = size();
-        final int trigger = targetCapacity <= 1 ? (targetCapacity - 1) : rand.nextInt(targetCapacity);
+        final int trigger =
+            targetCapacity <= 1 ? (targetCapacity - 1) : rand.nextInt(targetCapacity);
         if (size > trigger) {
           return false;
         }
@@ -117,5 +118,4 @@ class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
     super.afterExecute(r, t);
     ((ScalingQueue) getQueue()).setMaxPoolReached(getPoolSize() == getMaximumPoolSize());
   }
-
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/ScalingThreadPoolExecutor.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/ScalingThreadPoolExecutor.java
@@ -1,0 +1,121 @@
+package com.orientechnologies.common.thread;
+
+import java.util.Random;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link ThreadPoolExecutor} that scales the pool beyond the core pool size, even if an
+ * unbounded work queue is used.
+ */
+class ScalingThreadPoolExecutor extends OThreadPoolExecutorWithLogging {
+
+  /**
+   * An optionally bounded work queue for a {@link ThreadPoolExecutor} that causes the pool to
+   * scale beyond the {@link ThreadPoolExecutor#getCorePoolSize() core pool size}. <br>
+   * This is achieved by defining a target queue capacity, and wiring the {@link
+   * RejectedExecutionHandler} for the thread pool to re-queue using {@link #safeOffer(Runnable)}.
+   * <br>
+   * The work queue will probabilistically reject {@link #offer(Runnable) offers} to the work
+   * queue (with that probability growing to 100% as the indicated capacity is reached). The
+   * rejection of the offer will trigger pool growth in the thread pool, and once the max pool
+   * size has been reached will cause {@link RejectedExecutionHandler#rejectedExecution(Runnable,
+   * ThreadPoolExecutor) rejection}. <br>
+   * The implementation of {@link RejectedExecutionHandler} for the executor will then add it
+   * directly to the work queue, bypassing the rejection logic.
+   */
+  private static class ScalingQueue extends LinkedBlockingQueue<Runnable> {
+    private final int targetCapacity;
+
+    private final Random rand = new Random();
+
+    private volatile boolean maxPoolReached = false;
+
+    public ScalingQueue(int targetCapacity) {
+      super(); // Don't limit actual queue - capacity is used to signal ThreadPoolExecutor to grow
+      this.targetCapacity = targetCapacity;
+    }
+
+    public ScalingQueue(int targetCapacity, int maxQueueCapacity) {
+      super(maxQueueCapacity);
+      if (targetCapacity >= maxQueueCapacity) {
+        throw new IllegalArgumentException("Target capacity must be less than max queue capacity");
+      }
+      this.targetCapacity = targetCapacity;
+    }
+
+    @Override
+    public boolean offer(Runnable r) {
+      if (isEmpty()) {
+        maxPoolReached = false;
+      }
+      if (!maxPoolReached) {
+        final int size = size();
+        final int trigger = targetCapacity <= 1 ? (targetCapacity - 1) : rand.nextInt(targetCapacity);
+        if (size > trigger) {
+          return false;
+        }
+      }
+      return super.offer(r);
+    }
+
+    protected void safeOffer(Runnable r) {
+      // On unbounded/target queue, will always succeed immediately. For bounded, may block.
+      try {
+        super.put(r);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RejectedExecutionException(e);
+      }
+    }
+
+    protected void setMaxPoolReached(boolean maxPoolReached) {
+      this.maxPoolReached = maxPoolReached;
+    }
+  }
+
+  public ScalingThreadPoolExecutor(
+      int corePoolSize,
+      int maxPoolSize,
+      long timeout,
+      TimeUnit timeoutUnit,
+      int queueCapacity,
+      NamedThreadFactory namedThreadFactory) {
+    super(
+        corePoolSize,
+        maxPoolSize,
+        timeout,
+        timeoutUnit,
+        new ScalingQueue(queueCapacity),
+        namedThreadFactory,
+        (r, executor) -> ((ScalingQueue) executor.getQueue()).safeOffer(r));
+  }
+
+  public ScalingThreadPoolExecutor(
+      int corePoolSize,
+      int maxPoolSize,
+      long timeout,
+      TimeUnit timeoutUnit,
+      int targetQueueCapacity,
+      int maxQueueCapacity,
+      NamedThreadFactory namedThreadFactory) {
+    super(
+        corePoolSize,
+        maxPoolSize,
+        timeout,
+        timeoutUnit,
+        new ScalingQueue(targetQueueCapacity, maxQueueCapacity),
+        namedThreadFactory,
+        (r, executor) -> ((ScalingQueue) executor.getQueue()).safeOffer(r));
+  }
+
+  @Override
+  protected void afterExecute(Runnable r, Throwable t) {
+    super.afterExecute(r, t);
+    ((ScalingQueue) getQueue()).setMaxPoolReached(getPoolSize() == getMaximumPoolSize());
+  }
+
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/SingletonNamedThreadFactory.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/SingletonNamedThreadFactory.java
@@ -1,0 +1,16 @@
+package com.orientechnologies.common.thread;
+
+final class SingletonNamedThreadFactory extends BaseThreadFactory {
+
+  private final String name;
+
+  SingletonNamedThreadFactory(final String name, ThreadGroup parentThreadGroup) {
+    super(parentThreadGroup);
+    this.name = name;
+  }
+
+  @Override
+  protected String nextThreadName() {
+    return name;
+  }
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -272,7 +272,13 @@ public class Orient extends OListenerManger<OOrientListener> {
 
       workers =
           OThreadPoolExecutors.newBlockingScalingThreadPool(
-              "Orient Worker", threadGroup, cores, cores * 3, cores * 100, cores * 500, 10,
+              "Orient Worker",
+              threadGroup,
+              cores,
+              cores * 3,
+              cores * 100,
+              cores * 500,
+              10,
               TimeUnit.SECONDS);
 
       registerEngines();

--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -271,8 +271,9 @@ public class Orient extends OListenerManger<OOrientListener> {
       final int cores = Runtime.getRuntime().availableProcessors();
 
       workers =
-          OThreadPoolExecutors.newScalingThreadPool(
-              "Orient Worker", threadGroup, cores, cores * 3, cores * 100, 10, TimeUnit.SECONDS);
+          OThreadPoolExecutors.newBlockingScalingThreadPool(
+              "Orient Worker", threadGroup, cores, cores * 3, cores * 100, cores * 500, 10,
+              TimeUnit.SECONDS);
 
       registerEngines();
 

--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -28,7 +28,7 @@ import com.orientechnologies.common.parser.OSystemVariableResolver;
 import com.orientechnologies.common.profiler.OAbstractProfiler;
 import com.orientechnologies.common.profiler.OProfiler;
 import com.orientechnologies.common.profiler.OProfilerStub;
-import com.orientechnologies.common.thread.OThreadPoolExecutorWithLogging;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.common.util.OClassLoaderHelper;
 import com.orientechnologies.orient.core.cache.OLocalRecordCacheFactory;
 import com.orientechnologies.orient.core.cache.OLocalRecordCacheFactoryImpl;
@@ -64,8 +64,8 @@ import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -133,7 +133,7 @@ public class Orient extends OListenerManger<OOrientListener> {
   private volatile OAbstractProfiler profiler;
   private ODatabaseThreadLocalFactory databaseThreadFactory;
   private volatile boolean active = false;
-  private ThreadPoolExecutor workers;
+  private ExecutorService workers;
   private OSignalHandler signalHandler;
   private volatile OSecuritySystem security;
   private boolean runningDistributed = false;
@@ -271,24 +271,8 @@ public class Orient extends OListenerManger<OOrientListener> {
       final int cores = Runtime.getRuntime().availableProcessors();
 
       workers =
-          new OThreadPoolExecutorWithLogging(
-              cores,
-              cores * 3,
-              10,
-              TimeUnit.SECONDS,
-              new LinkedBlockingQueue<Runnable>(cores * 500) {
-                @Override
-                public boolean offer(Runnable e) {
-                  // turn offer() and add() into a blocking calls (unless interrupted)
-                  try {
-                    put(e);
-                    return true;
-                  } catch (InterruptedException ignore) {
-                    Thread.currentThread().interrupt();
-                  }
-                  return false;
-                }
-              });
+          OThreadPoolExecutors.newScalingThreadPool(
+              "Orient Worker", threadGroup, cores, cores * 3, cores * 100, 10, TimeUnit.SECONDS);
 
       registerEngines();
 
@@ -513,7 +497,7 @@ public class Orient extends OListenerManger<OOrientListener> {
    */
   @Deprecated
   public ThreadPoolExecutor getWorkers() {
-    return workers;
+    return (ThreadPoolExecutor) workers;
   }
 
   public Future<?> submit(final Runnable runnable) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -27,6 +27,7 @@ import com.orientechnologies.common.concur.lock.OModificationOperationProhibited
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OIOUtils;
 import com.orientechnologies.common.log.OLogManager;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.command.script.OScriptManager;
@@ -68,8 +69,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -152,12 +151,13 @@ public class OrientDBEmbedded implements OrientDBInternal {
     orient.addOrientDB(this);
 
     executor =
-        new ThreadPoolExecutor(
+        OThreadPoolExecutors.newScalingThreadPool(
+            "OrientDBEmbedded",
             1,
             Runtime.getRuntime().availableProcessors(),
+            100,
             30,
-            TimeUnit.MINUTES,
-            new LinkedBlockingQueue<>());
+            TimeUnit.MINUTES);
     timer = new Timer();
 
     cachedPoolFactory = createCachedDatabasePoolFactory(this.configurations);

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/OWOWCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/local/OWOWCache.java
@@ -35,12 +35,10 @@ import com.orientechnologies.common.log.OLogManager;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OLongSerializer;
-import com.orientechnologies.common.thread.OScheduledThreadPoolExecutorWithLogging;
-import com.orientechnologies.common.thread.OThreadPoolExecutorWithLogging;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.common.types.OModifiableBoolean;
 import com.orientechnologies.common.util.OQuarto;
 import com.orientechnologies.common.util.ORawPair;
-import com.orientechnologies.common.util.OUncaughtExceptionHandler;
 import com.orientechnologies.orient.core.command.OCommandOutputListener;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.exception.ODatabaseException;
@@ -91,20 +89,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.zip.CRC32;
@@ -207,23 +192,18 @@ public final class OWOWCache extends OAbstractWriteCache
   private static final int CHUNK_SIZE = 64 * 1024 * 1024;
 
   /** Executor which runs in single thread all tasks are related to flush of write cache data. */
-  private static final OScheduledThreadPoolExecutorWithLogging commitExecutor;
+  private static final ScheduledExecutorService commitExecutor;
 
   /** Executor which is used to call event listeners in background thread */
   private static final ExecutorService cacheEventsPublisher;
 
   static {
     cacheEventsPublisher =
-        new OThreadPoolExecutorWithLogging(
-            0,
-            Integer.MAX_VALUE,
-            60L,
-            TimeUnit.SECONDS,
-            new SynchronousQueue<>(),
-            new CacheEventsPublisherFactory());
-
-    commitExecutor = new OScheduledThreadPoolExecutorWithLogging(1, new FlushThreadFactory());
-    commitExecutor.setMaximumPoolSize(1);
+        OThreadPoolExecutors.newCachedThreadPool(
+            "OrientDB Write Cache Event Publisher", OStorageAbstract.storageThreadGroup);
+    commitExecutor =
+        OThreadPoolExecutors.newSingleThreadScheduledPool(
+            "OrientDB Write Cache Flush Task", OStorageAbstract.storageThreadGroup);
   }
 
   /** Limit of free space on disk after which database will be switched to "read only" mode */
@@ -3401,36 +3381,6 @@ public final class OWOWCache extends OAbstractWriteCache
       }
 
       return null;
-    }
-  }
-
-  private static final class FlushThreadFactory implements ThreadFactory {
-
-    private FlushThreadFactory() {}
-
-    @Override
-    public final Thread newThread(final Runnable r) {
-      final Thread thread = new Thread(OStorageAbstract.storageThreadGroup, r);
-      thread.setDaemon(true);
-      thread.setName("OrientDB Write Cache Flush Task");
-      thread.setUncaughtExceptionHandler(new OUncaughtExceptionHandler());
-      return thread;
-    }
-  }
-
-  private static final class CacheEventsPublisherFactory implements ThreadFactory {
-
-    private CacheEventsPublisherFactory() {}
-
-    @Override
-    public final Thread newThread(final Runnable r) {
-      final Thread thread = new Thread(OStorageAbstract.storageThreadGroup, r);
-
-      thread.setDaemon(true);
-      thread.setName("OrientDB Write Cache Event Publisher");
-      thread.setUncaughtExceptionHandler(new OUncaughtExceptionHandler());
-
-      return thread;
     }
   }
 }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/OAbstractPaginatedStorage.java
@@ -33,7 +33,7 @@ import com.orientechnologies.common.profiler.OProfiler;
 import com.orientechnologies.common.serialization.types.OBinarySerializer;
 import com.orientechnologies.common.serialization.types.OIntegerSerializer;
 import com.orientechnologies.common.serialization.types.OUTF8Serializer;
-import com.orientechnologies.common.thread.OScheduledThreadPoolExecutorWithLogging;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.common.types.OModifiableBoolean;
 import com.orientechnologies.common.types.OModifiableLong;
 import com.orientechnologies.common.util.*;
@@ -61,19 +61,6 @@ import com.orientechnologies.orient.core.encryption.OEncryption;
 import com.orientechnologies.orient.core.encryption.OEncryptionFactory;
 import com.orientechnologies.orient.core.encryption.impl.ONothingEncryption;
 import com.orientechnologies.orient.core.exception.*;
-import com.orientechnologies.orient.core.exception.OCommandExecutionException;
-import com.orientechnologies.orient.core.exception.OConcurrentCreateException;
-import com.orientechnologies.orient.core.exception.OConcurrentModificationException;
-import com.orientechnologies.orient.core.exception.OConfigurationException;
-import com.orientechnologies.orient.core.exception.ODatabaseException;
-import com.orientechnologies.orient.core.exception.OFastConcurrentModificationException;
-import com.orientechnologies.orient.core.exception.OInvalidDatabaseNameException;
-import com.orientechnologies.orient.core.exception.OInvalidIndexEngineIdException;
-import com.orientechnologies.orient.core.exception.OInvalidInstanceIdException;
-import com.orientechnologies.orient.core.exception.ORecordNotFoundException;
-import com.orientechnologies.orient.core.exception.ORetryQueryException;
-import com.orientechnologies.orient.core.exception.OStorageException;
-import com.orientechnologies.orient.core.exception.OStorageExistsException;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.index.OIndexAbstract;
@@ -176,7 +163,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -202,12 +189,11 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
   private static final Comparator<ORecordOperation> COMMIT_RECORD_OPERATION_COMPARATOR =
       Comparator.comparing(o -> o.getRecord().getIdentity());
 
-  protected static final OScheduledThreadPoolExecutorWithLogging fuzzyCheckpointExecutor;
+  protected static final ScheduledExecutorService fuzzyCheckpointExecutor;
 
   static {
     fuzzyCheckpointExecutor =
-        new OScheduledThreadPoolExecutorWithLogging(1, new FuzzyCheckpointThreadFactory());
-    fuzzyCheckpointExecutor.setMaximumPoolSize(1);
+        OThreadPoolExecutors.newSingleThreadScheduledPool("Fuzzy Checkpoint", storageThreadGroup);
   }
 
   private final OSimpleRWLockManager<ORID> lockManager;
@@ -7109,16 +7095,6 @@ public abstract class OAbstractPaginatedStorage extends OStorageAbstract
 
   public Optional<byte[]> getLastMetadata() {
     return Optional.ofNullable(lastMetadata);
-  }
-
-  private static final class FuzzyCheckpointThreadFactory implements ThreadFactory {
-    @Override
-    public final Thread newThread(final Runnable r) {
-      final Thread thread = new Thread(storageThreadGroup, r);
-      thread.setDaemon(true);
-      thread.setUncaughtExceptionHandler(new OUncaughtExceptionHandler());
-      return thread;
-    }
   }
 
   private final class WALVacuum implements Runnable {

--- a/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessor.java
+++ b/etl/src/main/java/com/orientechnologies/orient/etl/OETLProcessor.java
@@ -20,6 +20,7 @@ package com.orientechnologies.orient.etl;
 
 import com.orientechnologies.common.exception.OException;
 import com.orientechnologies.common.io.OIOUtils;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.command.OCommandContext;
@@ -39,7 +40,6 @@ import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -100,7 +100,7 @@ public class OETLProcessor {
     factory = new OETLComponentFactory();
     stats = new OETLProcessorStats();
 
-    executor = Executors.newCachedThreadPool();
+    executor = OThreadPoolExecutors.newCachedThreadPool("OETLProcessor");
 
     configRunBehaviour(context);
 

--- a/etl/src/main/java/com/orientechnologies/orient/etl/http/OETLHandler.java
+++ b/etl/src/main/java/com/orientechnologies/orient/etl/http/OETLHandler.java
@@ -1,6 +1,6 @@
 package com.orientechnologies.orient.etl.http;
 
-import com.orientechnologies.common.thread.OThreadPoolExecutorWithLogging;
+import com.orientechnologies.common.thread.OThreadPoolExecutors;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.etl.util.OMigrationConfigManager;
 import com.orientechnologies.orient.server.OServer;
@@ -11,15 +11,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /** Created by gabriele on 27/02/17. */
 public class OETLHandler {
 
-  private ExecutorService pool =
-      new OThreadPoolExecutorWithLogging(
-          1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+  private ExecutorService pool = OThreadPoolExecutors.newSingleThreadPool("OETLHandler");
+
   private OETLJob currentJob = null;
   private OETLListener listener;
 


### PR DESCRIPTION

What does this PR do?

- Consolidates all construction of ThreadPoolExecutors into a single factory class that standardises the logging, thread naming and thread group management (which was inconsistent across many of the instances)
- Fixes many of the thread pool instances to scale as intended 

Motivation
Most of the thread pool executors in OrientDB look like they were designed to scale, but because of the peculiarities of the JDK ThreadPoolExecutor, do not.

Additional Notes

The JDK ThreadPoolExecutor has a very unintuitive API, where the behaviour of the BlockingQueue used by the executor determines whether the pool will scale beyond the core (up to the max threads). Only a queue that fails on `offer` will cause growth of the pool beyond the core, so any executor using an unbounded LinkedBlockingQueue (for example) would never grow beyond core.

I've factored all the instantiations into a single factory class, and created thread pool implementations that actually behave as the construction seems to have intended (except for specific cases as noted below). Someone more familiar with the parts of the OrientDB engine should review to ensure this was the intended behaviour, or whether a different behaviour is required.

The scaling implementation uses a custom blocking queue that tricks the ThreadPoolExecutor into scaling based on a target queue size. The target queue size can be as low as 0 (which will force the thread pool to grow in favour of queuing), and triggers the thread pool probabilistically as the queue grows closer to the target size.

I haven't tried to implement blocking - this is surprisingly hard to achieve safely given all the edge cases in the thread pool lifecycle.

Notes on specific thread pools:

- `OrientDBEmbedded` - intent seems to have been to scale from 1 to available processors, but would only ever allocate 1 thread. It now scales as intended, with a target queue size of 100. 
- `OWowCache` - this is simply a cached thread pool construct
- `Orient` - this made an attempt to implement a blocking construct, but because the override of `offer` never returned false, the pool size would never scale beyond the core size. It now scales as intended but will queue instead of blocking.
- `ODistributedDatabaseImpl` - this was intended to scale to `totalWorkers` but would never grow past 1 thread. It now scales between 1 and `totalWorkers`, with a target queue size of 0 forcing thread scaling in preference to queuing (since these are latency sensitive).
- `OPushManager` - this scaled from 0 to 5 threads, but would reject executions. New implementation behaves as previously.

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios

