### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/maven_java_11.yml
+++ b/.github/workflows/maven_java_11.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache 
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven_java_17.yml
+++ b/.github/workflows/maven_java_17.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache 
       uses: actions/cache@v3
       with:

--- a/.github/workflows/maven_java_8.yml
+++ b/.github/workflows/maven_java_8.yml
@@ -27,14 +27,14 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         # Step that does that actual cache save and restore
     - name: Set up JDK 8 Branch
       if: github.event_name != 'pull_request'
       uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         server-id: sonatype-nexus-snapshots
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD


### PR DESCRIPTION
AdoptOpenJDK has moved the the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"

What does this PR do?
A brief description of the change being made with this pull request.

Motivation
What inspired you to submit this pull request?

Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

Additional Notes
Anything else we should know when reviewing?

Checklist
[] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
