### PR TITLE
Revert "chore(deps): bump org.knowm.xchart:xchart from 3.8.5 to 3.8.8"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -266,7 +266,7 @@
         <dependency>
             <groupId>org.knowm.xchart</groupId>
             <artifactId>xchart</artifactId>
-            <version>3.8.8</version>
+            <version>3.8.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.knowm.xchart</groupId>
             <artifactId>xchart</artifactId>
-            <version>3.8.8</version>
+            <version>3.8.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Reverts orientechnologies/orientdb#10245
Because it stop the module tests to run tests