### PR TITLE
Fix race in registering installing database to guard against concurrent installs

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedAbstractPlugin.java
@@ -1006,7 +1006,7 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
       // DON'T REPLICATE SYSTEM BECAUSE IS DIFFERENT AND PER SERVER
       return false;
 
-    if (installingDatabases.contains(databaseName)) {
+    if (!installingDatabases.add(databaseName)) {
       return false;
     }
 
@@ -1014,7 +1014,6 @@ public abstract class ODistributedAbstractPlugin extends OServerPluginAbstract
         messageService.registerDatabase(databaseName, null);
 
     try {
-      installingDatabases.add(databaseName);
       return executeInDistributedDatabaseLock(
           databaseName,
           20000,


### PR DESCRIPTION
### What does this PR do?

Prevents multiple concurrent database installs from executing.

### Related issues
Separated out from #9854