### PR TITLE
fix: Replace lz4-java with community-maintained fork to address CVEs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -351,9 +351,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
CVE addressed:
- [CVE-2025-12183](https://github.com/advisories/GHSA-vqf4-7m7x-wgfc)
- [CVE-2025-66566](https://github.com/advisories/GHSA-cmp6-m4wj-q63q)

What does this PR do?
Replace dependency from archived project https://github.com/lz4/lz4-java with a community-maintained fork https://github.com/yawkat/lz4-java.

Motivation
Projects depending on OrientDB artifacts received security advisories which could not be ignored.

Related issues
N/A

Additional Notes
Applicable to `develop` branch as well.

Checklist
- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
