### PR TITLE
HA STATUS improvements

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OHaStatusStatement.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OHaStatusStatement.java
@@ -30,6 +30,11 @@ public class OHaStatusStatement extends OSimpleExecStatement {
   }
 
   @Override
+  public boolean isIdempotent() {
+    return true;
+  }
+
+  @Override
   public void toString(Map<Object, Object> params, StringBuilder builder) {
     builder.append("HA STATUS");
     if (servers) {

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -499,6 +499,9 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
     cluster.field("members", members, OType.EMBEDDEDLIST);
     for (Member member : activeNodes.values()) {
       final ODocument memberConfig = getNodeConfigurationByUuid(member.getUuid(), true).copy();
+      if (memberConfig == null) {
+        continue;
+      }
       members.add(memberConfig);
 
       final String nodeName = getNodeName(member);

--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -498,7 +498,17 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
     final List<ODocument> members = new ArrayList<ODocument>();
     cluster.field("members", members, OType.EMBEDDEDLIST);
     for (Member member : activeNodes.values()) {
-      members.add(getNodeConfigurationByUuid(member.getUuid(), true));
+      final ODocument memberConfig = getNodeConfigurationByUuid(member.getUuid(), true).copy();
+      members.add(memberConfig);
+
+      final String nodeName = getNodeName(member);
+      final Map<String, String> dbStatus = new HashMap<>();
+      memberConfig.field("databasesStatus", dbStatus, OType.EMBEDDEDMAP);
+      // Member DB status
+      for (String db : getManagedDatabases()) {
+        final DB_STATUS nodeDbState = getDatabaseStatus(nodeName, db);
+        dbStatus.put(db, nodeDbState.toString());
+      }
     }
 
     return cluster;


### PR DESCRIPTION
### What does this PR do?

- Mark the HA STATUS command as idempotent, so it can be run in query mode rather than requiring command execution
- Fix a NPE in HA STATUS if member config is not available
- Add individual DB status in each node in HA STATUS server details to allow HA status to be monitored remotely


## Related issues
Separated out from #9854