### PR TITLE
Correct disk cache size tracking.

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cache/chm/AsyncReadCache.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cache/chm/AsyncReadCache.java
@@ -286,6 +286,7 @@ public final class AsyncReadCache implements OReadCache {
       throw new IllegalStateException(
           "Page  " + fileId + ":" + pageIndex + " was allocated in other thread");
     }
+    cacheSize.incrementAndGet();
 
     afterAdd(cacheEntry);
 


### PR DESCRIPTION
Increment cache size when new page pointers added to cache.

What does this PR do?

Update the `AsyncReadCache.cacheSize` when new page pointers mutate the cache map, otherwise when those entries are freed the cache size diverges from the actual cache data map size and goes below zero over time.

Motivation

We observed the disk cache used memory going negative (have exposed it via JMX) while the underlying data map size remains positive. After some debugging it looked like `addNewPagePointerToTheCache` was leaking a page in the counter every time it was called.
