### PR TITLE
Support debug mode on all console exceptions.

### DIFF
--- a/tools/src/main/java/com/orientechnologies/orient/console/OConsoleDatabaseApp.java
+++ b/tools/src/main/java/com/orientechnologies/orient/console/OConsoleDatabaseApp.java
@@ -3323,7 +3323,7 @@ public class OConsoleDatabaseApp extends OConsoleApplication
     return (float) (System.currentTimeMillis() - start) / 1000;
   }
 
-  protected void printError(final Exception e) {
+  protected void printError(final Throwable e) {
     if (properties.get(OConsoleProperties.DEBUG) != null
         && Boolean.parseBoolean(properties.get(OConsoleProperties.DEBUG))) {
       message("\n\n!ERROR:");
@@ -3598,11 +3598,7 @@ public class OConsoleDatabaseApp extends OConsoleApplication
 
   @Override
   protected void onException(Throwable e) {
-    Throwable current = e;
-    while (current != null) {
-      err.print("\nError: " + current.toString() + "\n");
-      current = current.getCause();
-    }
+    printError(e);
   }
 
   @Override


### PR DESCRIPTION
What does this PR do?

Handles all uncaught console exceptions with the `printError` handler, which supports printing of exception stack traces by configuring `set debug true`.

Motivation

Attempting to `TRUNCATE RECORD` with a broken record in the database that was causing an `IndexOutOfBoundsException`, but not being able to see the full stack trace of where the exception was occurring.

Related issues

Additional Notes

Technically the `try { ... } catch (Exception e) { printError(e) }` pattern throughout the console is redundant with this change.

Checklist
[x] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
