### PR TITLE
feat(backup): Log cluster names in debug only

### DIFF
--- a/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OBackgroundBackup.java
+++ b/distributed/src/main/java/com/orientechnologies/orient/server/distributed/impl/task/OBackgroundBackup.java
@@ -65,15 +65,26 @@ public class OBackgroundBackup implements Runnable, OSyncSource {
     try {
       try {
 
-        ODistributedServerLog.info(
-            this,
-            localNodeName,
-            syncTarget,
-            ODistributedServerLog.DIRECTION.OUT,
-            "Compressing database '%s' %d clusters %s...",
-            database.getName(),
-            database.getClusterNames().size(),
-            database.getClusterNames());
+        if (ODistributedServerLog.isDebugEnabled()) {
+          ODistributedServerLog.debug(
+              this,
+              localNodeName,
+              syncTarget,
+              ODistributedServerLog.DIRECTION.OUT,
+              "Compressing database '%s' %d clusters %s...",
+              database.getName(),
+              database.getClusterNames().size(),
+              database.getClusterNames());
+        } else {
+          ODistributedServerLog.info(
+              this,
+              localNodeName,
+              syncTarget,
+              ODistributedServerLog.DIRECTION.OUT,
+              "Compressing database '%s' %d clusters...",
+              database.getName(),
+              database.getClusterNames().size());
+        }
 
         if (resultedBackupFile.exists()) resultedBackupFile.delete();
         else resultedBackupFile.getParentFile().mkdirs();


### PR DESCRIPTION
### What does this PR do?

The background backup executor logs full list of cluster names in the database being backed up on the INFO level. This information is useless for the usual (non-debug) situations but consumes a lot of space in the output for a relatively large database (~8K clusters in our case).

This PR introduces a change so that the full list of cluster names is written only when `DEBUG` logging is enabled.

### Motivation

Improve OPS side of DEV.

### Related issues
N/A

### Additional Notes
N/A

### Checklist
- [x] I have run the build using `mvn clean package` command
- [ ] N/A - My unit tests cover both failure and success scenarios
