### PR TITLE
Big endian platform fixes

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
@@ -544,7 +544,7 @@ public final class OPaginatedClusterV2 extends OPaginatedCluster {
               }
             } else {
               for (int sizeOffset = (OIntegerSerializer.INT_SIZE - recordSizePart) << 3;
-                  sizeOffset < OIntegerSerializer.INT_SIZE & spaceLeft > 0;
+                  sizeOffset < (OIntegerSerializer.INT_SIZE * 8) && spaceLeft > 0;
                   sizeOffset += 8, spaceLeft--, written++) {
                 final byte sizeByte = (byte) (0xFF & (recordContent.length >> sizeOffset));
                 chunk[spaceLeft - 1] = sizeByte;

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/impl/local/paginated/base/ODurablePage.java
@@ -259,7 +259,7 @@ public class ODurablePage {
   protected final int setShortValue(final int pageOffset, final short value) {
 
     if (changes != null) {
-      changes.setIntValue(buffer, value, pageOffset);
+      changes.setShortValue(buffer, value, pageOffset);
     } else {
       assert buffer != null;
       assert buffer.order() == ByteOrder.nativeOrder();


### PR DESCRIPTION
What does this PR do?
This PR fixes two bugs that were found on big endian systems.

Motivation
Bug fixes for big endian platforms.

Related issues
May be related to:
https://github.com/orientechnologies/orientdb/issues/9972
https://github.com/orientechnologies/orientdb/issues/10019

Additional Notes
I added a unit test that triggers the bug in OPaginatedClusterV2 on big endian platforms.
The bug in ODurablePage causes test failures in the CellBTreeMultiValueV2TestIT on big endian platforms.

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
