### PR TITLE
Guard database create to avoid partially initialised storage being created

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -603,7 +603,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
     return basePath + "/" + name;
   }
 
-  public void create(String name, String user, String password, ODatabaseType type) {
+  public final void create(String name, String user, String password, ODatabaseType type) {
     create(name, user, password, type, null);
   }
 

--- a/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/core/db/OrientDBDistributed.java
@@ -55,6 +55,15 @@ public class OrientDBDistributed extends OrientDBEmbedded implements OServerAwar
     return plugin;
   }
 
+  @Override
+  public void create(
+      String name, String user, String password, ODatabaseType type, OrientDBConfig config) {
+    if (isDistributedEnabled() && (plugin == null)) {
+      throw new OOfflineNodeException("Distributed plugin is not active");
+    }
+    super.create(name, user, password, type, config);
+  }
+
   protected OSharedContext createSharedContext(OAbstractPaginatedStorage storage) {
     if (OSystemDatabase.SYSTEM_DB_NAME.equals(storage.getName())
         || getPlugin() == null


### PR DESCRIPTION
### What does this PR do?
If the plugin isn't online, initialisation of newly created database will fail, resulting in a partially initialised database that will break when used (usually because the schema hasn't been loaded).

### Related issues
Separated out from #9854