### PR TITLE
Correct calculation of cluster records size on record update and delete

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/storage/cluster/v2/OPaginatedClusterV2.java
@@ -611,6 +611,21 @@ public final class OPaginatedClusterV2 extends OPaginatedCluster {
     return entrySize + OByteSerializer.BYTE_SIZE + OLongSerializer.LONG_SIZE;
   }
 
+  private static int calculateContentSizeDeltaFromChunk(final byte[] chunk) {
+    final byte firstChunk =
+        OByteSerializer.INSTANCE.deserialize(
+            chunk, chunk.length - OLongSerializer.LONG_SIZE - OByteSerializer.BYTE_SIZE);
+    if (firstChunk == 0) {
+      // Subsequent chunk, no cluster entry header
+      // entry content - first entry flag - next entry pointer
+      return chunk.length - OLongSerializer.LONG_SIZE - OByteSerializer.BYTE_SIZE;
+    }
+    // entry content - record type - record length - first entry flag - next entry pointer
+    return calculateContentSizeFromClusterEntrySize(chunk.length)
+        - OByteSerializer.BYTE_SIZE
+        - OLongSerializer.LONG_SIZE;
+  }
+
   private static int getEntryContentLength(final int grownContentSize) {
 
     return grownContentSize
@@ -831,7 +846,7 @@ public final class OPaginatedClusterV2 extends OPaginatedCluster {
                 atomicOperation.addDeletedRecordPosition(
                     id, cacheEntry.getPageIndex(), recordPosition);
                 assert content != null;
-                removeRecordSize = calculateContentSizeFromClusterEntrySize(content.length);
+                removeRecordSize += calculateContentSizeDeltaFromChunk(content);
 
                 maxRecordSize = localPage.getMaxRecordSize();
                 removedContentSize += localPage.getFreeSpace() - initialFreeSpace;
@@ -892,7 +907,7 @@ public final class OPaginatedClusterV2 extends OPaginatedCluster {
               final OClusterPage page = new OClusterPage(cacheEntry);
               final byte[] deletedRecord = page.deleteRecord(nextRecordPosition, true);
               assert deletedRecord != null;
-              oldContentSize = calculateContentSizeFromClusterEntrySize(deletedRecord.length);
+              oldContentSize += calculateContentSizeDeltaFromChunk(deletedRecord);
               nextPagePointer =
                   OLongSerializer.INSTANCE.deserializeNative(
                       deletedRecord, deletedRecord.length - OLongSerializer.LONG_SIZE);

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/LocalPaginatedClusterAbstract.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/LocalPaginatedClusterAbstract.java
@@ -74,6 +74,10 @@ public abstract class LocalPaginatedClusterAbstract {
     }
   }
 
+  protected void checkRecordsSize(final int expectedRecordSize) throws IOException {
+    Assert.assertEquals(expectedRecordSize, paginatedCluster.getRecordsSize());
+  }
+
   @Test
   public void testDeleteRecordAndAddNewOnItsPlace() throws IOException {
     byte[] smallRecord = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
@@ -97,6 +101,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     Assert.assertEquals(0, paginatedCluster.getEntries());
     Assert.assertNull(paginatedCluster.readRecord(physicalPosition[0].clusterPosition, false));
+    checkRecordsSize(0);
 
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
@@ -107,6 +112,8 @@ public abstract class LocalPaginatedClusterAbstract {
           paginatedCluster.deleteRecord(atomicOperation, physicalPosition[0].clusterPosition);
         });
 
+    checkRecordsSize(0);
+
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
         atomicOperation ->
@@ -115,6 +122,7 @@ public abstract class LocalPaginatedClusterAbstract {
                     smallRecord, recordVersion, (byte) 1, null, atomicOperation));
 
     Assert.assertEquals(physicalPosition[0].recordVersion, recordVersion);
+    checkRecordsSize(smallRecord.length);
   }
 
   @Test
@@ -137,6 +145,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     Assert.assertEquals(0, paginatedCluster.getEntries());
     Assert.assertNull(paginatedCluster.readRecord(physicalPosition[0].clusterPosition, false));
+    checkRecordsSize(0);
 
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
@@ -151,6 +160,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, recordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(smallRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
+    checkRecordsSize(smallRecord.length);
   }
 
   @Test
