### PR TITLE
OJSONReader is only used in a single-thread situation when importing …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -407,6 +407,12 @@
             <version>3.8.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.20.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONReader.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/serialization/serializer/OJSONReader.java
@@ -23,6 +23,8 @@ import com.orientechnologies.common.util.OPair;
 import com.orientechnologies.orient.core.id.ORID;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.sql.executor.ORidSet;
+import org.apache.commons.io.input.UnsynchronizedBufferedReader;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -51,7 +53,7 @@ public class OJSONReader {
   public static final char[] BEGIN_COLLECTION = new char[] {'['};
   public static final char[] END_COLLECTION = new char[] {']'};
 
-  private BufferedReader in;
+  private UnsynchronizedBufferedReader in;
   private int cursor = 0;
   private int lineNumber = 0;
   private int columnNumber = 0;
@@ -62,7 +64,7 @@ public class OJSONReader {
   private Character missedChar;
 
   public OJSONReader(Reader iIn) {
-    this.in = new BufferedReader(iIn);
+    this.in = new UnsynchronizedBufferedReader(iIn);
   }
 
   public int getCursor() {


### PR DESCRIPTION
…large database. We can up the performance to shave off hours of waiting time when consuming a backup. Cons; adds commons-io dependency

What does this PR do?
See https://github.com/orientechnologies/orientdb/issues/10546

Motivation
We need to handle quite big backups and also need some sleep. Shaving off hours of locks that are unneccesary in a case of JSONReader using import gives us a few hours of sleep back :-)

Related issues
None

Additional Notes
It pulls in a new dependency which might be unwanted

Checklist
[] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
