### PR TITLE
WIP - Improved HA stability

### DIFF
--- a/client/src/main/java/com/orientechnologies/orient/core/db/OrientDBRemote.java
+++ b/client/src/main/java/com/orientechnologies/orient/core/db/OrientDBRemote.java
@@ -446,6 +446,11 @@ public class OrientDBRemote implements OrientDBInternal {
   }
 
   @Override
+  public ODatabaseDocumentInternal openInternal(String iDbUrl, String user) {
+    throw new UnsupportedOperationException("Open for internal use is not supported in remote");
+  }
+
+  @Override
   public ODatabaseDocumentInternal openNoAuthenticate(String iDbUrl, String user) {
     throw new UnsupportedOperationException(
         "Open with no authentication is not supported in remote");

--- a/core/src/main/java/com/orientechnologies/common/thread/OScheduledThreadPoolExecutorWithLogging.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OScheduledThreadPoolExecutorWithLogging.java
@@ -1,18 +1,14 @@
 package com.orientechnologies.common.thread;
 
 import com.orientechnologies.common.log.OLogManager;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.*;
 
 /**
  * The same as thread {@link ScheduledThreadPoolExecutor} but also logs all exceptions happened
  * inside of the tasks which caused tasks to stop.
  */
-public class OScheduledThreadPoolExecutorWithLogging extends ScheduledThreadPoolExecutor {
+public class OScheduledThreadPoolExecutorWithLogging extends ScheduledThreadPoolExecutor
+    implements TracingScheduledExecutorService {
   public OScheduledThreadPoolExecutorWithLogging(int corePoolSize) {
     super(corePoolSize);
   }
@@ -57,5 +53,169 @@ public class OScheduledThreadPoolExecutorWithLogging extends ScheduledThreadPool
       final Thread thread = Thread.currentThread();
       OLogManager.instance().errorNoDb(this, "Exception in thread '%s'", t, thread.getName());
     }
+  }
+
+  @Override
+  public <T> Future<T> submit(String taskName, Callable<T> task) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            return task.call();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        });
+  }
+
+  @Override
+  public Future<?> submit(String taskName, Runnable task) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            task.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        });
+  }
+
+  @Override
+  public <T> Future<T> submit(String taskName, Runnable task, T result) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            task.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        },
+        result);
+  }
+
+  @Override
+  public void execute(String taskName, Runnable command) {
+    final OTracedExecutionException trace =
+        OTracedExecutionException.prepareTrace(taskName, command);
+    super.execute(
+        () -> {
+          try {
+            command.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, command);
+          }
+        });
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return submit((String) null, task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return submit((String) null, task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return submit(null, task, result);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    execute(null, command);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(String taskName, Runnable command, long delay, TimeUnit unit) {
+    final OTracedExecutionException trace =
+        OTracedExecutionException.prepareTrace(taskName, command);
+    return super.schedule(
+        () -> {
+          try {
+            command.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, command);
+          }
+        },
+        delay,
+        unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(
+      String taskName, Callable<V> task, long delay, TimeUnit unit) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.schedule(
+        () -> {
+          try {
+            return task.call();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        },
+        delay,
+        unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(
+      String taskName, Runnable command, long initialDelay, long period, TimeUnit unit) {
+    final OTracedExecutionException trace =
+        OTracedExecutionException.prepareTrace(taskName, command);
+    return super.scheduleAtFixedRate(
+        () -> {
+          try {
+            command.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, command);
+          }
+        },
+        initialDelay,
+        period,
+        unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(
+      String taskName, Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    final OTracedExecutionException trace =
+        OTracedExecutionException.prepareTrace(taskName, command);
+    return super.scheduleWithFixedDelay(
+        () -> {
+          try {
+            command.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, command);
+          }
+        },
+        initialDelay,
+        delay,
+        unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    return schedule(null, command, delay, unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    return schedule(null, callable, delay, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(
+      Runnable command, long initialDelay, long period, TimeUnit unit) {
+    return scheduleAtFixedRate(null, command, initialDelay, period, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(
+      Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    return scheduleWithFixedDelay(null, command, initialDelay, delay, unit);
   }
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutorWithLogging.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutorWithLogging.java
@@ -2,6 +2,7 @@ package com.orientechnologies.common.thread;
 
 import com.orientechnologies.common.log.OLogManager;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -14,7 +15,8 @@ import java.util.concurrent.TimeUnit;
  * The same as thread {@link ThreadPoolExecutor} but also logs all exceptions happened inside of the
  * tasks which caused tasks to stop.
  */
-public class OThreadPoolExecutorWithLogging extends ThreadPoolExecutor {
+public class OThreadPoolExecutorWithLogging extends ThreadPoolExecutor
+    implements TracingExecutorService {
   public OThreadPoolExecutorWithLogging(
       int corePoolSize,
       int maximumPoolSize,
@@ -78,5 +80,79 @@ public class OThreadPoolExecutorWithLogging extends ThreadPoolExecutor {
       final Thread thread = Thread.currentThread();
       OLogManager.instance().errorNoDb(this, "Exception in thread '%s'", t, thread.getName());
     }
+  }
+
+  @Override
+  public <T> Future<T> submit(String taskName, Callable<T> task) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            return task.call();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        });
+  }
+
+  @Override
+  public Future<?> submit(String taskName, Runnable task) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            task.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        });
+  }
+
+  @Override
+  public <T> Future<T> submit(String taskName, Runnable task, T result) {
+    final OTracedExecutionException trace = OTracedExecutionException.prepareTrace(taskName, task);
+    return super.submit(
+        () -> {
+          try {
+            task.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, task);
+          }
+        },
+        result);
+  }
+
+  @Override
+  public void execute(String taskName, Runnable command) {
+    final OTracedExecutionException trace =
+        OTracedExecutionException.prepareTrace(taskName, command);
+    super.execute(
+        () -> {
+          try {
+            command.run();
+          } catch (Exception e) {
+            throw OTracedExecutionException.trace(trace, e, taskName, command);
+          }
+        });
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return submit((String) null, task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return submit((String) null, task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return submit(null, task, result);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    execute(null, command);
   }
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -130,4 +130,21 @@ public class OThreadPoolExecutors {
     return new OScheduledThreadPoolExecutorWithLogging(
         1, new SingletonNamedThreadFactory(threadName, parentThreadGroup));
   }
+
+  private static final TracingExecutorService GLOBAL_EXECUTOR =
+      newCachedThreadPool("OrientDB-Global");
+
+  public static void executeUnbound(Runnable task, String name) {
+    GLOBAL_EXECUTOR.submit(
+        name,
+        () -> {
+          final String poolThreadName = Thread.currentThread().getName();
+          try {
+            Thread.currentThread().setName(name);
+            task.run();
+          } finally {
+            Thread.currentThread().setName(poolThreadName);
+          }
+        });
+  }
 }

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -121,11 +121,11 @@ public class OThreadPoolExecutors {
         rejectHandler);
   }
 
-  public static ScheduledExecutorService newSingleThreadScheduledPool(String threadName) {
+  public static TracingScheduledExecutorService newSingleThreadScheduledPool(String threadName) {
     return newSingleThreadScheduledPool(threadName, Thread.currentThread().getThreadGroup());
   }
 
-  public static ScheduledExecutorService newSingleThreadScheduledPool(
+  public static TracingScheduledExecutorService newSingleThreadScheduledPool(
       String threadName, ThreadGroup parentThreadGroup) {
     return new OScheduledThreadPoolExecutorWithLogging(
         1, new SingletonNamedThreadFactory(threadName, parentThreadGroup));

--- a/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OThreadPoolExecutors.java
@@ -6,7 +6,7 @@ public class OThreadPoolExecutors {
 
   private OThreadPoolExecutors() {}
 
-  public static ExecutorService newScalingThreadPool(
+  public static TracingExecutorService newScalingThreadPool(
       String threadName,
       int corePoolSize,
       int maxPoolSize,
@@ -23,7 +23,7 @@ public class OThreadPoolExecutors {
         timeoutUnit);
   }
 
-  public static ExecutorService newScalingThreadPool(
+  public static TracingExecutorService newScalingThreadPool(
       String threadName,
       ThreadGroup parentThreadGroup,
       int corePoolSize,
@@ -40,7 +40,7 @@ public class OThreadPoolExecutors {
         new NamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  public static ExecutorService newBlockingScalingThreadPool(
+  public static TracingExecutorService newBlockingScalingThreadPool(
       String threadName,
       ThreadGroup parentThreadGroup,
       int corePoolSize,
@@ -59,11 +59,11 @@ public class OThreadPoolExecutors {
         new NamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  public static ExecutorService newFixedThreadPool(String threadName, int poolSize) {
+  public static TracingExecutorService newFixedThreadPool(String threadName, int poolSize) {
     return newFixedThreadPool(threadName, Thread.currentThread().getThreadGroup(), poolSize);
   }
 
-  public static ExecutorService newFixedThreadPool(
+  public static TracingExecutorService newFixedThreadPool(
       String threadName, ThreadGroup parentThreadGroup, int poolSize) {
     return new OThreadPoolExecutorWithLogging(
         poolSize,
@@ -74,16 +74,16 @@ public class OThreadPoolExecutors {
         new NamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  public static ExecutorService newCachedThreadPool(String threadName) {
+  public static TracingExecutorService newCachedThreadPool(String threadName) {
     return newCachedThreadPool(threadName, Thread.currentThread().getThreadGroup());
   }
 
-  public static ExecutorService newCachedThreadPool(
+  public static TracingExecutorService newCachedThreadPool(
       String threadName, ThreadGroup parentThreadGroup) {
     return newCachedThreadPool(threadName, parentThreadGroup, Integer.MAX_VALUE, 0);
   }
 
-  public static ExecutorService newCachedThreadPool(
+  public static TracingExecutorService newCachedThreadPool(
       String threadName, ThreadGroup parentThreadGroup, int maxThreads, int maxQueue) {
     return new OThreadPoolExecutorWithLogging(
         0,
@@ -94,11 +94,11 @@ public class OThreadPoolExecutors {
         new NamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  public static ExecutorService newSingleThreadPool(String threadName) {
+  public static TracingExecutorService newSingleThreadPool(String threadName) {
     return newSingleThreadPool(threadName, Thread.currentThread().getThreadGroup());
   }
 
-  public static ExecutorService newSingleThreadPool(
+  public static TracingExecutorService newSingleThreadPool(
       String threadName, ThreadGroup parentThreadGroup) {
     return new OThreadPoolExecutorWithLogging(
         1,
@@ -109,7 +109,7 @@ public class OThreadPoolExecutors {
         new SingletonNamedThreadFactory(threadName, parentThreadGroup));
   }
 
-  public static ExecutorService newSingleThreadPool(
+  public static TracingExecutorService newSingleThreadPool(
       String threadName, int maxQueue, RejectedExecutionHandler rejectHandler) {
     return new OThreadPoolExecutorWithLogging(
         1,

--- a/core/src/main/java/com/orientechnologies/common/thread/OTracedExecutionException.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/OTracedExecutionException.java
@@ -1,0 +1,51 @@
+package com.orientechnologies.common.thread;
+
+import com.orientechnologies.common.exception.OException;
+import com.orientechnologies.common.log.OLogManager;
+
+public class OTracedExecutionException extends OException {
+
+  public OTracedExecutionException(String message, Exception cause) {
+    super(message);
+    initCause(cause);
+  }
+
+  public OTracedExecutionException(String message) {
+    super(message);
+  }
+
+  private static String taskName(String taskName, Object task) {
+    if (taskName != null) {
+      return taskName;
+    }
+    if (task != null) {
+      return task.getClass().getSimpleName();
+    }
+    return "?";
+  }
+
+  public static OTracedExecutionException prepareTrace(String taskName, Object task) {
+    final OTracedExecutionException trace;
+    if (OLogManager.instance().isDebugEnabled()) {
+      trace =
+          new OTracedExecutionException(
+              String.format("Async task [%s] failed", taskName(taskName, task)));
+      trace.fillInStackTrace();
+    } else {
+      trace = null;
+    }
+    return trace;
+  }
+
+  public static OTracedExecutionException trace(
+      OTracedExecutionException trace, Exception e, String taskName, Object task)
+      throws OTracedExecutionException {
+    if (trace != null) {
+      trace.initCause(e);
+      return trace;
+    } else {
+      return new OTracedExecutionException(
+          String.format("Async task [%s] failed", taskName(taskName, task)), e);
+    }
+  }
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/TracingExecutorService.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/TracingExecutorService.java
@@ -1,0 +1,16 @@
+package com.orientechnologies.common.thread;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public interface TracingExecutorService extends ExecutorService {
+
+  <T> Future<T> submit(String taskName, Callable<T> task);
+
+  Future<?> submit(String taskName, Runnable task);
+
+  <T> Future<T> submit(String taskName, Runnable task, T result);
+
+  void execute(String taskName, Runnable command);
+}

--- a/core/src/main/java/com/orientechnologies/common/thread/TracingScheduledExecutorService.java
+++ b/core/src/main/java/com/orientechnologies/common/thread/TracingScheduledExecutorService.java
@@ -1,0 +1,20 @@
+package com.orientechnologies.common.thread;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public interface TracingScheduledExecutorService
+    extends TracingExecutorService, ScheduledExecutorService {
+
+  ScheduledFuture<?> schedule(String taskName, Runnable command, long delay, TimeUnit unit);
+
+  <V> ScheduledFuture<V> schedule(String taskName, Callable<V> callable, long delay, TimeUnit unit);
+
+  ScheduledFuture<?> scheduleAtFixedRate(
+      String taskName, Runnable command, long initialDelay, long period, TimeUnit unit);
+
+  ScheduledFuture<?> scheduleWithFixedDelay(
+      String taskName, Runnable command, long initialDelay, long delay, TimeUnit unit);
+}

--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -411,6 +411,11 @@ public class Orient extends OListenerManger<OOrientListener> {
   }
 
   public TimerTask scheduleTask(final Runnable task, final long delay, final long period) {
+    return scheduleTask(task.getClass().getSimpleName(), task, delay, period);
+  }
+
+  public TimerTask scheduleTask(
+      final String taskName, final Runnable task, final long delay, final long period) {
     engineLock.readLock().lock();
     try {
       final TimerTask timerTask =
@@ -421,16 +426,10 @@ public class Orient extends OListenerManger<OOrientListener> {
                 task.run();
               } catch (Exception e) {
                 OLogManager.instance()
-                    .error(
-                        this,
-                        "Error during execution of task " + task.getClass().getSimpleName(),
-                        e);
+                    .error(Orient.this, "Error during execution of task " + taskName, e);
               } catch (Error e) {
                 OLogManager.instance()
-                    .error(
-                        this,
-                        "Error during execution of task " + task.getClass().getSimpleName(),
-                        e);
+                    .error(Orient.this, "Error during execution of task " + taskName, e);
                 throw e;
               }
             }

--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -452,45 +452,7 @@ public class Orient extends OListenerManger<OOrientListener> {
   }
 
   public TimerTask scheduleTask(final Runnable task, final Date firstTime, final long period) {
-    engineLock.readLock().lock();
-    try {
-      final TimerTask timerTask =
-          new TimerTask() {
-            @Override
-            public void run() {
-              try {
-                task.run();
-              } catch (Exception e) {
-                OLogManager.instance()
-                    .error(
-                        this,
-                        "Error during execution of task " + task.getClass().getSimpleName(),
-                        e);
-              } catch (Error e) {
-                OLogManager.instance()
-                    .error(
-                        this,
-                        "Error during execution of task " + task.getClass().getSimpleName(),
-                        e);
-                throw e;
-              }
-            }
-          };
-
-      if (active) {
-        if (period > 0) {
-          timer.schedule(timerTask, firstTime, period);
-        } else {
-          timer.schedule(timerTask, firstTime);
-        }
-      } else {
-        OLogManager.instance().warn(this, "OrientDB engine is down. Task will not be scheduled.");
-      }
-
-      return timerTask;
-    } finally {
-      engineLock.readLock().unlock();
-    }
+    return scheduleTask(task, firstTime.getTime() - System.currentTimeMillis(), period);
   }
 
   public boolean isActive() {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -849,7 +849,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
     }
   }
 
-  public ODatabasePoolInternal openPool(String name, String user, String password) {
+  public final ODatabasePoolInternal openPool(String name, String user, String password) {
     return openPool(name, user, password, null);
   }
 
@@ -864,7 +864,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
   }
 
   @Override
-  public ODatabasePoolInternal cachedPool(String database, String user, String password) {
+  public final ODatabasePoolInternal cachedPool(String database, String user, String password) {
     return cachedPool(database, user, password, null);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -581,7 +581,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
     return basePath + "/" + name;
   }
 
-  public void create(String name, String user, String password, ODatabaseType type) {
+  public final void create(String name, String user, String password, ODatabaseType type) {
     create(name, user, password, type, null);
   }
 

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -539,6 +539,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
       String name, String user, String password, ODatabasePoolInternal pool) {
     final ODatabaseDocumentEmbedded embedded;
     synchronized (this) {
+      checkDatabaseName(name);
       checkOpen();
       OAbstractPaginatedStorage storage = getAndOpenStorage(name, pool.getConfig());
       embedded = newPooledSessionInstance(pool, storage);
@@ -810,10 +811,8 @@ public class OrientDBEmbedded implements OrientDBInternal {
 
   @Override
   public void drop(String name, String user, String password) {
-    synchronized (this) {
-      checkOpen();
-    }
     checkDatabaseName(name);
+    checkOpen();
     ODatabaseDocumentInternal current = ODatabaseRecordThreadLocal.instance().getIfDefined();
     try {
       ODatabaseDocumentInternal db = openNoAuthenticate(name, user);

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -451,6 +451,11 @@ public class OrientDBEmbedded implements OrientDBInternal {
     return doOpen(name, user, password, true, config);
   }
 
+  @Override
+  public final ODatabaseDocumentEmbedded openInternal(String name, String user) {
+    return doOpen(name, user, null, false, null);
+  }
+
   public ODatabaseDocumentEmbedded openNoAuthenticate(String name, String user) {
     return doOpen(name, user, null, false, null);
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBInternal.java
@@ -288,6 +288,8 @@ public interface OrientDBInternal extends AutoCloseable, OSchedulerInternal {
     return orientDB.internal;
   }
 
+  ODatabaseDocumentInternal openInternal(String iDbUrl, String user);
+
   ODatabaseDocumentInternal openNoAuthenticate(String iDbUrl, String user);
 
   ODatabaseDocumentInternal openNoAuthorization(String name);

--- a/core/src/main/java/com/orientechnologies/orient/core/db/viewmanager/ViewManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/viewmanager/ViewManager.java
@@ -97,15 +97,17 @@ public class ViewManager {
   }
 
   protected void init() {
-    orientDB.executeNoAuthorization(
-        dbName,
-        (db) -> {
-          // do this to make sure that the storage is already initialized and so is the shared
-          // context.
-          // you just don't need the db passed as a param here
-          registerLiveUpdates(db);
-          return null;
-        });
+    ((OrientDBEmbedded) orientDB)
+        .executeInternalNoAuthorization(
+            "ViewManager.registerLiveUpdates",
+            dbName,
+            (db) -> {
+              // do this to make sure that the storage is already initialized and so is the shared
+              // context.
+              // you just don't need the db passed as a param here
+              registerLiveUpdates(db);
+              return null;
+            });
   }
 
   private synchronized void registerLiveUpdates(ODatabaseSession db) {

--- a/core/src/main/java/com/orientechnologies/orient/core/db/viewmanager/ViewManager.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/viewmanager/ViewManager.java
@@ -178,18 +178,20 @@ public class ViewManager {
     }
     if (lastTask != null) {
       try {
-        try {
+        // Try to cancel last task before it runs, otherwise wait for completion
+        if (!lastTask.cancel(false)) {
           lastTask.get(20, TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-          lastTask.cancel(true);
-          lastTask.get();
         }
-
+      } catch (TimeoutException e) {
+        OLogManager.instance()
+            .warn(
+                this,
+                "Timeout waiting for last task to complete view update background operations");
       } catch (InterruptedException e) {
         throw OException.wrapException(
             new OInterruptedException("Terminated while waiting update view to finis"), e);
       } catch (ExecutionException e) {
-        OLogManager.instance().warn(this, "Issue terminating view update background operations", e);
+        // Will already have been logged by thread pool executor
       }
     }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
@@ -62,6 +62,15 @@ public class OrientDBDistributed extends OrientDBEmbedded implements OServerAwar
     return plugin;
   }
 
+  @Override
+  public void create(
+      String name, String user, String password, ODatabaseType type, OrientDBConfig config) {
+    if (isDistributedEnabled() && (plugin == null)) {
+      throw new OOfflineNodeException("Distributed plugin is not active");
+    }
+    super.create(name, user, password, type, config);
+  }
+
   protected OSharedContext createSharedContext(OAbstractPaginatedStorage storage) {
     if (!isDistributedEnabled() || OSystemDatabase.SYSTEM_DB_NAME.equals(storage.getName())) {
       return new OSharedContextEmbedded(storage, this);

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -1008,7 +1008,7 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
       // DON'T REPLICATE SYSTEM BECAUSE IS DIFFERENT AND PER SERVER
       return false;
 
-    if (installingDatabases.contains(databaseName)) {
+    if (!installingDatabases.add(databaseName)) {
       return false;
     }
 
@@ -1016,7 +1016,6 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
         messageService.registerDatabase(databaseName, null);
 
     try {
-      installingDatabases.add(databaseName);
       return executeInDistributedDatabaseLock(
           databaseName,
           20000,

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -20,6 +20,8 @@
 package com.orientechnologies.orient.server.distributed.impl;
 
 import static com.orientechnologies.orient.core.config.OGlobalConfiguration.DISTRIBUTED_MAX_STARTUP_DELAY;
+import static com.orientechnologies.orient.server.distributed.ODistributedServerManager.NODE_STATUS.OFFLINE;
+import static com.orientechnologies.orient.server.distributed.ODistributedServerManager.NODE_STATUS.SHUTTINGDOWN;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -1978,6 +1980,10 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
       OModifiableDistributedConfiguration lastCfg,
       final OCallable<T, OModifiableDistributedConfiguration> iCallback) {
 
+    if (getNodeStatus() == SHUTTINGDOWN || getNodeStatus() == OFFLINE) {
+      throw new OOfflineNodeException(
+          String.format("Node %s is shutting down or offline.", nodeName));
+    }
     boolean updated;
     T result;
     getLockManagerExecutor().acquireExclusiveLock(databaseName, nodeName, timeoutLocking);

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
@@ -903,9 +903,7 @@ public class ODistributedDatabaseImpl implements ODistributedDatabase {
 
   @Override
   public ODatabaseDocumentInternal getDatabaseInstance() {
-    return manager
-        .getServerInstance()
-        .openDatabase(databaseName, "internal", "internal", null, true);
+    return manager.getServerInstance().openDatabase(databaseName);
   }
 
   @Override

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
@@ -910,7 +910,10 @@ public class ODistributedDatabaseImpl implements ODistributedDatabase {
     shutdown(true);
   }
 
-  public void shutdown(boolean wait) {
+  public synchronized void shutdown(boolean wait) {
+    if (!running) {
+      return;
+    }
     waitPending();
     running = false;
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedMessageServiceImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedMessageServiceImpl.java
@@ -57,7 +57,7 @@ public class ODistributedMessageServiceImpl implements ODistributedMessageServic
   private final ConcurrentHashMap<Long, ODistributedResponseManager> responsesByRequestIds;
   private final TimerTask asynchMessageManager;
   protected final ConcurrentHashMap<String, ODistributedDatabaseImpl> databases =
-      new ConcurrentHashMap<String, ODistributedDatabaseImpl>();
+      new ConcurrentHashMap<>();
   private Thread responseThread;
   private long[] responseTimeMetrics = new long[10];
   private volatile boolean running = true;
@@ -153,11 +153,8 @@ public class ODistributedMessageServiceImpl implements ODistributedMessageServic
   /** Creates a distributed database instance if not defined yet. */
   public ODistributedDatabaseImpl registerDatabase(
       final String iDatabaseName, ODistributedConfiguration cfg) {
-    final ODistributedDatabaseImpl ddb = databases.get(iDatabaseName);
-    if (ddb != null) return ddb;
-
-    return new ODistributedDatabaseImpl(
-        manager, this, iDatabaseName, cfg, manager.getServerInstance());
+    return databases.computeIfAbsent(
+        iDatabaseName, db -> new ODistributedDatabaseImpl(manager, this, iDatabaseName));
   }
 
   public ODistributedDatabaseImpl unregisterDatabase(final String iDatabaseName) {

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase2Task.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OTransactionPhase2Task.java
@@ -147,7 +147,8 @@ public class OTransactionPhase2Task extends OAbstractReplicatedTask implements O
           OLogManager.instance()
               .info(
                   OTransactionPhase2Task.this,
-                  "Received second phase but not yet first phase, re-enqueue second phase");
+                  "Received second phase but not yet first phase for commit tx:%s, re-enqueue second phase",
+                  firstPhaseId);
           ((ODatabaseDocumentDistributed) database)
               .getStorageDistributed()
               .getLocalDistributedDatabase()

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/sql/OCommandExecutorSQLHASyncCluster.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/sql/OCommandExecutorSQLHASyncCluster.java
@@ -257,7 +257,7 @@ public class OCommandExecutorSQLHASyncCluster extends OCommandExecutorSQLAbstrac
 
       ODatabaseDocumentInternal db = ODatabaseRecordThreadLocal.instance().getIfDefined();
       final boolean openDatabaseHere = db == null;
-      if (db == null) db = serverInstance.openDatabase("plocal:" + dbPath, "", "", null, true);
+      if (db == null) db = serverInstance.openDatabase("plocal:" + dbPath);
 
       try {
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -163,7 +163,6 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
   public void startup() {
     if (!enabled) return;
 
-    running = true;
     if (serverInstance.getDatabases() instanceof OrientDBDistributed)
       ((OrientDBDistributed) serverInstance.getDatabases()).setPlugin(this);
 
@@ -372,6 +371,7 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
           new ODistributedStartupException("Error on starting distributed plugin"), e);
     }
 
+    running = true;
     dumpServersStatus();
   }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/hazelcast/OHazelcastPlugin.java
@@ -164,6 +164,17 @@ public class OHazelcastPlugin extends ODistributedAbstractPlugin
   public void startup() {
     if (!enabled) return;
 
+    try {
+      final String delayEnv = System.getenv("HAZELCAST_PLUGIN_STARTUP_DELAY");
+      if (delayEnv != null) {
+        long delay = Long.parseLong(delayEnv);
+        OLogManager.instance().info(this, "Delaying HazelcastPlugin startup by '%d' ms", delay);
+        Thread.sleep(delay);
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+    }
+
     if (serverInstance.getDatabases() instanceof OrientDBDistributed)
       ((OrientDBDistributed) serverInstance.getDatabases()).setPlugin(this);
 

--- a/server/src/main/java/com/orientechnologies/orient/server/OServer.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/OServer.java
@@ -977,7 +977,7 @@ public class OServer {
     // TODO: final String path = getStoragePath(iDbUrl); it use to resolve the path in some way
     boolean serverAuth = false;
     if (iBypassAccess) {
-      database = databases.openNoAuthenticate(iDbUrl, user);
+      database = databases.openInternal(iDbUrl, user);
       serverAuth = true;
     } else {
       OServerUserConfiguration serverUser = serverLogin(user, password, "database.passthrough");

--- a/server/src/main/java/com/orientechnologies/orient/server/handler/OAutomaticBackup.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/handler/OAutomaticBackup.java
@@ -183,7 +183,7 @@ public class OAutomaticBackup extends OServerPluginAbstract implements OServerPl
                 if (include) {
                   ODatabaseDocumentInternal db = null;
                   try {
-                    db = serverInstance.openDatabase(dbName, null, null, null, true);
+                    db = serverInstance.openDatabase(dbName);
 
                     final long begin = System.currentTimeMillis();
 


### PR DESCRIPTION
## What does this PR do?

This is an in-progress set of changes we're working on to increase the stability of OrientDB in HA/distributed deployments.
We're currently testing these fixes in pre-production and then moving them to production, but are opening them up now for discussion to see if there are potentially better ways to fix these issues, and allow broader testing to see if they introduce other issues (as we don't exhaustively test all features/APIs).

## Motivation

We have encountered multiple outages in production due to various stability issues related to distributed operation.
These issues are numerous and somewhat interacting, and required the development of a dedicated stress test suite to replicate in development.

A full list of the unique issues encountered during testing is too long to enumerate, covering many (many) different exceptions, but a general overview of the core issues follows:

- there is no way to remotely (via API) verify the HA status of the servers/databases in the community edition. This is remedied by a small update to the `HA STATUS -servers` query to effectively do what the enterprise agent APIs can achieve.
- database opening is not coordinated with the distributed plugin status, allowing some internal structures (notably shared context construction) to be initialised in the window between startup and distributed plugin startup completing if there is a client transaction load on the database during node startup, resulting in inconsistent initialisation and subsequent transaction failures.
- database opening does not effectively check that the distributed server/database status was online, resulting in access to inconsistent/uninitialised state and subsequent exceptions during transactions.
- remote full database install sometimes fails with corrupted zip streams. We suspect this is related to a stream copying bug,  which is patched and seems to have fixed that issue.
- construction of the DistributedDatabaseImpl was not thread-safe, and allowed uninitialised object structures to be accessed, causing NPEs at runtime.
- database creation suffers from similar issues to database opening when load exists on the server, so checks have been added to prevent database creation before the HA status is stable.

## Related issues

There's a patch in this PR that artificially widens the distributed plugin startup time - we found that this allows easier reproduction of the production issues we observe. The cause of this is that the distributed plugin makes TCP connections to remote nodes during startup, which in our production case is cross AZ in AWS and thus has higher latencies than a local data-centre, which increases the window in which some of the startup issues occur.

During testing/resolving these issues, multiple enhancements were made to logging/tracing:

- a facility to name and trace async tasks has been added, allowing failed background tasks to be identified precisely in logs to make debugging error conditions much easier.
- the log format used when an exception is logged is corrected - currently it omits the leading newline and the formatting, which causes error messages to be smashed into the preceding log message.
- various individual cases of incorrect logging of errors were fixed.

The stress test tool we have developed is now available at [https://github.com/indexity-io/orientdb-stress]. It's open source licensed, but we've kept it distinct from OrientDB as it needs to run across multiple versions/patches and that doesn't work well in-tree. It currently requires some of the patches in this branch to run successfully.

## Additional Notes

There is an additional class of issues that this branch does not currently fix, which is related to storage closures during database installation while in-flight transactions have already opened the database. This causes transaction errors due to closed in-memory and on-disk structures, and often leads to cascading database installs, failed updates and (in rarer situations) lost updates.
We have some fixes designed for this issue, but are debating whether it's worth developing them further as they are not observed with the enterprise agent deployed (the full database sync in the enterprise edition does not close storage for backup/remote install, and so does not encounter these problems).

I've ported these changes to 3.2 and tested to the point that I'm fairly confident that they can be reproduced in that branch and solve the same issues - 3.2 already had some changes that 3.1 did not have that try to address some of these issues, but fail under stress testing without the fixes in this branch. I've paused that work for now until the 3.1 changes can be discussed and made stable.
There are additional issues in 3.2 that will need to be addressed (creating databases currently fails in a distributed cluster soon after startup) that cause problems for the stress test tool, and 3.2 also suffers from the issues with database storage closure under load (in particular I've observed lost updates on some occasions).

## Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
