### PR TITLE
Fix flaky test in OLuceneSortTest by making assertion not relying on order

### DIFF
--- a/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneSortTest.java
+++ b/lucene/src/test/java/com/orientechnologies/lucene/tests/OLuceneSortTest.java
@@ -35,7 +35,7 @@ public class OLuceneSortTest extends OLuceneBaseTest {
     List<Integer> scores =
         resultSet.stream().map(o -> o.<Integer>getProperty("score")).collect(Collectors.toList());
 
-    assertThat(scores).containsExactly(4, 5, 10, 10, 7);
+    assertThat(scores).containsExactlyInAnyOrder(4, 5, 10, 10, 7);
     resultSet.close();
   }
 


### PR DESCRIPTION
What does this PR do?
This PR fixes a flaky test `OLuceneSortTest.shouldSortByReverseDocScore` by relaxing the assertion to ignore the order of the results.

Motivation
The test `shouldSortByReverseDocScore` was detected to be flaky by NonDex. The test sorts results by Lucene's internal Doc ID (`type:'DOC'`). However the index is created on existing data and the order in which OrientDB iterates over the records to populate the index is not deterministic. Since Doc IDs are assigned based on indexing order the resulting sort order is also non-deterministic. Asserting a specific order is brittle for this test.

Related issues
None.

Additional Notes
None.

Checklist
[√] I have run the build using `mvn clean package` command
[N/A] My unit tests cover both failure and success scenarios