### PR TITLE
Correct scheduling of Orient tasks in past

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/Orient.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/Orient.java
@@ -429,7 +429,8 @@ public class Orient extends OListenerManger<OOrientListener> {
   }
 
   public TimerTask scheduleTask(final Runnable task, final Date firstTime, final long period) {
-    return scheduleTask(task, firstTime.getTime() - System.currentTimeMillis(), period);
+    return scheduleTask(
+        task, Math.max(0, firstTime.getTime() - System.currentTimeMillis()), period);
   }
 
   public boolean isActive() {

--- a/core/src/test/java/com/orientechnologies/orient/core/OrientScheduleTaskTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/OrientScheduleTaskTest.java
@@ -1,0 +1,86 @@
+package com.orientechnologies.orient.core;
+
+import java.util.Date;
+import java.util.TimerTask;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OrientScheduleTaskTest {
+
+  @Before
+  public void beforeClass() {
+    Orient.instance().startup();
+  }
+
+  @After
+  public void afterClass() {
+    Orient.instance().shutdown();
+  }
+
+  @Test
+  public void testScheduleTask() {
+    TestTask task = new TestTask();
+    TimerTask timer = Orient.instance().scheduleTask(task, 0, 20);
+    task.waitFor(2, 30);
+    timer.cancel();
+  }
+
+  @Test
+  public void testScheduleTaskInPast() {
+    TestTask task = new TestTask();
+    TimerTask timer =
+        Orient.instance().scheduleTask(task, new Date(System.currentTimeMillis() - 100), 20);
+    task.waitFor(2, 30);
+    timer.cancel();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testScheduleWithNegativeDelay() {
+    TestTask task = new TestTask();
+    Orient.instance().scheduleTask(task, -1, 20);
+  }
+
+  @Test
+  public void testScheduleOneShotTask() {
+    TestTask task = new TestTask();
+    TimerTask timer = Orient.instance().scheduleTask(task, 0, 0);
+    task.waitFor(1, 30);
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException ignored) {
+    }
+    Assert.assertEquals(1, task.getRuns());
+    timer.cancel();
+  }
+
+  private static class TestTask implements Runnable {
+
+    private int runs = 0;
+
+    @Override
+    public synchronized void run() {
+      runs = runs + 1;
+      notifyAll();
+    }
+
+    public synchronized int getRuns() {
+      return runs;
+    }
+
+    public synchronized void waitFor(int runs, long timeout) {
+      long end = System.currentTimeMillis() + timeout;
+      while (this.runs < runs) {
+        long wait = end - System.currentTimeMillis();
+        if (wait <= 0) {
+          Assert.fail("Timeout waiting for " + runs + " runs, current runs: " + this.runs);
+        }
+        try {
+          wait(wait);
+        } catch (InterruptedException ignored) {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Correct scheduling of tasks in the past to work as it did before refactoring in 1b9cbe2e0cf58bc966b5a29acb2cc5ccff7d5fab.
Also with regression tests.

Fixes #10550