### PR TITLE
Actually run the distributed tx expiry task

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/ODistributedDatabaseImpl.java
@@ -648,9 +648,11 @@ public class ODistributedDatabaseImpl implements ODistributedDatabase {
         new TimerTask() {
           @Override
           public void run() {
-            checkTxTimeout();
+            context.execute(() -> checkTxTimeout());
           }
         };
+    final long timeout = OGlobalConfiguration.DISTRIBUTED_TX_EXPIRE_TIMEOUT.getValueAsLong();
+    context.schedule(txTimeoutTask, timeout / 3, timeout / 3);
   }
 
   public void checkTxTimeout() {


### PR DESCRIPTION
What does this PR do?

Actually create a timer and schedule the distributed transaction timeout task.
The `com.orientechnologies.orient.server.distributed.impl.ODistributedDatabaseImpl#startTxTimeoutTimerTask` method creates the timeout task, but never schedules it on a Timer.

Motivation

During heap dump analysis we observed some transactions remaining in the tracking list forever.

Related issues

Additional Notes

Checklist
[x] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
