### PR TITLE
fix: commons-lang 2.6 dependency is obsolete and unsupported

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -356,9 +356,10 @@
             <version>1.8.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/db/OrientDBEmbedded.java
@@ -58,18 +58,7 @@ import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -77,7 +66,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.NullArgumentException;
 
 /** Created by tglman on 08/04/16. */
 public class OrientDBEmbedded implements OrientDBInternal {
@@ -1226,9 +1214,7 @@ public class OrientDBEmbedded implements OrientDBInternal {
   }
 
   private void checkDatabaseName(String name) {
-    if (name == null) {
-      throw new NullArgumentException("database");
-    }
+    Objects.requireNonNull(name, "Database name is null");
     if (name.contains("/") || name.contains(":")) {
       throw new ODatabaseException(String.format("Invalid database name:'%s'", name));
     }

--- a/core/src/main/java/com/orientechnologies/orient/core/storage/index/nkbtree/normalizers/StringKeyNormalizer.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/index/nkbtree/normalizers/StringKeyNormalizer.java
@@ -1,10 +1,8 @@
 package com.orientechnologies.orient.core.storage.index.nkbtree.normalizers;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.text.CollationKey;
 import java.text.Collator;
-import org.apache.commons.lang.ArrayUtils;
 
 public class StringKeyNormalizer implements KeyNormalizers {
   private final Collator instance = Collator.getInstance();
@@ -13,8 +11,10 @@ public class StringKeyNormalizer implements KeyNormalizers {
   public byte[] execute(Object key, int decomposition) throws IOException {
     instance.setDecomposition(decomposition);
     final CollationKey collationKey = instance.getCollationKey((String) key);
-    final ByteBuffer bb = ByteBuffer.allocate(1);
-    bb.put((byte) 0);
-    return ArrayUtils.addAll(bb.array(), collationKey.toByteArray());
+    final byte[] ckArray = collationKey.toByteArray();
+    final byte[] result = new byte[ckArray.length + 1];
+    result[0] = 0;
+    System.arraycopy(ckArray, 0, result, 1, ckArray.length);
+    return result;
   }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ConvertToResultInternalStepTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ConvertToResultInternalStepTest.java
@@ -7,7 +7,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ConvertToUpdatableResultStepTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/ConvertToUpdatableResultStepTest.java
@@ -7,7 +7,7 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/TestUtilsFixture.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/TestUtilsFixture.java
@@ -3,7 +3,7 @@ package com.orientechnologies.orient.core.sql.executor;
 import com.orientechnologies.BaseMemoryDatabase;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /** Created by olena.kolesnyk on 28/07/2017. */
 public class TestUtilsFixture extends BaseMemoryDatabase {

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,17 @@
         <maven.central.plugin.version>0.8.0</maven.central.plugin.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
# What does this PR do?
- `commons-lang` dependency has been replaced with `commons-lang3` for tests only;
- usages of `commons-lang` in production code were replaced with Java 8 equivalents.

# Motivation
https://github.com/orientechnologies/orientdb/issues/10510

# Related issues
N/A

# Additional Notes
Should be trivially portable to `develop` branch.

Checklist
- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
