### PR TITLE
test: refactor http tests and migrated to a newer API

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -71,12 +71,13 @@
             <version>1.77</version>
         </dependency>
 
+
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
-		</dependency>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/BaseHttpDatabaseTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/BaseHttpDatabaseTest.java
@@ -29,8 +29,7 @@ public abstract class BaseHttpDatabaseTest extends BaseHttpTest {
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     onAfterDatabaseCreated();
@@ -43,8 +42,7 @@ public abstract class BaseHttpDatabaseTest extends BaseHttpTest {
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         204);
     super.stopServer();
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpAuthenticationTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpAuthenticationTest.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import org.junit.Assert;
 
-/** @author Luca Garulli (l.garulli--(at)--orientdb.com) (l.garulli--at-orientdb.com) */
+/**
+ * @author Luca Garulli (l.garulli--(at)--orientdb.com) (l.garulli--at-orientdb.com)
+ */
 public class HttpAuthenticationTest extends BaseHttpDatabaseTest {
   public void testChangeOfUserOnSameConnectionIsAllowed() throws IOException {
     Assert.assertEquals(
@@ -16,8 +18,7 @@ public class HttpAuthenticationTest extends BaseHttpDatabaseTest {
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -29,8 +30,7 @@ public class HttpAuthenticationTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpBatchTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpBatchTest.java
@@ -7,8 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -24,13 +23,12 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
     getServer().getPlugin("script-interpreter").startup();
   }
 
-  public void batchUpdate() throws IOException {
+  public void batchUpdate() throws Exception {
     Assert.assertEquals(
         post("command/" + getDatabaseName() + "/sql/")
             .payload("create class User", CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -39,8 +37,7 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     String response = EntityUtils.toString(getResponse().getEntity());
@@ -71,8 +68,7 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
                     + "}",
                 CONTENT.JSON)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     // TEST DOUBLE UPDATE
@@ -96,8 +92,7 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
                     + "}",
                 CONTENT.JSON)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     // TEST WRONG VERSION ON UPDATE
@@ -121,8 +116,7 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
                     + "}",
                 CONTENT.JSON)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         409);
 
     batchWithEmpty();
@@ -139,10 +133,9 @@ public class HttpBatchTest extends BaseHttpDatabaseTest {
             + "return [$a, $b]\""
             + "}]\n"
             + "}";
-    HttpResponse response =
-        post("batch/" + getDatabaseName()).payload(json, CONTENT.TEXT).getResponse();
+    var response = post("batch/" + getDatabaseName()).payload(json, CONTENT.TEXT).getResponse();
 
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(response.getCode(), 200);
     InputStream stream = response.getEntity().getContent();
     String string = "";
     BufferedReader reader = new BufferedReader(new InputStreamReader(stream));

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpClassTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpClassTest.java
@@ -11,45 +11,27 @@ import org.junit.Test;
 public class HttpClassTest extends BaseHttpDatabaseTest {
   @Test
   public void testExistentClass() throws Exception {
-    Assert.assertEquals(
-        get("class/" + getDatabaseName() + "/OUser").getResponse().getStatusLine().getStatusCode(),
-        200);
+    Assert.assertEquals(get("class/" + getDatabaseName() + "/OUser").getResponse().getCode(), 200);
   }
 
   @Test
   public void testNonExistentClass() throws Exception {
     Assert.assertEquals(
-        get("class/" + getDatabaseName() + "/NonExistentCLass")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        404);
+        get("class/" + getDatabaseName() + "/NonExistentCLass").getResponse().getCode(), 404);
   }
 
   @Test
   public void testCreateClass() throws Exception {
     Assert.assertEquals(
-        post("class/" + getDatabaseName() + "/NewClass")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        201);
+        post("class/" + getDatabaseName() + "/NewClass").getResponse().getCode(), 201);
   }
 
   @Test
   public void testDropClass() throws Exception {
     Assert.assertEquals(
-        post("class/" + getDatabaseName() + "/NewClassToDrop")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        201);
+        post("class/" + getDatabaseName() + "/NewClassToDrop").getResponse().getCode(), 201);
     Assert.assertEquals(
-        delete("class/" + getDatabaseName() + "/NewClassToDrop")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        204);
+        delete("class/" + getDatabaseName() + "/NewClassToDrop").getResponse().getCode(), 204);
   }
 
   @Override

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpClusterTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpClusterTest.java
@@ -12,21 +12,13 @@ public class HttpClusterTest extends BaseHttpDatabaseTest {
   @Test
   public void testExistentClass() throws Exception {
     Assert.assertEquals(
-        get("cluster/" + getDatabaseName() + "/OUser")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        200);
+        get("cluster/" + getDatabaseName() + "/OUser").getResponse().getCode(), 200);
   }
 
   @Test
   public void testNonExistentClass() throws Exception {
     Assert.assertEquals(
-        get("cluster/" + getDatabaseName() + "/NonExistentCLass")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
-        404);
+        get("cluster/" + getDatabaseName() + "/NonExistentCLass").getResponse().getCode(), 404);
   }
 
   @Override

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpCommandTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpCommandTest.java
@@ -20,8 +20,7 @@ public class HttpCommandTest extends BaseHttpDatabaseTest {
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 
@@ -33,8 +32,7 @@ public class HttpCommandTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 
@@ -49,8 +47,7 @@ public class HttpCommandTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     final InputStream response = getResponse().getEntity().getContent();
@@ -73,8 +70,7 @@ public class HttpCommandTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     final InputStream response = getResponse().getEntity().getContent();

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpConnectionTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpConnectionTest.java
@@ -15,8 +15,7 @@ import org.junit.Test;
 public class HttpConnectionTest extends BaseHttpDatabaseTest {
   @Test
   public void testConnect() throws Exception {
-    Assert.assertEquals(
-        get("connect/" + getDatabaseName()).getResponse().getStatusLine().getStatusCode(), 204);
+    Assert.assertEquals(get("connect/" + getDatabaseName()).getResponse().getCode(), 204);
   }
 
   public void testTooManyConnect() throws Exception {
@@ -37,11 +36,7 @@ public class HttpConnectionTest extends BaseHttpDatabaseTest {
       for (int i = 0; i < TOTAL; ++i) {
         try {
           final int response =
-              get("connect/" + getDatabaseName())
-                  .setRetry(0)
-                  .getResponse()
-                  .getStatusLine()
-                  .getStatusCode();
+              get("connect/" + getDatabaseName()).setRetry(0).getResponse().getCode();
           Assert.assertEquals(response, 204);
           good++;
         } catch (IOException e) {
@@ -79,12 +74,7 @@ public class HttpConnectionTest extends BaseHttpDatabaseTest {
     int TOTAL = max * 3;
 
     for (int i = 0; i < TOTAL; ++i) {
-      final int response =
-          get("connect/" + getDatabaseName())
-              .setRetry(0)
-              .getResponse()
-              .getStatusLine()
-              .getStatusCode();
+      final int response = get("connect/" + getDatabaseName()).setRetry(0).getResponse().getCode();
       Assert.assertEquals(response, 204);
 
       if (i % 100 == 0) System.out.printf("\nConnections " + i);
@@ -100,8 +90,7 @@ public class HttpConnectionTest extends BaseHttpDatabaseTest {
               .setUserName("root")
               .setUserPassword("root")
               .getResponse()
-              .getStatusLine()
-              .getStatusCode(),
+              .getCode(),
           200);
 
       final ODocument serverStatus =

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDatabaseTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDatabaseTest.java
@@ -2,11 +2,10 @@ package com.orientechnologies.orient.test.server.network.http;
 
 import com.orientechnologies.orient.core.OConstants;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.test.server.network.http.BaseHttpTest.CONTENT;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Map;
-import org.apache.http.HttpResponse;
+import org.apache.hc.core5.http.HttpResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,8 +24,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .setUserPassword("root")
             .post("database/" + getDatabaseName())
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         500);
   }
 
@@ -37,8 +35,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .setUserPassword("wrongPasswod")
             .post("database/wrongpasswd")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         401);
   }
 
@@ -53,8 +50,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .post("database/" + getDatabaseName() + "/memory")
             .payload(pass.toJSON(), CONTENT.JSON)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     HttpResponse response =
@@ -63,7 +59,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .get("database/" + getDatabaseName())
             .getResponse();
 
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Assert.assertEquals(200, response.getCode());
 
     final ODocument payload = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
@@ -81,8 +77,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .post("database/" + getDatabaseName() + "/memory")
             .payload(pass.toJSON(), CONTENT.JSON)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -95,8 +90,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
                     + URLEncoder.encode("select from OUSer", "UTF8")
                     + "/10")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -104,8 +98,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .setUserPassword("root")
             .delete("database/" + getDatabaseName())
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         204);
   }
 
@@ -116,8 +109,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
             .setUserPassword("root")
             .delete("database/whateverdbname")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         500);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDisabledTokenTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDisabledTokenTest.java
@@ -5,13 +5,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.Test;
 
 public class HttpDisabledTokenTest extends BaseHttpDatabaseTest {
@@ -27,7 +27,7 @@ public class HttpDisabledTokenTest extends BaseHttpDatabaseTest {
     request.setEntity(new StringEntity("grant_type=password&username=admin&password=admin"));
     final CloseableHttpClient httpClient = HttpClients.createDefault();
     CloseableHttpResponse response = httpClient.execute(request);
-    assertEquals(response.getStatusLine().getStatusCode(), 400);
+    assertEquals(response.getCode(), 400);
     HttpEntity entity = response.getEntity();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     entity.writeTo(out);

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDocumentTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpDocumentTest.java
@@ -18,7 +18,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:99, \"@version\":100}", CONTENT.JSON)
         .exec();
 
-    Assert.assertEquals(201, getResponse().getStatusLine().getStatusCode());
+    Assert.assertEquals(201, getResponse().getCode());
 
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
@@ -34,7 +34,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:99}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -44,7 +44,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
 
     get("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(getResponse().getCode(), 200);
     final ODocument updated = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(updated.field("name"), "Jay");
@@ -58,7 +58,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -73,7 +73,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     put("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .payload(created.toJSON(), CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(getResponse().getCode(), 200);
     final ODocument updated = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(updated.field("name"), "Jay2");
@@ -87,7 +87,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -98,7 +98,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     put("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .payload("{name:'Jay2', surname:'Miner2',age:1}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(getResponse().getCode(), 200);
     final ODocument updated = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(updated.field("name"), "Jay2");
@@ -112,7 +112,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -123,7 +123,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     put("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .payload("{name:'Jay2', surname:'Miner2',age:1, @version: 2}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 409);
+    Assert.assertEquals(getResponse().getCode(), 409);
   }
 
   @Test
@@ -131,7 +131,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -146,7 +146,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
             + "?updateMode=partial")
         .payload("{age:1}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(getResponse().getCode(), 200);
     final ODocument updated = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(updated.field("name"), "Jay");
@@ -160,7 +160,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -171,7 +171,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     patch("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .payload("{age:1,@version:1}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(getResponse().getCode(), 200);
     final ODocument updated = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(updated.field("name"), "Jay");
@@ -185,7 +185,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -195,11 +195,11 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
 
     delete("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 204);
+    Assert.assertEquals(getResponse().getCode(), 204);
 
     get("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 404);
+    Assert.assertEquals(getResponse().getCode(), 404);
   }
 
   @Test
@@ -207,7 +207,7 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     post("document/" + getDatabaseName())
         .payload("{@class:'V', name:'Jay', surname:'Miner',age:0}", CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 201);
+    Assert.assertEquals(getResponse().getCode(), 201);
     final ODocument created = new ODocument().fromJSON(getResponse().getEntity().getContent());
 
     Assert.assertEquals(created.field("name"), "Jay");
@@ -218,11 +218,11 @@ public class HttpDocumentTest extends BaseHttpDatabaseTest {
     delete("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .payload(created.toJSON(), CONTENT.JSON)
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 204);
+    Assert.assertEquals(getResponse().getCode(), 204);
 
     get("document/" + getDatabaseName() + "/" + created.getIdentity().toString().substring(1))
         .exec();
-    Assert.assertEquals(getResponse().getStatusLine().getStatusCode(), 404);
+    Assert.assertEquals(getResponse().getCode(), 404);
   }
 
   @Override

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpErrorsTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpErrorsTest.java
@@ -14,24 +14,14 @@ public class HttpErrorsTest extends BaseHttpTest {
   @Test
   public void testCommandNotFound() throws Exception {
     Assert.assertEquals(
-        setUserName("root")
-            .setUserPassword("root")
-            .get("commandNotfound")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+        setUserName("root").setUserPassword("root").get("commandNotfound").getResponse().getCode(),
         405);
   }
 
   @Test
   public void testCommandWrongMethod() throws Exception {
     Assert.assertEquals(
-        setUserName("root")
-            .setUserPassword("root")
-            .post("listDatabases")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+        setUserName("root").setUserPassword("root").post("listDatabases").getResponse().getCode(),
         405);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpFunctionTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpFunctionTest.java
@@ -1,9 +1,8 @@
 package com.orientechnologies.orient.test.server.network.http;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import java.io.IOException;
 import java.util.List;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,7 +14,7 @@ import org.junit.Test;
 public class HttpFunctionTest extends BaseHttpDatabaseTest {
 
   @Test
-  public void callFunction() throws IOException {
+  public void callFunction() throws Exception {
     // CREATE FUNCTION FIRST
     Assert.assertEquals(
         post("command/" + getDatabaseName() + "/sql/")
@@ -24,8 +23,7 @@ public class HttpFunctionTest extends BaseHttpDatabaseTest {
                     + " [name,surname] LANGUAGE javascript",
                 CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -34,8 +32,7 @@ public class HttpFunctionTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     String response = EntityUtils.toString(getResponse().getEntity());

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGephiTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGephiTest.java
@@ -1,7 +1,7 @@
 package com.orientechnologies.orient.test.server.network.http;
 
 import java.io.IOException;
-import org.apache.http.HttpResponse;
+import org.apache.hc.core5.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,12 +20,12 @@ public class HttpGephiTest extends BaseHttpDatabaseTest {
             .setUserPassword("root")
             .getResponse();
 
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Assert.assertEquals(200, response.getCode());
   }
 
   @Test
   public void commandDatabaseCredentials() throws IOException {
-    HttpResponse response =
+    var response =
         get("gephi/" + getDatabaseName() + "/sql/select%20from%20V")
             .setUserName("admin")
             .setUserPassword("admin")
@@ -33,7 +33,7 @@ public class HttpGephiTest extends BaseHttpDatabaseTest {
 
     response.getEntity().writeTo(System.out);
 
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    Assert.assertEquals(200, response.getCode());
   }
 
   @Override
@@ -48,8 +48,7 @@ public class HttpGephiTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -60,8 +59,7 @@ public class HttpGephiTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     Assert.assertEquals(
@@ -73,8 +71,7 @@ public class HttpGephiTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGetStaticContentTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGetStaticContentTest.java
@@ -7,7 +7,6 @@ import com.orientechnologies.orient.server.network.protocol.http.ONetworkProtoco
 import com.orientechnologies.orient.server.network.protocol.http.command.get.OServerCommandGetStaticContent;
 import java.io.BufferedInputStream;
 import java.net.URL;
-import org.apache.http.HttpResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,8 +53,8 @@ public class HttpGetStaticContentTest extends BaseHttpTest {
 
   @Test
   public void testIndexHTML() throws Exception {
-    HttpResponse response = get("fake/index.htm").getResponse();
-    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    var response = get("fake/index.htm").getResponse();
+    Assert.assertEquals(200, response.getCode());
 
     String expected =
         OIOUtils.readStreamAsString(

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGraphTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpGraphTest.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,15 +22,13 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
         post("command/" + getDatabaseName() + "/sql/")
             .payload("create class Foo extends V", CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
     Assert.assertEquals(
         post("command/" + getDatabaseName() + "/sql/")
             .payload("create class FooEdge extends E", CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     String script = "begin;";
@@ -45,11 +42,11 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
         "{ \"operations\" : [{ \"type\" : \"script\", \"language\" : \"SQL\",  \"script\" :"
             + " \"%s\"}]}";
 
-    HttpResponse response =
+    var response =
         post("batch/" + getDatabaseName() + "/sql/")
             .payload(String.format(scriptPayload, script), CONTENT.JSON)
             .getResponse();
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(response.getCode(), 200);
 
     final ODocument result = new ODocument().fromJSON(response.getEntity().getContent());
 
@@ -68,7 +65,7 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
             .payload(created.toJSON(), CONTENT.JSON)
             .exec()
             .getResponse();
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(response.getCode(), 200);
 
     final ODocument updated = new ODocument().fromJSON(response.getEntity().getContent());
     Assert.assertEquals(updated.field("name"), "fooUpdated");
@@ -83,15 +80,13 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
         post("command/" + getDatabaseName() + "/sql/")
             .payload("create class Foo extends V", CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
     Assert.assertEquals(
         post("command/" + getDatabaseName() + "/sql/")
             .payload("create class FooEdge extends E", CONTENT.TEXT)
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
 
     String script = "begin;";
@@ -105,11 +100,11 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
         "{ \"operations\" : [{ \"type\" : \"script\", \"language\" : \"SQL\",  \"script\" :"
             + " \"%s\"}]}";
 
-    HttpResponse response =
+    var response =
         post("batch/" + getDatabaseName() + "/sql/")
             .payload(String.format(scriptPayload, script), CONTENT.JSON)
             .getResponse();
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    Assert.assertEquals(response.getCode(), 200);
 
     final String payload =
         new ODocument().field("command", "select from E").field("mode", "graph").toJSON();

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpImportTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpImportTest.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.http.HttpResponse;
 import org.junit.Test;
 
 /** Created by tglman on 16/03/16. */
@@ -20,8 +19,8 @@ public class HttpImportTest extends BaseHttpDatabaseTest {
     String content =
         "{\"records\": [{\"@type\": \"d\", \"@rid\": \"#9:0\",\"@version\": 1,\"@class\": \"V\"}]}";
     post("import/" + getDatabaseName() + "?merge=true").payload(content, CONTENT.TEXT);
-    HttpResponse response = getResponse();
-    assertEquals(200, response.getStatusLine().getStatusCode());
+    var response = getResponse();
+    assertEquals(200, response.getCode());
 
     InputStream is = response.getEntity().getContent();
     List<String> out = new LinkedList<>();

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpListDatabasesTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpListDatabasesTest.java
@@ -14,24 +14,14 @@ public class HttpListDatabasesTest extends BaseHttpTest {
   @Test
   public void testListDatabasesRootUser() throws Exception {
     Assert.assertEquals(
-        setUserName("root")
-            .setUserPassword("root")
-            .get("listDatabases")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+        setUserName("root").setUserPassword("root").get("listDatabases").getResponse().getCode(),
         200);
   }
 
   @Test
   public void testListDatabasesGuestUser() throws Exception {
     Assert.assertEquals(
-        setUserName("guest")
-            .setUserPassword("guest")
-            .get("listDatabases")
-            .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+        setUserName("guest").setUserPassword("guest").get("listDatabases").getResponse().getCode(),
         200);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpQueryTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpQueryTest.java
@@ -22,8 +22,7 @@ public class HttpQueryTest extends BaseHttpDatabaseTest {
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 
@@ -38,8 +37,7 @@ public class HttpQueryTest extends BaseHttpDatabaseTest {
             .setUserName("admin")
             .setUserPassword("admin")
             .getResponse()
-            .getStatusLine()
-            .getStatusCode(),
+            .getCode(),
         200);
   }
 

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpServerTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpServerTest.java
@@ -2,15 +2,14 @@ package com.orientechnologies.orient.test.server.network.http;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import java.io.IOException;
-import org.apache.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class HttpServerTest extends BaseHttpDatabaseTest {
   @Test
   public void testGetServer() throws Exception {
-    HttpResponse res = get("server").getResponse();
-    Assert.assertEquals(res.getStatusLine().getStatusCode(), 200);
+    var res = get("server").getResponse();
+    Assert.assertEquals(res.getCode(), 200);
 
     ODocument payload = new ODocument().fromJSON(res.getEntity().getContent());
 
@@ -19,9 +18,8 @@ public class HttpServerTest extends BaseHttpDatabaseTest {
 
   @Test
   public void testGetConnections() throws Exception {
-    HttpResponse res =
-        setUserName("root").setUserPassword("root").get("connections/").getResponse();
-    Assert.assertEquals(res.getStatusLine().getStatusCode(), 200);
+    var res = setUserName("root").setUserPassword("root").get("connections/").getResponse();
+    Assert.assertEquals(res.getCode(), 200);
 
     ODocument payload = new ODocument().fromJSON(res.getEntity().getContent());
 
@@ -31,14 +29,14 @@ public class HttpServerTest extends BaseHttpDatabaseTest {
   @Test
   public void testCreateDatabase() throws IOException {
     String dbName = getClass().getSimpleName() + "testCreateDatabase";
-    HttpResponse res =
+    var res =
         setUserName("root")
             .setUserPassword("root")
             .post("servercommand")
             .payload("{\"command\":\"create database " + dbName + " plocal\" }", CONTENT.JSON)
             .getResponse();
-    System.out.println(res.getStatusLine().getReasonPhrase());
-    Assert.assertEquals(res.getStatusLine().getStatusCode(), 200);
+    System.out.println(res.getCode());
+    Assert.assertEquals(res.getCode(), 200);
 
     Assert.assertTrue(getServer().getContext().exists(dbName));
     getServer().getContext().drop(dbName);

--- a/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpXRequestedWithXMLHttpRequestTest.java
+++ b/server/src/test/java/com/orientechnologies/orient/test/server/network/http/HttpXRequestedWithXMLHttpRequestTest.java
@@ -1,13 +1,14 @@
 package com.orientechnologies.orient.test.server.network.http;
 
 import java.io.IOException;
-import org.apache.http.Header;
-import org.apache.http.HttpResponse;
-import org.apache.http.message.BasicHeader;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** @author Enrico Risa */
+/**
+ * @author Enrico Risa
+ */
 public class HttpXRequestedWithXMLHttpRequestTest extends BaseHttpDatabaseTest {
   protected void onAfterDatabaseCreated() throws Exception {
     setUserPassword("123456");
@@ -17,17 +18,17 @@ public class HttpXRequestedWithXMLHttpRequestTest extends BaseHttpDatabaseTest {
   public void sendXMLHttpRequest() throws IOException {
     Header[] headers = {new BasicHeader("X-Requested-With", "XMLHttpRequest")};
 
-    HttpResponse response = get("class/" + getDatabaseName() + "/OUser", headers).getResponse();
+    var response = get("class/" + getDatabaseName() + "/OUser", headers).getResponse();
 
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 401);
+    Assert.assertEquals(response.getCode(), 401);
     Assert.assertEquals(response.containsHeader("WWW-Authenticate"), false);
   }
 
   @Test
   public void sendHttpRequest() throws IOException {
-    HttpResponse response = get("class/" + getDatabaseName() + "/OUser").getResponse();
+    var response = get("class/" + getDatabaseName() + "/OUser").getResponse();
 
-    Assert.assertEquals(response.getStatusLine().getStatusCode(), 401);
+    Assert.assertEquals(response.getCode(), 401);
     Assert.assertEquals(response.containsHeader("WWW-Authenticate"), true);
   }
 


### PR DESCRIPTION
Hi,

I think this is fine we can merge it, I just want to understand why this was needed, is just for the more recent version or are other reasons.
