### PR TITLE
fix: truncate asDate timestamps with 24-hour clock

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/functions/conversion/OSQLMethodAsDate.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/functions/conversion/OSQLMethodAsDate.java
@@ -59,7 +59,7 @@ public class OSQLMethodAsDate extends OAbstractSQLMethod {
       if (iThis instanceof Date) {
         Calendar cal = new GregorianCalendar();
         cal.setTime((Date) iThis);
-        cal.set(Calendar.HOUR, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
@@ -68,7 +68,7 @@ public class OSQLMethodAsDate extends OAbstractSQLMethod {
         Date val = new Date(((Number) iThis).longValue());
         Calendar cal = new GregorianCalendar();
         cal.setTime(val);
-        cal.set(Calendar.HOUR, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionConvertTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/functions/OSQLFunctionConvertTest.java
@@ -7,9 +7,12 @@ import static org.junit.Assert.assertTrue;
 
 import com.orientechnologies.BaseMemoryDatabase;
 import com.orientechnologies.orient.core.id.ORID;
+import com.orientechnologies.orient.core.sql.executor.OResult;
 import com.orientechnologies.orient.core.sql.executor.OResultSet;
 import java.math.BigDecimal;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import org.junit.Test;
 
 /** @author Luca Garulli (l.garulli--(at)--orientdb.com) */
@@ -74,5 +77,34 @@ public class OSQLFunctionConvertTest extends BaseMemoryDatabase {
             "select selfrid.substring(3).convert('LINK').string as convert from TestConversion");
     assertEquals(results.next().getProperty("convert"), "Jay");
     assertFalse(results.hasNext());
+  }
+
+  @Test
+  public void testAsDateTruncatesAfternoonTimestampsToMidnight() {
+    db.command("create class TestAsDate").close();
+
+    Date input = dateAt(2024, Calendar.JANUARY, 2, 15, 30, 45, 123);
+    db.command("insert into TestAsDate set date = ?, millis = ?", input, input.getTime()).close();
+
+    Date expected = dateAt(2024, Calendar.JANUARY, 2, 0, 0, 0, 0);
+
+    try (OResultSet results =
+        db.query(
+            "select date.asDate() as dateConvert, millis.asDate() as millisConvert from"
+                + " TestAsDate")) {
+      OResult result = results.next();
+      assertEquals(expected, result.getProperty("dateConvert"));
+      assertEquals(expected, result.getProperty("millisConvert"));
+      assertFalse(results.hasNext());
+    }
+  }
+
+  private static Date dateAt(
+      int year, int month, int day, int hour, int minute, int second, int millisecond) {
+    Calendar calendar = new GregorianCalendar();
+    calendar.clear();
+    calendar.set(year, month, day, hour, minute, second);
+    calendar.set(Calendar.MILLISECOND, millisecond);
+    return calendar.getTime();
   }
 }


### PR DESCRIPTION
What does this PR do?

Fixes `asDate()` so `Date` and numeric timestamp inputs are truncated with `Calendar.HOUR_OF_DAY`, producing midnight instead of noon for PM inputs. Adds regression coverage for both input paths.

Motivation

`asDate()` cleared the 12-hour `Calendar.HOUR` field and preserved the PM marker. Afternoon timestamps such as `2024-01-02 15:30:45.123` normalized to `2024-01-02 12:00:00.000` instead of `00:00:00.000`.

Related issues

Fixes #10772

Additional Notes

Validation:
- `git diff --check`
- `mvn -pl core -am -Dtest=OSQLFunctionConvertTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl core -am test` (2,798 tests, 0 failures, 0 errors, 44 skipped)

Checklist

[ ] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios
