### PR TITLE
fix: Casting to float lose precision in some cases

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
@@ -40,7 +40,13 @@ public class OFloatingPoint extends ONumber {
     } else {
       try {
         double returnValue = Double.parseDouble(stringValue) * sign;
+        float floatValue = (float) returnValue;
+        double check = (double) floatValue;
+        if(check == returnValue) {
+         finalValue= floatValue;
+        } else {
         finalValue = returnValue;
+        }
       } catch (Exception ignore) {
         return null; // TODO NaN?
       }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
@@ -42,8 +42,8 @@ public class OFloatingPoint extends ONumber {
         double returnValue = Double.parseDouble(stringValue) * sign;
         float floatValue = (float) returnValue;
         double check = (double) floatValue;
-        if(check == returnValue) {
-         finalValue= floatValue;
+        if (check == returnValue) {
+         finalValue = floatValue;
         } else {
         finalValue = returnValue;
         }

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/parser/OFloatingPoint.java
@@ -40,11 +40,7 @@ public class OFloatingPoint extends ONumber {
     } else {
       try {
         double returnValue = Double.parseDouble(stringValue) * sign;
-        if (Math.abs(returnValue) < Float.MAX_VALUE) {
-          finalValue = (float) returnValue;
-        } else {
-          finalValue = returnValue;
-        }
+        finalValue = returnValue;
       } catch (Exception ignore) {
         return null; // TODO NaN?
       }


### PR DESCRIPTION
What does this PR do?
I reproduced the case and it seems like when casting to float the precision is lost
Related to -> #10391

Motivation
Because i use this database everyday

Related issues
#10391

Additional Notes
I don't know exactly why that cast to float was used, but it seems generates some problems
