### PR TITLE
Fix copyStream to not terminate on 0 byte read.

### DIFF
--- a/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
+++ b/core/src/main/java/com/orientechnologies/common/io/OIOUtils.java
@@ -183,14 +183,11 @@ public class OIOUtils {
     }
   }
 
-  public static long copyStream(final InputStream in, final OutputStream out, long iMax)
-      throws IOException {
-    if (iMax < 0) iMax = Long.MAX_VALUE;
-
+  public static long copyStream(final InputStream in, final OutputStream out) throws IOException {
     final byte[] buf = new byte[8192];
     int byteRead = 0;
     long byteTotal = 0;
-    while ((byteRead = in.read(buf, 0, (int) Math.min(buf.length, iMax - byteTotal))) > 0) {
+    while ((byteRead = in.read(buf)) != -1) {
       out.write(buf, 0, byteRead);
       byteTotal += byteRead;
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/compression/impl/OZIPCompressionUtil.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/compression/impl/OZIPCompressionUtil.java
@@ -112,7 +112,7 @@ public class OZIPCompressionUtil {
     final BufferedOutputStream out =
         new BufferedOutputStream(new FileOutputStream(new File(outdir, name)));
     try {
-      OIOUtils.copyStream(in, out, -1);
+      OIOUtils.copyStream(in, out);
     } finally {
       out.close();
     }
@@ -249,7 +249,7 @@ public class OZIPCompressionUtil {
     try {
       final FileInputStream in = new FileInputStream(folderName);
       try {
-        OIOUtils.copyStream(in, zos, -1);
+        OIOUtils.copyStream(in, zos);
       } finally {
         in.close();
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/ORecordAbstract.java
@@ -165,7 +165,7 @@ public abstract class ORecordAbstract implements ORecord {
 
   public <RET extends ORecord> RET fromJSON(final InputStream iContentResult) throws IOException {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    OIOUtils.copyStream(iContentResult, out, -1);
+    OIOUtils.copyStream(iContentResult, out);
     ORecordSerializerJSON.INSTANCE.fromString(out.toString(), this, null);
     return (RET) this;
   }

--- a/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java
@@ -178,7 +178,7 @@ public class ODocument extends ORecordAbstract
    */
   public ODocument(final InputStream iSource) throws IOException {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    OIOUtils.copyStream(iSource, out, -1);
+    OIOUtils.copyStream(iSource, out);
     source = out.toByteArray();
     setup(ODatabaseRecordThreadLocal.instance().getIfDefined());
   }

--- a/lucene/src/test/java/com/orientechnologies/spatial/LuceneSpatialMultiPolygonTest.java
+++ b/lucene/src/test/java/com/orientechnologies/spatial/LuceneSpatialMultiPolygonTest.java
@@ -103,7 +103,7 @@ public class LuceneSpatialMultiPolygonTest extends BaseSpatialLuceneTest {
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-    OIOUtils.copyStream(systemResourceAsStream, outputStream, -1);
+    OIOUtils.copyStream(systemResourceAsStream, outputStream);
     db.command(
             new OCommandSQL(
                 "insert into Place set name = 'TestInsert' , location = ST_GeomFromText('"
@@ -132,7 +132,7 @@ public class LuceneSpatialMultiPolygonTest extends BaseSpatialLuceneTest {
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-    OIOUtils.copyStream(systemResourceAsStream, outputStream, -1);
+    OIOUtils.copyStream(systemResourceAsStream, outputStream);
 
     JtsSpatialContext.GEO.getWktShapeParser().parse(outputStream.toString());
   }

--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetStaticContent.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/command/get/OServerCommandGetStaticContent.java
@@ -150,7 +150,7 @@ public class OServerCommandGetStaticContent extends OServerCommandConfigurableAb
         ByteArrayOutputStream bytesOutput = new ByteArrayOutputStream();
         GZIPOutputStream stream = new GZIPOutputStream(bytesOutput, 16384);
         try {
-          OIOUtils.copyStream(staticContent.is, stream, -1);
+          OIOUtils.copyStream(staticContent.is, stream);
           stream.finish();
           byte[] compressedBytes = bytesOutput.toByteArray();
           iResponse.sendStream(


### PR DESCRIPTION
### What does this PR do?

Fix a bug in stream copy that could cause premature termination of stream if read returned 0 bytes.

## Related issues
Separated out from #9854