### PR TITLE
refactor: use direct locking instead of syncrhonize for legacy database

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTxInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTxInternal.java
@@ -10,7 +10,9 @@ public class ODatabaseDocumentTxInternal {
   private ODatabaseDocumentTxInternal() {}
 
   public static ODatabaseDocumentInternal getInternal(ODatabaseDocumentInternal db) {
-    if (db instanceof ODatabaseDocumentTx) db = ((ODatabaseDocumentTx) db).internal;
+    if (db instanceof ODatabaseDocumentTx) {
+      db = ((ODatabaseDocumentTx) db).internal;
+    }
     return db;
   }
 
@@ -28,14 +30,21 @@ public class ODatabaseDocumentTxInternal {
   }
 
   public static void closeAllOnShutdown() {
-    synchronized (ODatabaseDocumentTx.embedded) {
+    ODatabaseDocumentTx.embeddedLock.lock();
+    try {
       for (OrientDBInternal factory : ODatabaseDocumentTx.embedded.values()) {
         factory.internalClose();
       }
       ODatabaseDocumentTx.embedded.clear();
+    } finally {
+      ODatabaseDocumentTx.embeddedLock.unlock();
     }
-    synchronized (ODatabaseDocumentTx.remote) {
+
+    ODatabaseDocumentTx.remoteLock.lock();
+    try {
       ODatabaseDocumentTx.remote.clear();
+    } finally {
+      ODatabaseDocumentTx.remoteLock.unlock();
     }
   }
 }


### PR DESCRIPTION
Hi,

So this swap the synchronize for the locking for some legacy component, I guess this is for keep separate the remote and embedded locking, is this the case, being a legacy component that is plan to be delete before release I do not see much the point, but maybe this may improve the execution of some test case meanwhile they are migrated to the new approach.

Regards