### PR TITLE
test: cover embedded document validation

### DIFF
--- a/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/record/impl/ODocumentTest.java
@@ -12,6 +12,7 @@ import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.db.OrientDB;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentAbstract;
 import com.orientechnologies.orient.core.db.record.ridbag.ORidBag;
+import com.orientechnologies.orient.core.exception.OValidationException;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OProperty;
@@ -91,6 +92,57 @@ public class ODocumentTest {
     assertEquals(doc.fieldType("integer"), null);
     assertEquals(doc.fieldType("string"), null);
     assertEquals(doc.fieldType("binary"), null);
+  }
+
+  @Test
+  public void testValidateEmbeddedRejectsRecordIdValue() {
+    final String name = dbName + "_embeddedRid";
+    ODatabaseSession db = null;
+    OrientDB odb = null;
+    try {
+      odb = OCreateDatabaseUtil.createDatabase(name, "memory:", OCreateDatabaseUtil.TYPE_MEMORY);
+      db = odb.open(name, defaultDbAdminCredentials, OCreateDatabaseUtil.NEW_ADMIN_PASSWORD);
+
+      OClass clazz = db.getMetadata().getSchema().createClass("EmbeddedRidOwner");
+      OProperty property = clazz.createProperty("embedded", OType.EMBEDDED);
+
+      try {
+        ODocument.validateEmbedded(property, new ORecordId(1, 2));
+        org.junit.Assert.fail("Expected embedded RecordID value to be rejected");
+      } catch (OValidationException expected) {
+        assertTrue(expected.getMessage().contains("RecordID"));
+      }
+    } finally {
+      if (db != null) db.close();
+      if (odb != null) {
+        odb.drop(name);
+        odb.close();
+      }
+    }
+  }
+
+  @Test
+  public void testValidateEmbeddedAcceptsLinkedEmbeddedDocument() {
+    final String name = dbName + "_embeddedLinked";
+    ODatabaseSession db = null;
+    OrientDB odb = null;
+    try {
+      odb = OCreateDatabaseUtil.createDatabase(name, "memory:", OCreateDatabaseUtil.TYPE_MEMORY);
+      db = odb.open(name, defaultDbAdminCredentials, OCreateDatabaseUtil.NEW_ADMIN_PASSWORD);
+
+      OSchema schema = db.getMetadata().getSchema();
+      OClass embeddedClass = schema.createClass("EmbeddedLinkedValue");
+      OClass ownerClass = schema.createClass("EmbeddedLinkedOwner");
+      OProperty property = ownerClass.createProperty("embedded", OType.EMBEDDED, embeddedClass);
+
+      ODocument.validateEmbedded(property, new ODocument(embeddedClass));
+    } finally {
+      if (db != null) db.close();
+      if (odb != null) {
+        odb.drop(name);
+        odb.close();
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Hi,

## What does this PR do?

Adds two focused unit tests for `ODocument.validateEmbedded`: one for rejecting a RecordID value on an embedded property, and one for accepting a document that matches the linked embedded class.

## Motivation

These embedded validation paths are important to keep covered because they distinguish invalid linked records from valid embedded documents. The tests cover the `validateEmbedded` logic around [ODocument.java:1026-1114](https://github.com/amirdeljouyi/orientdb/blob/fc72c208075814254df049c0b07b840bac69c45b/core/src/main/java/com/orientechnologies/orient/core/record/impl/ODocument.java#L1026-L1114), and line coverage for `ODocument` increases by around 2%.

## Related issues

None.

## Additional Notes

The focused `ODocumentTest` run passes locally.

## Checklist

[x] I have run the build using `mvn clean package` command
[x] My unit tests cover both failure and success scenarios

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
