### PR TITLE
Introducing OrientDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE status](https://api.reuse.software/badge/github.com/orientechnologies/orientdb)](https://api.reuse.software/info/github.com/orientechnologies/orientdb)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OrientDB%20Guru-006BFF)](https://gurubase.io/g/orientdb)
 
 ------
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [OrientDB Guru](https://gurubase.io/g/orientdb) to Gurubase. OrientDB Guru uses the data from this repo and data from the [docs](https://orientdb.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "OrientDB Guru", which highlights that OrientDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable OrientDB Guru in Gurubase, just let me know that's totally fine.