@@ -177,6 +187,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     Assert.assertEquals(0, paginatedCluster.getEntries());
     Assert.assertNull(paginatedCluster.readRecord(physicalPosition[0].clusterPosition, false));
+    checkRecordsSize(0);
 
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
@@ -191,6 +202,13 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, recordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(bigRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
+    checkRecordsSize(bigRecord.length);
+
+    atomicOperationsManager.executeInsideAtomicOperation(
+        null,
+        atomicOperation ->
+            paginatedCluster.deleteRecord(atomicOperation, physicalPosition[0].clusterPosition));
+    checkRecordsSize(0);
   }
 
   @Test
@@ -204,6 +222,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records / 2; i++) {
       int recordSize = mersenneTwisterFast.nextInt(OClusterPage.MAX_RECORD_SIZE - 1) + 1;
@@ -219,6 +238,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
             positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     final Set<Long> rolledBackRecordSet = new HashSet<>();
@@ -240,6 +261,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(totalRecordSize);
 
     for (long clusterPosition : rolledBackRecordSet) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(clusterPosition, false);
@@ -259,6 +281,8 @@ public abstract class LocalPaginatedClusterAbstract {
                     smallRecord, recordVersion, (byte) 2, null, atomicOperation);
             positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
@@ -285,6 +309,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     final int recordVersion = 2;
 
+    int totalRecordSize = 0;
     for (int i = 0; i < records / 2; i++) {
       int recordSize =
           mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE)
@@ -302,6 +327,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
             positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     Set<Long> rolledBackRecordSet = new HashSet<>();
@@ -326,6 +353,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(totalRecordSize);
 
     for (long clusterPosition : rolledBackRecordSet) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(clusterPosition, false);
@@ -348,6 +376,8 @@ public abstract class LocalPaginatedClusterAbstract {
                     bigRecord, recordVersion, (byte) 2, null, atomicOperation);
             positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
@@ -371,6 +401,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records / 2; i++) {
       int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -386,6 +417,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
             positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     Set<Long> rolledBackRecordSet = new HashSet<>();
@@ -408,6 +441,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(totalRecordSize);
 
     for (long clusterPosition : rolledBackRecordSet) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(clusterPosition, false);
@@ -428,6 +462,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
             positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
@@ -460,6 +496,8 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertTrue(position.clusterPosition >= 0);
     ORawBuffer rec = paginatedCluster.readRecord(position.clusterPosition, false);
     Assert.assertNull(rec);
+    checkRecordsSize(0);
+
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
         atomicOperation ->
@@ -467,6 +505,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     rec = paginatedCluster.readRecord(position.clusterPosition, false);
     Assert.assertNotNull(rec);
+    checkRecordsSize(20);
   }
 
   @Test
@@ -484,6 +523,7 @@ public abstract class LocalPaginatedClusterAbstract {
       Assert.assertNull(rec);
       positions.add(position);
     }
