### PR TITLE
Make server reference volatile

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
 /** Created by tglman on 08/08/17. */
 public class OrientDBDistributed extends OrientDBEmbedded implements OServerAware {
 
-  private OServer server;
+  private volatile OServer server;
   private volatile OHazelcastPlugin plugin;
 
   public OrientDBDistributed(String directoryPath, OrientDBConfig config, Orient instance) {


### PR DESCRIPTION
### What does this PR do?

Makes the OServer reference in  OrientDBDistributed volatile, as it's updated by other threads.

## Related issues
Separated out from #9854