### PR TITLE
Support limits on records loaded from Lucene index

### DIFF
--- a/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineUtils.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/engine/OLuceneIndexEngineUtils.java
@@ -27,7 +27,8 @@ import org.apache.lucene.search.TopDocs;
 /** Created by frank on 04/05/2017. */
 public class OLuceneIndexEngineUtils {
 
-  public static void sendTotalHits(String indexName, OCommandContext context, long totalHits) {
+  public static void sendTotalHits(
+      String indexName, OCommandContext context, long totalHits, long returnedHits) {
     if (context != null) {
 
       if (context.getVariable("totalHits") == null) {
@@ -36,6 +37,12 @@ public class OLuceneIndexEngineUtils {
         context.setVariable("totalHits", null);
       }
       context.setVariable((indexName + ".totalHits").replace(".", "_"), totalHits);
+      if (context.getVariable("returnedHits") == null) {
+        context.setVariable("returnedHits", returnedHits);
+      } else {
+        context.setVariable("returnedHits", null);
+      }
+      context.setVariable((indexName + ".returnedHits").replace(".", "_"), returnedHits);
     }
   }
 

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
@@ -5,12 +5,17 @@ import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.metadata.OMetadataInternal;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.parser.OExpression;
+import com.orientechnologies.orient.core.sql.parser.OFromClause;
+import com.orientechnologies.orient.core.sql.parser.OSelectStatement;
 import org.apache.lucene.index.memory.MemoryIndex;
 
 /** Created by frank on 13/02/2017. */
 public class OLuceneFunctionsUtils {
   public static final String MEMORY_INDEX = "_memoryIndex";
+
+  private static final String MAX_HITS = "luceneMaxHits";
 
   protected static OLuceneFullTextIndex searchForIndex(OExpression[] args, OCommandContext ctx) {
     final String indexName = (String) args[0].execute((OIdentifiable) null, ctx);
@@ -56,5 +61,30 @@ public class OLuceneFunctionsUtils {
       sb.append(c);
     }
     return sb.toString();
+  }
+
+  public static void configureResultLimit(
+      OFromClause target, OCommandContext ctx, ODocument metadata) {
+    Object limitType = metadata.getProperty("limit");
+
+    long maxHits = 0;
+    if ("select".equals(limitType) && target.jjtGetParent() instanceof OSelectStatement) {
+      OSelectStatement select = (OSelectStatement) target.jjtGetParent();
+      if (select.getLimit() != null) {
+        maxHits += ((Number) select.getLimit().getValue(ctx)).longValue();
+      }
+      if (select.getSkip() != null) {
+        maxHits += ((Number) select.getSkip().getValue(ctx)).longValue();
+      }
+    } else if (limitType instanceof Number) {
+      maxHits = ((Number) limitType).longValue();
+    }
+    if (maxHits != 0) {
+      ctx.setVariable(MAX_HITS, maxHits);
+    }
+  }
+
+  public static Long getResultLimit(OCommandContext ctx) {
+    return (Long) ctx.getVariable(OLuceneFunctionsUtils.MAX_HITS);
   }
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneFunctionsUtils.java
@@ -85,6 +85,9 @@ public class OLuceneFunctionsUtils {
   }
 
   public static Long getResultLimit(OCommandContext ctx) {
+    if (ctx == null) {
+      return null;
+    }
     return (Long) ctx.getVariable(OLuceneFunctionsUtils.MAX_HITS);
   }
 }

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchMoreLikeThisFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchMoreLikeThisFunction.java
@@ -88,6 +88,7 @@ public class OLuceneSearchMoreLikeThisFunction extends OSQLFunctionAbstract
     OExpression expression = args[0];
 
     ODocument metadata = parseMetadata(args);
+    OLuceneFunctionsUtils.configureResultLimit(target, ctx, metadata);
 
     List<String> ridsAsString = parseRids(ctx, expression);
 

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnClassFunction.java
@@ -130,6 +130,7 @@ public class OLuceneSearchOnClassFunction extends OLuceneSearchFunctionTemplate 
     if (index != null) {
 
       ODocument metadata = getMetadata(args, ctx);
+      OLuceneFunctionsUtils.configureResultLimit(target, ctx, metadata);
 
       List<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnFieldsFunction.java
@@ -117,6 +117,7 @@ public class OLuceneSearchOnFieldsFunction extends OLuceneSearchFunctionTemplate
     if (index != null) {
 
       ODocument meta = getMetadata(args, ctx);
+      OLuceneFunctionsUtils.configureResultLimit(target, ctx, meta);
       Set<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =
           index

--- a/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunction.java
+++ b/lucene/src/main/java/com/orientechnologies/lucene/functions/OLuceneSearchOnIndexFunction.java
@@ -123,6 +123,7 @@ public class OLuceneSearchOnIndexFunction extends OLuceneSearchFunctionTemplate 
     if (index != null && query != null) {
 
       ODocument meta = getMetadata(args, ctx);
+      OLuceneFunctionsUtils.configureResultLimit(target, ctx, meta);
 
       List<OIdentifiable> luceneResultSet;
       try (Stream<ORID> rids =

--- a/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneLimitResultsTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneLimitResultsTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2010-2016 OrientDB LTD (http://orientdb.com)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orientechnologies.lucene.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.orientechnologies.orient.core.sql.executor.OResult;
+import com.orientechnologies.orient.core.sql.executor.OResultSet;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OLuceneLimitResultsTest extends OLuceneBaseTest {
+
+  @Before
+  public void init() {
+    InputStream stream = ClassLoader.getSystemResourceAsStream("testLuceneIndex.sql");
+
+    db.execute("sql", getScriptFromStream(stream));
+
+    db.command("create index Song.title on Song (title) FULLTEXT ENGINE LUCENE");
+  }
+
+  private void checkSongTitleHits(
+      String query, int expectedResultSetSize, int expectedTotalHits, int expectedReturnedHits) {
+    OResultSet docs = db.query(query);
+
+    List<OResult> results = docs.stream().collect(Collectors.toList());
+    assertThat(results).hasSize(expectedResultSetSize);
+
+    OResult doc = results.get(0);
+    System.out.println("doc.toElement().toJSON() = " + doc.toElement().toJSON());
+
+    assertThat(doc.<Long>getProperty("$totalHits")).isEqualTo(expectedTotalHits);
+    assertThat(doc.<Long>getProperty("$Song_title_totalHits")).isEqualTo(expectedTotalHits);
+    assertThat(doc.<Long>getProperty("$returnedHits")).isEqualTo(expectedReturnedHits);
+    assertThat(doc.<Long>getProperty("$Song_title_returnedHits")).isEqualTo(expectedReturnedHits);
+    docs.close();
+  }
+
+  @Test
+  public void testLimitSelect() {
+    checkSongTitleHits(
+        "select *,$totalHits,$Song_title_totalHits,$returnedHits,$Song_title_returnedHits "
+            + "from Song where search_class('title:man', {\"limit\":\"select\"})= true limit 1",
+        1,
+        14,
+        1);
+
+    checkSongTitleHits(
+        "select *,$totalHits,$Song_title_totalHits,$returnedHits,$Song_title_returnedHits "
+            + "from Song where search_class('title:man', {\"limit\":\"select\"})= true skip 5 limit 5",
+        5,
+        14,
+        10);
+  }
+
+  @Test
+  public void testLimitByNumber() {
+    checkSongTitleHits(
+        "select *,$totalHits,$Song_title_totalHits,$returnedHits,$Song_title_returnedHits from Song "
+            + "where search_class('title:man', {\"limit\": 5})= true limit 1",
+        1,
+        14,
+        5);
+
+    checkSongTitleHits(
+        "select *,$totalHits,$Song_title_totalHits,$returnedHits,$Song_title_returnedHits from Song "
+            + "where search_class('title:man', {\"limit\": 5})= true limit 10",
+        5,
+        14,
+        5);
+  }
+}


### PR DESCRIPTION
What does this PR do?

Allows the records (rids) retrieved from the Lucene search to be limited, where it is known that the remainder of the query does not require the entire set to be loaded.  This is useful when the underlying Lucene query returns many results, but the query overall is only intended to return a small number of them (and in the ranked order from Lucene). 

This mode is opt in, by providing a `limit` metadata element to the Lucene search function. A value of `select` uses the skip/limit in the `SELECT` statement to determine the max hits, and an integral value specifies an explicit max hits (e.g. for a safety margin where subsequent query filter/order operations are desired).

Motivation

100% of our Lucene index queries apply all of the filtering criteria in the Lucene query, and we have some pathological scenarios where those criteria can be ranking (non mandatory) and on very general criteria.
In the worst case this resulted in millions of RIDs being loaded from the Lucene index, when we would only want the top 100.
This causes high memory pressure (and often out of memory errors), with some of the RID arrays loaded being 800MB.

Related issues

Neo4J has a similar capability: https://community.neo4j.com/t/full-text-search-skip-and-limit/58773

Additional Notes

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