+    checkRecordsSize(0);
 
     try {
       atomicOperationsManager.executeInsideAtomicOperation(
@@ -500,6 +540,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(0);
 
     for (int i = records / 2; i < records; i++) {
       OPhysicalPosition position =
@@ -511,6 +552,7 @@ public abstract class LocalPaginatedClusterAbstract {
       Assert.assertNull(rec);
       positions.add(position);
     }
+    checkRecordsSize(0);
 
     for (int i = 0; i < records; i++) {
       OPhysicalPosition position = positions.get(i);
@@ -522,6 +564,7 @@ public abstract class LocalPaginatedClusterAbstract {
       ORawBuffer rec = paginatedCluster.readRecord(position.clusterPosition, false);
       Assert.assertNotNull(rec);
     }
+    checkRecordsSize(20 * records);
   }
 
   @Test
@@ -535,6 +578,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize = mersenneTwisterFast.nextInt(OClusterPage.MAX_RECORD_SIZE - 1) + 1;
@@ -549,6 +593,8 @@ public abstract class LocalPaginatedClusterAbstract {
                       smallRecord, recordVersion, (byte) 2, null, atomicOperation));
 
       positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -571,6 +617,7 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
 
       for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
         ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -585,9 +632,11 @@ public abstract class LocalPaginatedClusterAbstract {
     int deletedRecords = 0;
     Assert.assertEquals(records, paginatedCluster.getEntries());
     Set<Long> deletedPositions = new HashSet<>();
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         deletedPositions.add(clusterPosition);
         atomicOperationsManager.executeInsideAtomicOperation(
@@ -599,6 +648,8 @@ public abstract class LocalPaginatedClusterAbstract {
         Assert.assertEquals(records - deletedRecords, paginatedCluster.getEntries());
 
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -610,6 +661,7 @@ public abstract class LocalPaginatedClusterAbstract {
           atomicOperation ->
               Assert.assertFalse(paginatedCluster.deleteRecord(atomicOperation, deletedPosition)));
     }
+    checkRecordsSize(totalRecordSize);
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -632,6 +684,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize =
@@ -650,6 +703,8 @@ public abstract class LocalPaginatedClusterAbstract {
                       bigRecord, recordVersion, (byte) 2, null, atomicOperation));
 
       positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -674,6 +729,7 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
 
       for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
         ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -688,9 +744,11 @@ public abstract class LocalPaginatedClusterAbstract {
     int deletedRecords = 0;
     Assert.assertEquals(records, paginatedCluster.getEntries());
     Set<Long> deletedPositions = new HashSet<>();
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         deletedPositions.add(clusterPosition);
         atomicOperationsManager.executeInsideAtomicOperation(
@@ -702,6 +760,8 @@ public abstract class LocalPaginatedClusterAbstract {
         Assert.assertEquals(records - deletedRecords, paginatedCluster.getEntries());
 
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -713,6 +773,7 @@ public abstract class LocalPaginatedClusterAbstract {
           atomicOperation ->
               Assert.assertFalse(paginatedCluster.deleteRecord(atomicOperation, deletedPosition)));
     }
+    checkRecordsSize(totalRecordSize);
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -735,6 +796,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize = mersenneTwisterFast.nextInt(3 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -750,6 +812,8 @@ public abstract class LocalPaginatedClusterAbstract {
                       bigRecord, recordVersion, (byte) 2, null, atomicOperation));
 
       positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -772,6 +836,7 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
 
       for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
         ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -786,9 +851,11 @@ public abstract class LocalPaginatedClusterAbstract {
     int deletedRecords = 0;
     Assert.assertEquals(records, paginatedCluster.getEntries());
     Set<Long> deletedPositions = new HashSet<>();
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         deletedPositions.add(clusterPosition);
         atomicOperationsManager.executeInsideAtomicOperation(
@@ -800,6 +867,8 @@ public abstract class LocalPaginatedClusterAbstract {
         Assert.assertEquals(records - deletedRecords, paginatedCluster.getEntries());
 
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -811,6 +880,7 @@ public abstract class LocalPaginatedClusterAbstract {
           atomicOperation ->
               Assert.assertFalse(paginatedCluster.deleteRecord(atomicOperation, deletedPosition)));
     }
+    checkRecordsSize(totalRecordSize);
 
     for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
       ORawBuffer rawBuffer = paginatedCluster.readRecord(entry.getKey(), false);
@@ -833,6 +903,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Map<Long, byte[]> positionRecordMap = new HashMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize = mersenneTwisterFast.nextInt(3 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -848,14 +919,18 @@ public abstract class LocalPaginatedClusterAbstract {
                       bigRecord, recordVersion, (byte) 2, null, atomicOperation));
 
       positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     int deletedRecords = 0;
     Assert.assertEquals(records, paginatedCluster.getEntries());
 
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         atomicOperationsManager.executeInsideAtomicOperation(
             null,
@@ -866,6 +941,8 @@ public abstract class LocalPaginatedClusterAbstract {
         Assert.assertEquals(paginatedCluster.getEntries(), records - deletedRecords);
 
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -885,6 +962,8 @@ public abstract class LocalPaginatedClusterAbstract {
                       bigRecord, recordVersion, (byte) 2, null, atomicOperation));
 
       positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     Assert.assertEquals(paginatedCluster.getEntries(), (long) (1.5 * records - deletedRecords));
@@ -911,6 +990,8 @@ public abstract class LocalPaginatedClusterAbstract {
                 paginatedCluster.createRecord(
                     smallRecord, recordVersion, (byte) 1, null, atomicOperation));
 
+    checkRecordsSize(smallRecord.length);
+
     final int updatedRecordVersion = 3;
     final byte[] updatedRecord = new byte[] {2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3};
 
@@ -928,6 +1009,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(smallRecord.length);
 
     ORawBuffer rawBuffer = paginatedCluster.readRecord(physicalPosition.clusterPosition, false);
     Assert.assertNotNull(rawBuffer);
@@ -945,6 +1027,7 @@ public abstract class LocalPaginatedClusterAbstract {
                 updatedRecordVersion,
                 (byte) 2,
                 atomicOperation));
+    checkRecordsSize(updatedRecord.length);
 
     rawBuffer = paginatedCluster.readRecord(physicalPosition.clusterPosition, false);
 
@@ -964,6 +1047,7 @@ public abstract class LocalPaginatedClusterAbstract {
             atomicOperation ->
                 paginatedCluster.createRecord(
                     smallRecord, recordVersion, (byte) 1, null, atomicOperation));
+    checkRecordsSize(smallRecord.length);
 
     final int updateRecordVersion = 1;
 
@@ -983,11 +1067,12 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(smallRecord.length);
 
     ORawBuffer rawBuffer = paginatedCluster.readRecord(physicalPosition.clusterPosition, false);
     Assert.assertNotNull(rawBuffer);
     Assert.assertEquals(rawBuffer.version, recordVersion);
-    Assertions.assertThat(rawBuffer.buffer).isEqualTo(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0});
+    Assertions.assertThat(rawBuffer.buffer).isEqualTo(smallRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
 
     atomicOperationsManager.executeInsideAtomicOperation(
@@ -1005,6 +1090,7 @@ public abstract class LocalPaginatedClusterAbstract {
 
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(updatedRecord);
     Assert.assertEquals(rawBuffer.recordType, 2);
+    checkRecordsSize(updatedRecord.length);
   }
 
   @Test
@@ -1018,6 +1104,7 @@ public abstract class LocalPaginatedClusterAbstract {
             atomicOperation ->
                 paginatedCluster.createRecord(
                     smallRecord, recordVersion, (byte) 1, null, atomicOperation));
+    checkRecordsSize(smallRecord.length);
 
     final int updateRecordVersion;
     updateRecordVersion = -2;
@@ -1038,12 +1125,13 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(smallRecord.length);
 
     ORawBuffer rawBuffer = paginatedCluster.readRecord(physicalPosition.clusterPosition, false);
     Assert.assertNotNull(rawBuffer);
 
     Assert.assertEquals(rawBuffer.version, recordVersion);
-    Assertions.assertThat(rawBuffer.buffer).isEqualTo(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0});
+    Assertions.assertThat(rawBuffer.buffer).isEqualTo(smallRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
 
     atomicOperationsManager.executeInsideAtomicOperation(
@@ -1061,6 +1149,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, updateRecordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(smallRecord);
     Assert.assertEquals(rawBuffer.recordType, 2);
+    checkRecordsSize(smallRecord.length);
   }
 
   @Test
@@ -1087,6 +1176,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, recordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(bigRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
+    checkRecordsSize(bigRecord.length);
 
     final int updatedRecordVersion = 3;
     final byte[] updatedBigRecord = new byte[2 * 65536 + 20];
@@ -1106,6 +1196,7 @@ public abstract class LocalPaginatedClusterAbstract {
           });
     } catch (RollbackException ignore) {
     }
+    checkRecordsSize(bigRecord.length);
 
     rawBuffer = paginatedCluster.readRecord(physicalPosition.clusterPosition, false);
     Assert.assertNotNull(rawBuffer);
@@ -1113,6 +1204,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, recordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(bigRecord);
     Assert.assertEquals(rawBuffer.recordType, 1);
+    checkRecordsSize(bigRecord.length);
 
     atomicOperationsManager.executeInsideAtomicOperation(
         null,
@@ -1128,6 +1220,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(rawBuffer.version, recordVersion);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(updatedBigRecord);
     Assert.assertEquals(rawBuffer.recordType, 2);
+    checkRecordsSize(updatedBigRecord.length);
   }
 
   @Test
@@ -1142,6 +1235,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Set<Long> updatedPositions = new HashSet<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize = mersenneTwisterFast.nextInt(OClusterPage.MAX_RECORD_SIZE - 1) + 1;
@@ -1156,6 +1250,8 @@ public abstract class LocalPaginatedClusterAbstract {
                     smallRecord, recordVersion, (byte) 2, null, atomicOperation);
             positionRecordMap.put(physicalPosition.clusterPosition, smallRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     final int newRecordVersion;
@@ -1185,9 +1281,12 @@ public abstract class LocalPaginatedClusterAbstract {
         } catch (RollbackException ignore) {
         }
       }
+      checkRecordsSize(totalRecordSize);
     }
 
-    for (long clusterPosition : positionRecordMap.keySet()) {
+    for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         int recordSize = mersenneTwisterFast.nextInt(OClusterPage.MAX_RECORD_SIZE - 1) + 1;
         byte[] smallRecord = new byte[recordSize];
@@ -1201,6 +1300,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
         positionRecordMap.put(clusterPosition, smallRecord);
         updatedPositions.add(clusterPosition);
+        totalRecordSize += recordSize - record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -1232,6 +1333,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Set<Long> updatedPositions = new HashSet<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize =
@@ -1249,6 +1351,8 @@ public abstract class LocalPaginatedClusterAbstract {
                     bigRecord, recordVersion, (byte) 2, null, atomicOperation);
             positionRecordMap.put(physicalPosition.clusterPosition, bigRecord);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     final int newRecordVersion = recordVersion + 1;
@@ -1274,9 +1378,12 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
     }
 
-    for (long clusterPosition : positionRecordMap.keySet()) {
+    for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         int recordSize =
             mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE)
@@ -1293,6 +1400,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
         positionRecordMap.put(clusterPosition, bigRecord);
         updatedPositions.add(clusterPosition);
+        totalRecordSize += recordSize - record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -1324,6 +1433,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Set<Long> updatedPositions = new HashSet<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records; i++) {
       int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -1337,6 +1447,8 @@ public abstract class LocalPaginatedClusterAbstract {
                   paginatedCluster.createRecord(
                       record, recordVersion, (byte) 2, null, atomicOperation));
       positionRecordMap.put(physicalPosition.clusterPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     final int newRecordVersion = recordVersion + 1;
@@ -1362,9 +1474,12 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
     }
 
-    for (long clusterPosition : positionRecordMap.keySet()) {
+    for (Map.Entry<Long, byte[]> entry : positionRecordMap.entrySet()) {
+      long clusterPosition = entry.getKey();
+      byte[] oldRecord = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
         byte[] record = new byte[recordSize];
@@ -1378,6 +1493,8 @@ public abstract class LocalPaginatedClusterAbstract {
 
         positionRecordMap.put(clusterPosition, record);
         updatedPositions.add(clusterPosition);
+        totalRecordSize += recordSize - oldRecord.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -1418,6 +1535,7 @@ public abstract class LocalPaginatedClusterAbstract {
     Assert.assertEquals(recordVersion, rawBuffer.version);
     Assertions.assertThat(rawBuffer.buffer).isEqualTo(record);
     Assert.assertEquals(2L, rawBuffer.recordType);
+    checkRecordsSize(recordSize);
 
     for (int i = 0; i < 40; i++) {
       int updatedRecordVersion = recordVersion + 1 + i;
@@ -1438,6 +1556,7 @@ public abstract class LocalPaginatedClusterAbstract {
       Assert.assertEquals(updatedRecordVersion, rawBuffer.version);
       Assertions.assertThat(rawBuffer.buffer).isEqualTo(updatedRecord);
       Assert.assertEquals(2L, rawBuffer.recordType);
+      checkRecordsSize(recordSize + i);
     }
   }
 
@@ -1452,6 +1571,7 @@ public abstract class LocalPaginatedClusterAbstract {
     NavigableMap<Long, byte[]> positionRecordMap = new TreeMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records / 2; i++) {
       int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -1466,6 +1586,8 @@ public abstract class LocalPaginatedClusterAbstract {
                     record, recordVersion, (byte) 2, null, atomicOperation);
             positionRecordMap.put(physicalPosition.clusterPosition, record);
           });
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -1492,6 +1614,7 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
     }
 
     for (int i = 0; i < records / 2; i++) {
@@ -1506,17 +1629,23 @@ public abstract class LocalPaginatedClusterAbstract {
                   paginatedCluster.createRecord(
                       record, recordVersion, (byte) 2, null, atomicOperation));
       positionRecordMap.put(physicalPosition.clusterPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         atomicOperationsManager.executeInsideAtomicOperation(
             null,
             atomicOperation ->
                 Assert.assertTrue(paginatedCluster.deleteRecord(atomicOperation, clusterPosition)));
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -1554,6 +1683,7 @@ public abstract class LocalPaginatedClusterAbstract {
     NavigableMap<Long, byte[]> positionRecordMap = new TreeMap<>();
 
     final int recordVersion = 2;
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records / 2; i++) {
       int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -1567,6 +1697,8 @@ public abstract class LocalPaginatedClusterAbstract {
                   paginatedCluster.createRecord(
                       record, recordVersion, (byte) 2, null, atomicOperation));
       positionRecordMap.put(physicalPosition.clusterPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -1583,16 +1715,17 @@ public abstract class LocalPaginatedClusterAbstract {
                     record, recordVersion, (byte) 2, null, atomicOperation);
               }
 
-              for (long clusterPosition : positionRecordMap.keySet()) {
+              for (Map.Entry<Long, byte[]> record : positionRecordMap.entrySet()) {
                 if (mersenneTwisterFast.nextBoolean()) {
                   Assert.assertTrue(
-                      paginatedCluster.deleteRecord(atomicOperation, clusterPosition));
+                      paginatedCluster.deleteRecord(atomicOperation, record.getKey()));
                 }
               }
               throw new RollbackException();
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
     }
 
     for (int i = 0; i < records / 2; i++) {
@@ -1607,17 +1740,23 @@ public abstract class LocalPaginatedClusterAbstract {
                   paginatedCluster.createRecord(
                       record, recordVersion, (byte) 2, null, atomicOperation));
       positionRecordMap.put(physicalPosition.clusterPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
-    Iterator<Long> positionIterator = positionRecordMap.keySet().iterator();
+    Iterator<Map.Entry<Long, byte[]>> positionIterator = positionRecordMap.entrySet().iterator();
     while (positionIterator.hasNext()) {
-      long clusterPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long clusterPosition = entry.getKey();
+      byte[] record = entry.getValue();
       if (mersenneTwisterFast.nextBoolean()) {
         atomicOperationsManager.executeInsideAtomicOperation(
             null,
             atomicOperation ->
                 Assert.assertTrue(paginatedCluster.deleteRecord(atomicOperation, clusterPosition)));
         positionIterator.remove();
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
@@ -1627,12 +1766,13 @@ public abstract class LocalPaginatedClusterAbstract {
     OPhysicalPosition[] positions = paginatedCluster.floorPositions(physicalPosition);
     Assert.assertTrue(positions.length > 0);
 
-    positionIterator = positionRecordMap.descendingKeySet().iterator();
+    positionIterator = positionRecordMap.descendingMap().entrySet().iterator();
     int counter = 0;
     while (positionIterator.hasNext()) {
       Assert.assertTrue(positions.length > 0);
 
-      long testedPosition = positionIterator.next();
+      Map.Entry<Long, byte[]> entry = positionIterator.next();
+      long testedPosition = entry.getKey();
       Assert.assertEquals(positions[positions.length - 1].clusterPosition, testedPosition);
 
       OPhysicalPosition positionToFind = positions[positions.length - 1];
@@ -1655,9 +1795,10 @@ public abstract class LocalPaginatedClusterAbstract {
     Random mersenneTwisterFast = new Random(seed);
     System.out.println("testGetPhysicalPosition seed : " + seed);
 
-    Set<OPhysicalPosition> positions = new HashSet<>();
+    Map<OPhysicalPosition, byte[]> positions = new HashMap<>();
 
     final OModifiableInteger recordVersion = new OModifiableInteger();
+    int totalRecordSize = 0;
 
     for (int i = 0; i < records / 2; i++) {
       int recordSize = mersenneTwisterFast.nextInt(2 * OClusterPage.MAX_RECORD_SIZE) + 1;
@@ -1673,7 +1814,9 @@ public abstract class LocalPaginatedClusterAbstract {
               atomicOperation ->
                   paginatedCluster.createRecord(
                       record, recordVersion.value, recordType, null, atomicOperation));
-      positions.add(physicalPosition);
+      positions.put(physicalPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     {
@@ -1692,7 +1835,7 @@ public abstract class LocalPaginatedClusterAbstract {
                     record, recordVersion.value, (byte) i, null, atomicOperation);
               }
 
-              for (OPhysicalPosition position : positions) {
+              for (OPhysicalPosition position : positions.keySet()) {
                 OPhysicalPosition physicalPosition = new OPhysicalPosition();
                 physicalPosition.clusterPosition = position.clusterPosition;
 
@@ -1710,6 +1853,7 @@ public abstract class LocalPaginatedClusterAbstract {
             });
       } catch (RollbackException ignore) {
       }
+      checkRecordsSize(totalRecordSize);
     }
 
     for (int i = 0; i < records / 2; i++) {
@@ -1725,11 +1869,15 @@ public abstract class LocalPaginatedClusterAbstract {
               atomicOperation ->
                   paginatedCluster.createRecord(
                       record, recordVersion.value, currentType, null, atomicOperation));
-      positions.add(physicalPosition);
+      positions.put(physicalPosition, record);
+      totalRecordSize += recordSize;
+      checkRecordsSize(totalRecordSize);
     }
 
     Set<OPhysicalPosition> removedPositions = new HashSet<>();
-    for (OPhysicalPosition position : positions) {
+    for (Map.Entry<OPhysicalPosition, byte[]> entry : positions.entrySet()) {
+      OPhysicalPosition position = entry.getKey();
+      byte[] record = entry.getValue();
       OPhysicalPosition physicalPosition = new OPhysicalPosition();
       physicalPosition.clusterPosition = position.clusterPosition;
 
@@ -1745,10 +1893,12 @@ public abstract class LocalPaginatedClusterAbstract {
             atomicOperation ->
                 paginatedCluster.deleteRecord(atomicOperation, position.clusterPosition));
         removedPositions.add(position);
+        totalRecordSize -= record.length;
+        checkRecordsSize(totalRecordSize);
       }
     }
 
-    for (OPhysicalPosition position : positions) {
+    for (OPhysicalPosition position : positions.keySet()) {
       OPhysicalPosition physicalPosition = new OPhysicalPosition();
       physicalPosition.clusterPosition = position.clusterPosition;
 

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/v0/LocalPaginatedClusterV0TestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/v0/LocalPaginatedClusterV0TestIT.java
@@ -42,4 +42,9 @@ public class LocalPaginatedClusterV0TestIT extends LocalPaginatedClusterAbstract
         .executeInsideAtomicOperation(
             null, atomicOperation -> paginatedCluster.create(atomicOperation));
   }
+
+  @Override
+  protected void checkRecordsSize(int expectedRecordSize) throws IOException {
+    // TODO: Check record size calculations in V0
+  }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/v1/LocalPaginatedClusterV1TestIT.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/storage/cluster/v1/LocalPaginatedClusterV1TestIT.java
@@ -37,4 +37,9 @@ public class LocalPaginatedClusterV1TestIT extends LocalPaginatedClusterAbstract
         .executeInsideAtomicOperation(
             null, atomicOperation -> paginatedCluster.create(atomicOperation));
   }
+
+  @Override
+  protected void checkRecordsSize(int expectedRecordSize) throws IOException {
+    // TODO: Check record size calculations in V1
+  }
 }


### PR DESCRIPTION
This PR corrects the adjustment of records size in clusters on update and delete operations.
The chunk overheads were not being applied when calculating the records size delta, and additionally not all chunks in the record were being considered (so multi chunk records had very wrong deltas).
This is observed as records size dropping by (typically) 9 bytes on each update that doesn't change the actual record content size, or when a record is deleted.

Motivation
Found this while working on a feature that exposes records size (and file sizes and record counts) for clusters in an SQL command, and observing that adding properties (which applies record updates during DB migration) and updating records via SQL causes cluster records size counts to go to 0 or even negative values.

Additional Notes
I've also implemented checking the records size in the cluster ITs for the V2 cluster format (which covers the multi-chunk records as well).
The V0 and V1 clusters use a different scheme to calculate records size, and have different numbers than V2, so I've just stubbed out their record size checks for now - it might be an issue worth fixing overall, but I haven't delved into why the V0/V1 clusters have different records size numbers and don't use them.

Checklist
[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
