### PR TITLE
Fix flaky test in HttpImportTest.testImport by fixing race condition

### DIFF
--- a/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpDb.java
+++ b/server/src/main/java/com/orientechnologies/orient/server/network/protocol/http/ONetworkProtocolHttpDb.java
@@ -55,11 +55,16 @@ public class ONetworkProtocolHttpDb extends ONetworkProtocolHttpAbstract {
             + iSocket.getRemoteSocketAddress());
 
     super.config(iListener, server, iSocket, iConfiguration);
-    cmdManager.registerCommand(new OServerCommandPostImportDatabase());
-    cmdManager.registerCommand(new OServerCommandPostUploadSingleFile());
 
     connection.getData().serverInfo =
         iConfiguration.getValueAsString(OGlobalConfiguration.NETWORK_HTTP_SERVER_INFO);
+  }
+
+  @Override
+  protected void registerStatelessCommands(OServerNetworkListener iListener) {
+    super.registerStatelessCommands(iListener);
+    cmdManager.registerCommand(new OServerCommandPostImportDatabase());
+    cmdManager.registerCommand(new OServerCommandPostUploadSingleFile());
   }
 
   @Override


### PR DESCRIPTION
What does this PR do?
This PR fixes the flaky test `com.orientechnologies.orient.test.server.network.http.HttpImportTest.testImport`. The registration of the import and upload commands in ONetworkProtocolHttpDb is moved to happen earlier within registerStatelessCommands() instead of after super.config().

Motivation
The test was detected to be failing by NonDex. The issue is a race condition in ONetworkProtocolHttpDb. The config method calls super.config() that starts the network listener thread. However the import command was being registered after this call. If the test request hit the server before the main thread reached that registration line, the command wouldn't be found. Moving the registration to registerStatelessCommands makes sure the commands are available before-hand.

Related issues
None.

Additional Notes
None.

### Checklist
- [✓] I have run the build using `mvn clean package` command
- [N/A] My unit tests cover both failure and success scenarios
